### PR TITLE
[docs] Add extension library foundation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thanks for helping build the Hermes WebUI extension ecosystem.
+
+The extension system is still taking shape, so keep PRs small and explicit.
+If an extension needs new WebUI APIs, start by describing the requirement
+before adding a large implementation.
+
+## Contribution Rules
+
+- Keep each extension self-contained under `extensions/<extension-id>/`.
+- Include a `README.md` with install, disable, uninstall, and trust notes.
+- Include a `manifest.json` that uses same-origin asset paths.
+- Do not commit secrets, tokens, credentials, cookies, private endpoints, or
+  machine-specific state.
+- Do not load remote third-party scripts at runtime.
+- Disclose any network, filesystem, native host, sidecar, or OS integration.
+- Bind sidecar services to localhost by default and document any ports used.
+- Prefer docs and examples when the WebUI extension contract is still changing.
+
+## Pull Request Checklist
+
+Before opening a PR, confirm:
+
+- [ ] The change belongs in the extension library, not Hermes WebUI core.
+- [ ] The extension or example is isolated under one directory.
+- [ ] The README explains the user workflow and trust model.
+- [ ] The manifest uses local extension assets.
+- [ ] Install, disable, and uninstall behavior is documented.
+- [ ] Any sidecar or native integration is documented clearly.
+- [ ] No secrets, generated local state, or unreviewed binaries are included.
+
+## Review Expectations
+
+Maintainers may ask for an extension to start as documentation or an example
+until the WebUI-side API is ready. This is expected while the foundation work
+lands in stages.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ before adding a large implementation.
 - Do not load remote third-party scripts at runtime.
 - Disclose any network, filesystem, native host, sidecar, or OS integration.
 - Bind sidecar services to localhost by default and document any ports used.
+- Document the WebUI version or extension API surface the entry was tested
+  against.
 - Prefer docs and examples when the WebUI extension contract is still changing.
 
 ## Pull Request Checklist
@@ -28,6 +30,7 @@ Before opening a PR, confirm:
 - [ ] The manifest uses local extension assets.
 - [ ] Install, disable, and uninstall behavior is documented.
 - [ ] Any sidecar or native integration is documented clearly.
+- [ ] Compatibility and verification notes are included.
 - [ ] No secrets, generated local state, or unreviewed binaries are included.
 
 ## Review Expectations
@@ -35,4 +38,3 @@ Before opening a PR, confirm:
 Maintainers may ask for an extension to start as documentation or an example
 until the WebUI-side API is ready. This is expected while the foundation work
 lands in stages.
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Hermes WebUI Extensions
+
+This repository is the community extension library for Hermes WebUI.
+
+The goal is to give trusted local extensions a shared place to document,
+package, review, and iterate without turning every optional workflow into
+Hermes WebUI core code.
+
+## Status
+
+This repository is intentionally early. The WebUI extension APIs and backend
+support are still evolving, so the conventions here should be treated as a
+foundation for review rather than a locked marketplace contract.
+
+For the current WebUI-side loading contract, see `docs/EXTENSIONS.md` in the
+main Hermes WebUI repository.
+
+## What Belongs Here
+
+- Optional local workflows that should not be core WebUI features.
+- UI panels, tools, diagnostics, or workspace helpers that run as trusted
+  same-origin extension assets.
+- Local sidecar integrations, such as native desktop helpers, when their trust
+  model and installation steps are explicit.
+- Examples that help extension authors follow the current WebUI contract.
+
+## What Does Not Belong Here
+
+- Core bug fixes or required WebUI behavior.
+- Remote third-party script loaders.
+- Secrets, tokens, credentials, or machine-specific configuration.
+- Unreviewed binaries or installers.
+- Extensions that require broad WebUI core changes before they can run.
+
+## Trust Model
+
+Hermes WebUI extensions are trusted local code. Extension JavaScript runs in
+the WebUI origin and can interact with the authenticated WebUI session. That
+means extensions should be reviewed like application code, not like passive
+themes.
+
+Extension PRs should disclose:
+
+- what APIs or DOM surfaces they use
+- whether they start or talk to a local sidecar process
+- whether they access the network, filesystem, native host, or OS APIs
+- how a user can install, disable, and remove the extension
+
+## Repository Layout
+
+```text
+extensions/
+  <extension-id>/
+    README.md
+    manifest.json
+    assets/
+    screenshots/
+docs/
+  extension-entry.md
+examples/
+  manifest-bundle/
+```
+
+Each extension should stay self-contained under `extensions/<extension-id>/`.
+Shared docs and examples live under `docs/` and `examples/`.
+
+## First Phase Scope
+
+This first phase defines repository shape and contribution expectations only.
+It does not add an extension registry UI, install flow, backend proxy, or any
+Desktop Companion assets.
+

--- a/README.md
+++ b/README.md
@@ -59,14 +59,32 @@ docs/
   extension-entry.md
 examples/
   manifest-bundle/
+  loopback-sidecar/
 ```
 
 Each extension should stay self-contained under `extensions/<extension-id>/`.
 Shared docs and examples live under `docs/` and `examples/`.
+
+## Compatibility And Testing
+
+Extensions should declare the WebUI extension API surface they expect, not just
+the WebUI version they were first tested with. This gives maintainers a way to
+check existing extensions when the main Hermes WebUI repo rolls forward.
+
+Extension entries should document:
+
+- supported Hermes WebUI version or release range
+- required extension API surface, such as manifest bundles or sidecar metadata
+- sidecar health expectations, if a local helper process is used
+- install, disable, and uninstall behavior
+- manual verification steps
+- any future CI check that should protect the extension
+
+The long-term goal is for this repository to validate existing extension
+entries as the main WebUI extension contract evolves.
 
 ## First Phase Scope
 
 This first phase defines repository shape and contribution expectations only.
 It does not add an extension registry UI, install flow, backend proxy, or any
 Desktop Companion assets.
-

--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -1,0 +1,79 @@
+# Extension Entry Contract
+
+This document defines the repository-side shape for extension entries in this
+library. It complements the WebUI-side loading contract documented in the main
+Hermes WebUI repository.
+
+## Required Files
+
+Each extension entry should include:
+
+```text
+extensions/<extension-id>/
+  README.md
+  manifest.json
+  assets/
+```
+
+Optional files:
+
+```text
+extensions/<extension-id>/
+  screenshots/
+  docs/
+  scripts/
+```
+
+## Manifest Shape
+
+The current WebUI loader reads a manifest bundle with an `extensions` array.
+Extension entries should keep paths local to the extension directory.
+
+```json
+{
+  "extensions": [
+    {
+      "id": "example-extension",
+      "scripts": ["assets/example-extension.js"],
+      "stylesheets": ["assets/example-extension.css"]
+    }
+  ]
+}
+```
+
+Use stable, lowercase extension IDs. Prefer letters, numbers, and hyphens.
+
+## README Shape
+
+Each extension README should cover:
+
+- what the extension does
+- who it is for
+- installation steps
+- disable and uninstall steps
+- WebUI APIs or DOM surfaces used
+- trust model and permissions
+- sidecar or native host behavior, if any
+- known limitations
+
+## Sidecar And Native Host Notes
+
+Some extensions may need a local process outside the browser, such as a desktop
+helper, native window, model bridge, or OS integration. Those entries should
+document:
+
+- how the sidecar starts and stops
+- default host and port
+- whether it exposes any network listener
+- whether it reads or writes local files
+- whether it can run without modifying Hermes WebUI core
+- what breaks if the WebUI extension API changes
+
+Sidecars should bind to localhost by default and avoid public network exposure.
+
+## Compatibility Notes
+
+Because the WebUI extension API is still evolving, extension READMEs should
+name the WebUI version, PR, or API surface they were tested against whenever
+possible.
+

--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -43,6 +43,43 @@ Extension entries should keep paths local to the extension directory.
 
 Use stable, lowercase extension IDs. Prefer letters, numbers, and hyphens.
 
+## Sidecar Metadata
+
+Extensions that depend on a local helper process should declare it in manifest
+metadata once the WebUI-side contract supports that field. This lets WebUI show
+users that an extension has a local dependency and eventually report coarse
+health state without hardcoding extension-specific behavior.
+
+Example shape:
+
+```json
+{
+  "extensions": [
+    {
+      "id": "desktop-companion",
+      "name": "Desktop Companion",
+      "scripts": ["assets/companion-adapter.js"],
+      "stylesheets": ["assets/companion-adapter.css"],
+      "sidecar": {
+        "type": "loopback",
+        "origin": "http://127.0.0.1:17787",
+        "health_path": "/health"
+      }
+    }
+  ]
+}
+```
+
+The `sidecar` object should stay descriptive unless the main WebUI repo defines
+stronger behavior. Declaring a sidecar should not imply install, auto-start,
+proxy, or public network access semantics.
+
+Suggested fields:
+
+- `type`: use `loopback` for a local HTTP service bound to localhost
+- `origin`: the localhost origin the extension expects
+- `health_path`: a read-only path WebUI can use for coarse health checks
+
 ## README Shape
 
 Each extension README should cover:
@@ -55,6 +92,7 @@ Each extension README should cover:
 - trust model and permissions
 - sidecar or native host behavior, if any
 - known limitations
+- compatibility and verification notes
 
 ## Sidecar And Native Host Notes
 
@@ -77,3 +115,6 @@ Because the WebUI extension API is still evolving, extension READMEs should
 name the WebUI version, PR, or API surface they were tested against whenever
 possible.
 
+Compatibility notes should prefer capability names over exact versions when
+possible. For example, say an extension needs manifest bundles and sidecar
+metadata rather than only naming the first release where those features worked.

--- a/examples/loopback-sidecar/README.md
+++ b/examples/loopback-sidecar/README.md
@@ -1,0 +1,12 @@
+# Loopback Sidecar Example
+
+This example shows how a trusted local extension can declare a loopback sidecar
+dependency in its manifest metadata.
+
+It is not a working feature extension. It documents the intended shape for
+extensions such as Desktop Companion, where WebUI loads local JS/CSS assets and
+the desktop or native behavior runs in a separate localhost process.
+
+The `sidecar` metadata is descriptive until the main Hermes WebUI repository
+defines and ships the corresponding manifest contract.
+

--- a/examples/loopback-sidecar/manifest.json
+++ b/examples/loopback-sidecar/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "desktop-companion",
+      "name": "Desktop Companion",
+      "scripts": ["assets/companion-adapter.js"],
+      "stylesheets": ["assets/companion-adapter.css"],
+      "sidecar": {
+        "type": "loopback",
+        "origin": "http://127.0.0.1:17787",
+        "health_path": "/health"
+      }
+    }
+  ]
+}

--- a/examples/manifest-bundle/README.md
+++ b/examples/manifest-bundle/README.md
@@ -7,3 +7,5 @@ It is not a working feature extension. It exists so contributors have a stable
 reference for manifest formatting while the WebUI extension APIs continue to
 evolve.
 
+For a manifest that declares a local helper process, see
+`examples/loopback-sidecar/`.

--- a/examples/manifest-bundle/README.md
+++ b/examples/manifest-bundle/README.md
@@ -1,0 +1,9 @@
+# Manifest Bundle Example
+
+This example shows the smallest repository-side shape for a WebUI extension
+manifest bundle.
+
+It is not a working feature extension. It exists so contributors have a stable
+reference for manifest formatting while the WebUI extension APIs continue to
+evolve.
+

--- a/examples/manifest-bundle/manifest.json
+++ b/examples/manifest-bundle/manifest.json
@@ -1,0 +1,9 @@
+{
+  "extensions": [
+    {
+      "id": "example-extension",
+      "scripts": ["assets/example-extension.js"],
+      "stylesheets": ["assets/example-extension.css"]
+    }
+  ]
+}

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,0 +1,16 @@
+# Extensions
+
+Extension entries will live in this directory.
+
+Use one directory per extension:
+
+```text
+extensions/<extension-id>/
+  README.md
+  manifest.json
+  assets/
+```
+
+Do not add shared runtime code here unless multiple accepted extensions already
+need it and maintainers agree on the shared contract.
+


### PR DESCRIPTION
## Summary
- add the initial README for the Hermes WebUI extension library purpose, layout, and trust model
- add contribution rules and PR checklist for extension entries
- add a repository-side extension entry contract and minimal manifest-bundle example
- document sidecar metadata expectations for loopback helpers such as Desktop Companion
- add compatibility/testing guidance so existing extensions can be checked as the main WebUI extension contract evolves

## Why
This repo is new and needs a small shared convention before real extensions are submitted. The PR is docs-only so it can fit around the ongoing WebUI extension foundation work without adding Desktop Companion assets yet.

The latest update also captures the Discord consensus that sidecar extensions should be declared in manifest metadata and that this repo should eventually support compatibility/testing checks for existing extensions.

## Verification
- git diff --check
- python3 -m json.tool examples/manifest-bundle/manifest.json
- python3 -m json.tool examples/loopback-sidecar/manifest.json

## Notes
- No extension implementation is included
- No Desktop Companion code or assets are included
- Sidecar metadata is documented as descriptive until the main WebUI repo defines and ships the corresponding contract
- AI-assisted with Codex