### PR TITLE
Add repo-wide extension validation and registry generation

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,0 +1,78 @@
+name: Extensions
+
+on:
+  pull_request:
+    paths:
+      - 'extensions/**'
+      - 'scripts/**'
+      - 'README.md'
+      - 'docs/extension-entry.md'
+      - 'docs/rfcs/0001-extension-json-schema.md'
+      - '.github/workflows/extensions.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'extensions/**'
+      - 'scripts/**'
+      - 'README.md'
+      - 'docs/extension-entry.md'
+      - 'docs/rfcs/0001-extension-json-schema.md'
+      - '.github/workflows/extensions.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate extensions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate extension entries
+        run: node scripts/validate-extensions.mjs
+
+      - name: Test extension validator
+        run: node scripts/test-extension-validator.mjs
+
+      - name: Generate registry
+        run: node scripts/generate-registry.mjs --out dist/registry.json
+
+      - name: Validate generated registry JSON
+        run: node -e "JSON.parse(require('node:fs').readFileSync('dist/registry.json','utf8'))"
+
+      - name: Upload registry artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-registry
+          path: dist/registry.json
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy-pages:
+    name: Deploy registry to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Extension entries should document:
 The long-term goal is for this repository to validate existing extension
 entries as the main WebUI extension contract evolves.
 
+Run the current repo-wide checks locally with:
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/test-extension-validator.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+```
+
+Pull requests run the same validator in CI. Pushes to `main` generate the
+registry artifact for GitHub Pages. Artifact zip delivery and install-time hash
+verification are tracked separately from this first registry generator.
+
 ## Current Entries
 
 - `extensions/desktop-companion/`: trusted local Desktop Companion entry and

--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -123,3 +123,29 @@ possible.
 Compatibility notes should prefer capability names over exact versions when
 possible. For example, say an extension needs manifest bundles and sidecar
 metadata rather than only naming the first release where those features worked.
+
+## Validation And Registry
+
+Run the repo-wide validator before opening or updating an extension PR:
+
+```bash
+node scripts/validate-extensions.mjs
+```
+
+The validator scans every `extensions/*/extension.json`, checks required files,
+safe local asset paths, runtime `manifest.json` consistency, shipped capability
+names, lifecycle and permission shape, and selected permissions-vs-code drift
+such as WebUI API read/write disclosures.
+
+Generate the registry locally with:
+
+```bash
+node scripts/generate-registry.mjs --out dist/registry.json
+```
+
+The generated registry is the gallery/install index consumed by future WebUI
+extension UI work. The first version includes the reviewed entry metadata plus
+Action-added fields such as `entry_path`, `runtime_manifest_path`,
+`published_at`, `file_count`, and per-file `file_sha256` values. Per-extension
+download zips and install-time `sha256` verification are tracked separately in
+the install-delivery issue.

--- a/scripts/extension-registry-lib.mjs
+++ b/scripts/extension-registry-lib.mjs
@@ -1,0 +1,392 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export const REPO_ROOT = process.cwd();
+export const EXTENSIONS_ROOT = path.join(REPO_ROOT, 'extensions');
+
+const VALID_CAPABILITIES = new Set([
+  'manifest-bundle',
+  'loopback-sidecar'
+]);
+
+const WEBUI_READ_ENDPOINTS = new Map([
+  ['sessions', /\/api\/sessions(?=$|[/?#'"`])/],
+  ['session', /\/api\/session(?!\/draft)(?=$|[/?#'"`])/],
+  ['approval/pending', /\/api\/approval\/pending(?=$|[/?#'"`])/],
+  ['clarify/pending', /\/api\/clarify\/pending(?=$|[/?#'"`])/]
+]);
+
+const WEBUI_WRITE_ENDPOINTS = new Map([
+  ['session/draft', /\/api\/session\/draft(?=$|[/?#'"`])/],
+  ['approval/respond', /\/api\/approval\/respond(?=$|[/?#'"`])/],
+  ['clarify/respond', /\/api\/clarify\/respond(?=$|[/?#'"`])/]
+]);
+
+const SHARED_STORAGE_KEYS = [
+  'hermes-session-viewed-counts',
+  'hermes-session-completion-unread',
+  'hermes-webui-session'
+];
+
+const OWNED_STORAGE_KEYS = [
+  'hermes-pet-navigation-last-id',
+  'hermes-pet-action-last-id'
+];
+
+export function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+export function repoRelative(filePath) {
+  return path.relative(REPO_ROOT, filePath).split(path.sep).join('/');
+}
+
+export function discoverEntries() {
+  if (!existsSync(EXTENSIONS_ROOT)) return [];
+  return readdirSync(EXTENSIONS_ROOT, { withFileTypes: true })
+    .filter((item) => item.isDirectory())
+    .map((item) => {
+      const root = path.join(EXTENSIONS_ROOT, item.name);
+      const extensionJsonPath = path.join(root, 'extension.json');
+      return existsSync(extensionJsonPath)
+        ? { idFromDir: item.name, root, extensionJsonPath }
+        : null;
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.idFromDir.localeCompare(b.idFromDir));
+}
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isLowerHyphenId(value) {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(String(value || ''));
+}
+
+function isSemver(value) {
+  return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(String(value || ''));
+}
+
+function isSafeLocalPath(value) {
+  if (!isNonEmptyString(value)) return false;
+  if (value.startsWith('/') || value.startsWith('\\')) return false;
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)) return false;
+  if (value.includes('\\')) return false;
+  const normalized = path.posix.normalize(value);
+  if (normalized === '.' || normalized.startsWith('../') || normalized === '..') return false;
+  if (normalized.includes('\0')) return false;
+  return normalized === value;
+}
+
+function localFile(entryRoot, rel) {
+  return path.join(entryRoot, rel.split('/').join(path.sep));
+}
+
+function collectFiles(dir, prefix = '') {
+  const files = [];
+  for (const item of readdirSync(dir, { withFileTypes: true })) {
+    const rel = prefix ? `${prefix}/${item.name}` : item.name;
+    const target = path.join(dir, item.name);
+    if (item.isDirectory()) {
+      files.push(...collectFiles(target, rel));
+    } else if (item.isFile()) {
+      files.push(rel);
+    }
+  }
+  return files.sort();
+}
+
+function sha256File(filePath) {
+  return createHash('sha256').update(readFileSync(filePath)).digest('hex');
+}
+
+function assertArray(value, label, errors) {
+  if (!Array.isArray(value)) {
+    errors.push(`${label} must be an array`);
+    return [];
+  }
+  return value;
+}
+
+function assertBoolean(value, label, errors) {
+  if (typeof value !== 'boolean') errors.push(`${label} must be a boolean`);
+}
+
+function assertString(value, label, errors) {
+  if (!isNonEmptyString(value)) errors.push(`${label} must be a non-empty string`);
+}
+
+function validateAssets(entry, errors) {
+  if (!isPlainObject(entry.assets)) {
+    errors.push('assets must be an object');
+    return { scripts: [], stylesheets: [] };
+  }
+  const scripts = assertArray(entry.assets.scripts, 'assets.scripts', errors);
+  const stylesheets = assertArray(entry.assets.stylesheets, 'assets.stylesheets', errors);
+  for (const rel of [...scripts, ...stylesheets]) {
+    if (!isSafeLocalPath(rel)) {
+      errors.push(`asset path is not safe/local: ${rel}`);
+      continue;
+    }
+    const target = localFile(entry.__root, rel);
+    if (!existsSync(target) || !statSync(target).isFile()) {
+      errors.push(`asset file missing: ${rel}`);
+    }
+  }
+  for (const script of scripts) {
+    if (!/\.(?:cjs|js|mjs)$/.test(script)) continue;
+    const check = spawnSync(process.execPath, ['--check', localFile(entry.__root, script)], {
+      encoding: 'utf8',
+      timeout: 30000
+    });
+    if (check.status !== 0) {
+      errors.push(`JavaScript syntax check failed for ${script}: ${check.stderr || check.stdout}`);
+    }
+  }
+  return { scripts, stylesheets };
+}
+
+function validateRuntimeManifest(entry, assets, errors) {
+  const manifestPath = path.join(entry.__root, 'manifest.json');
+  if (!existsSync(manifestPath)) {
+    errors.push('manifest.json is required until the registry Action derives it');
+    return;
+  }
+  let manifest;
+  try {
+    manifest = readJson(manifestPath);
+  } catch (error) {
+    errors.push(`manifest.json is not valid JSON: ${error.message}`);
+    return;
+  }
+  const extensions = assertArray(manifest.extensions, 'manifest.extensions', errors);
+  if (extensions.length !== 1) {
+    errors.push('manifest.extensions must contain exactly one entry');
+    return;
+  }
+  const runtime = extensions[0];
+  if (!isPlainObject(runtime)) {
+    errors.push('manifest.extensions[0] must be an object');
+    return;
+  }
+  if (runtime.id !== entry.id) errors.push(`manifest id ${runtime.id || '<missing>'} must match extension id ${entry.id}`);
+  const runtimeScripts = assertArray(runtime.scripts || [], 'manifest scripts', errors);
+  const runtimeStylesheets = assertArray(runtime.stylesheets || [], 'manifest stylesheets', errors);
+  if (JSON.stringify(runtimeScripts) !== JSON.stringify(assets.scripts)) {
+    errors.push('manifest scripts must match extension.json assets.scripts');
+  }
+  if (JSON.stringify(runtimeStylesheets) !== JSON.stringify(assets.stylesheets)) {
+    errors.push('manifest stylesheets must match extension.json assets.stylesheets');
+  }
+}
+
+function validatePermissions(entry, scriptText, errors) {
+  const permissions = entry.permissions;
+  if (!isPlainObject(permissions)) {
+    errors.push('permissions must be an object');
+    return;
+  }
+  const webuiApi = isPlainObject(permissions.webui_api) ? permissions.webui_api : {};
+  const declaredReads = new Set(assertArray(webuiApi.read || [], 'permissions.webui_api.read', errors));
+  const declaredWrites = new Set(assertArray(webuiApi.write || [], 'permissions.webui_api.write', errors));
+
+  for (const [endpoint, pattern] of WEBUI_READ_ENDPOINTS) {
+    if (pattern.test(scriptText) && !declaredReads.has(endpoint)) {
+      errors.push(`permissions.webui_api.read must include ${endpoint}`);
+    }
+  }
+  for (const [endpoint, pattern] of WEBUI_WRITE_ENDPOINTS) {
+    if (pattern.test(scriptText) && !declaredWrites.has(endpoint)) {
+      errors.push(`permissions.webui_api.write must include ${endpoint}`);
+    }
+  }
+
+  if (/(window\.loadSession|switchPanel|window\.location\.assign|hermes-webui-session)/.test(scriptText)) {
+    if (permissions.webui_navigation !== true) errors.push('permissions.webui_navigation must be true when adapter navigates WebUI');
+  }
+  assertBoolean(permissions.webui_navigation, 'permissions.webui_navigation', errors);
+
+  if (/\/api\/pet\/(?:navigation|actions)/.test(scriptText)) {
+    if (!isPlainObject(permissions.sidecar_commands) || permissions.sidecar_commands.from_loopback !== true) {
+      errors.push('permissions.sidecar_commands.from_loopback must be true when polling sidecar commands');
+    }
+  }
+
+  if (!isPlainObject(permissions.dom)) {
+    errors.push('permissions.dom must be an object');
+  } else {
+    assertBoolean(permissions.dom.owned, 'permissions.dom.owned', errors);
+    assertBoolean(permissions.dom.mutates_core_views, 'permissions.dom.mutates_core_views', errors);
+    if (permissions.dom.owned === false && /(document\.createElement|appendChild|innerHTML)/.test(scriptText)) {
+      errors.push('permissions.dom.owned is false but scripts appear to create/mutate DOM');
+    }
+  }
+
+  if (!isPlainObject(permissions.storage)) {
+    errors.push('permissions.storage must be an object');
+  } else {
+    const owned = new Set(assertArray(permissions.storage.owned || [], 'permissions.storage.owned', errors));
+    const shared = new Set(assertArray(permissions.storage.shared_webui_keys || [], 'permissions.storage.shared_webui_keys', errors));
+    for (const key of OWNED_STORAGE_KEYS) {
+      if (scriptText.includes(key) && !owned.has(key)) errors.push(`permissions.storage.owned must include ${key}`);
+    }
+    for (const key of SHARED_STORAGE_KEYS) {
+      if (scriptText.includes(key) && !shared.has(key)) errors.push(`permissions.storage.shared_webui_keys must include ${key}`);
+    }
+  }
+
+  assertBoolean(permissions.loopback_sidecar, 'permissions.loopback_sidecar', errors);
+  assertBoolean(permissions.native_host, 'permissions.native_host', errors);
+  assertBoolean(permissions.network_external, 'permissions.network_external', errors);
+
+  if (!isPlainObject(permissions.filesystem)) {
+    errors.push('permissions.filesystem must be an object');
+  } else {
+    assertBoolean(permissions.filesystem.arbitrary, 'permissions.filesystem.arbitrary', errors);
+    assertBoolean(permissions.filesystem.serves_bundled_assets, 'permissions.filesystem.serves_bundled_assets', errors);
+  }
+
+  const externalFetch = /fetch\(\s*['"]https?:\/\/(?!(?:127\.0\.0\.1|localhost|\[::1\])(?=$|[:/?#'"`]))/;
+  if (permissions.network_external === false && externalFetch.test(scriptText)) {
+    errors.push('permissions.network_external is false but scripts appear to fetch an external origin');
+  }
+  if (/\b(eval|Function)\s*\(/.test(scriptText)) {
+    errors.push('scripts must not use eval() or Function()');
+  }
+}
+
+function validateLifecycle(entry, errors) {
+  if (!isPlainObject(entry.lifecycle)) {
+    errors.push('lifecycle must be an object');
+    return;
+  }
+  assertBoolean(entry.lifecycle.webui_restart_required, 'lifecycle.webui_restart_required', errors);
+  assertBoolean(entry.lifecycle.sidecar_start_required, 'lifecycle.sidecar_start_required', errors);
+  assertBoolean(entry.lifecycle.native_host_start_required, 'lifecycle.native_host_start_required', errors);
+  const autostart = entry.lifecycle.native_host_autostart;
+  if (!['extension_owned', 'webui_owned', 'none'].includes(autostart)) {
+    errors.push('lifecycle.native_host_autostart must be extension_owned, webui_owned, or none');
+  }
+}
+
+function validateSidecar(entry, errors) {
+  const hasCapability = Array.isArray(entry.capabilities) && entry.capabilities.includes('loopback-sidecar');
+  if (!hasCapability) return;
+  if (!isPlainObject(entry.sidecar)) {
+    errors.push('sidecar block is required when loopback-sidecar capability is declared');
+    return;
+  }
+  if (entry.sidecar.type !== 'loopback') errors.push('sidecar.type must be loopback');
+  try {
+    const origin = new URL(entry.sidecar.origin);
+    if (!['http:', 'https:'].includes(origin.protocol)) errors.push('sidecar.origin must be http(s)');
+    if (!['127.0.0.1', 'localhost', '::1'].includes(origin.hostname)) {
+      errors.push('sidecar.origin must be loopback');
+    }
+  } catch (_) {
+    errors.push('sidecar.origin must be a valid URL');
+  }
+  if (!isNonEmptyString(entry.sidecar.health_path) || !entry.sidecar.health_path.startsWith('/')) {
+    errors.push('sidecar.health_path must be an absolute path');
+  }
+}
+
+function validateCapabilities(entry, errors) {
+  const capabilities = assertArray(entry.capabilities, 'capabilities', errors);
+  for (const capability of capabilities) {
+    if (!VALID_CAPABILITIES.has(capability)) {
+      errors.push(`capability is not currently shipped/allowed: ${capability}`);
+    }
+  }
+}
+
+export function validateEntry(discovered) {
+  const errors = [];
+  let entry;
+  try {
+    entry = readJson(discovered.extensionJsonPath);
+  } catch (error) {
+    return {
+      id: discovered.idFromDir,
+      root: discovered.root,
+      errors: [`extension.json is not valid JSON: ${error.message}`]
+    };
+  }
+
+  entry.__root = discovered.root;
+  assertString(entry.id, 'id', errors);
+  assertString(entry.name, 'name', errors);
+  assertString(entry.description, 'description', errors);
+  assertString(entry.author, 'author', errors);
+  if (!isSemver(entry.version)) errors.push('version must be semver-like, for example 0.1.0');
+  if (!isLowerHyphenId(entry.id)) errors.push('id must be lowercase-hyphen');
+  if (entry.id !== discovered.idFromDir) errors.push(`id must match directory name ${discovered.idFromDir}`);
+  if (!existsSync(path.join(discovered.root, 'README.md'))) errors.push('README.md is required');
+  if (!Array.isArray(entry.screenshots)) errors.push('screenshots must be an array');
+
+  const assets = validateAssets(entry, errors);
+  validateRuntimeManifest(entry, assets, errors);
+  validateCapabilities(entry, errors);
+  validateLifecycle(entry, errors);
+  validateSidecar(entry, errors);
+
+  const scriptText = assets.scripts
+    .map((rel) => (existsSync(localFile(discovered.root, rel)) ? readFileSync(localFile(discovered.root, rel), 'utf8') : ''))
+    .join('\n');
+  validatePermissions(entry, scriptText, errors);
+
+  delete entry.__root;
+  return { id: entry.id || discovered.idFromDir, root: discovered.root, entry, errors };
+}
+
+export function validateAllEntries() {
+  const discovered = discoverEntries();
+  const seen = new Set();
+  const results = discovered.map((item) => {
+    const result = validateEntry(item);
+    if (seen.has(result.id)) result.errors.push(`duplicate extension id: ${result.id}`);
+    seen.add(result.id);
+    return result;
+  });
+  return { discovered, results };
+}
+
+export function buildRegistry({ publishedAt = new Date().toISOString() } = {}) {
+  const { results } = validateAllEntries();
+  const failures = results.filter((result) => result.errors.length);
+  if (failures.length) {
+    const message = failures
+      .map((result) => `${result.id}\n${result.errors.map((error) => `  - ${error}`).join('\n')}`)
+      .join('\n');
+    throw new Error(`Cannot generate registry from invalid entries:\n${message}`);
+  }
+
+  return {
+    version: 1,
+    generated_at: publishedAt,
+    extensions: results
+      .map((result) => {
+        const entryDir = repoRelative(result.root);
+        const fileHashes = collectFiles(result.root).map((rel) => ({
+          path: rel,
+          sha256: sha256File(path.join(result.root, rel.split('/').join(path.sep)))
+        }));
+        return {
+          ...result.entry,
+          entry_path: `${entryDir}/extension.json`,
+          runtime_manifest_path: `${entryDir}/manifest.json`,
+          published_at: publishedAt,
+          file_count: fileHashes.length,
+          file_sha256: fileHashes
+        };
+      })
+      .sort((a, b) => a.id.localeCompare(b.id))
+  };
+}

--- a/scripts/generate-registry.mjs
+++ b/scripts/generate-registry.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { buildRegistry } from './extension-registry-lib.mjs';
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : '';
+}
+
+const out = argValue('--out') || 'registry.json';
+const registry = buildRegistry();
+const payload = `${JSON.stringify(registry, null, 2)}\n`;
+
+mkdirSync(path.dirname(path.resolve(out)), { recursive: true });
+writeFileSync(out, payload, 'utf8');
+
+console.log(`wrote ${out} with ${registry.extensions.length} extension entr${registry.extensions.length === 1 ? 'y' : 'ies'}`);

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { validateEntry } from './extension-registry-lib.mjs';
+
+const tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'hermes-extension-validator-'));
+
+function writeJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function validationErrors(scriptText) {
+  const id = `validator-case-${Math.random().toString(36).slice(2, 8)}`;
+  const root = path.join(tmpRoot, id);
+  const asset = 'assets/adapter.js';
+  mkdirSync(path.join(root, 'assets'), { recursive: true });
+  writeFileSync(path.join(root, 'README.md'), '# Validator fixture\n', { encoding: 'utf8', flag: 'w' });
+  writeFileSync(path.join(root, 'assets/adapter.js'), scriptText, { encoding: 'utf8', flag: 'w' });
+  writeJson(path.join(root, 'manifest.json'), {
+    extensions: [
+      {
+        id,
+        name: 'Validator Fixture',
+        scripts: [asset],
+        stylesheets: []
+      }
+    ]
+  });
+  writeJson(path.join(root, 'extension.json'), {
+    id,
+    name: 'Validator Fixture',
+    description: 'Temporary validator test fixture.',
+    version: '0.0.1',
+    author: 'test',
+    assets: {
+      scripts: [asset],
+      stylesheets: []
+    },
+    capabilities: ['manifest-bundle'],
+    lifecycle: {
+      webui_restart_required: false,
+      sidecar_start_required: false,
+      native_host_start_required: false,
+      native_host_autostart: 'none'
+    },
+    screenshots: [],
+    permissions: {
+      webui_api: {
+        read: [],
+        write: []
+      },
+      webui_navigation: false,
+      dom: {
+        owned: true,
+        mutates_core_views: false
+      },
+      storage: {
+        owned: [],
+        shared_webui_keys: []
+      },
+      loopback_sidecar: false,
+      native_host: false,
+      filesystem: {
+        arbitrary: false,
+        serves_bundled_assets: true
+      },
+      network_external: false
+    }
+  });
+  return validateEntry({
+    idFromDir: id,
+    root,
+    extensionJsonPath: path.join(root, 'extension.json')
+  }).errors;
+}
+
+try {
+  let errors = validationErrors("fetch('/api/sessions/123');\n");
+  assert(errors.includes('permissions.webui_api.read must include sessions'));
+
+  errors = validationErrors("fetch('/api/session/draft');\n");
+  assert(errors.includes('permissions.webui_api.write must include session/draft'));
+  assert(!errors.includes('permissions.webui_api.read must include session'));
+
+  errors = validationErrors("fetch('/api/approval/pending-old');\n");
+  assert(!errors.includes('permissions.webui_api.read must include approval/pending'));
+
+  errors = validationErrors("fetch('/api/clarify/pending?session_id=123');\n");
+  assert(errors.includes('permissions.webui_api.read must include clarify/pending'));
+
+  errors = validationErrors("fetch('https://example.com/data');\n");
+  assert(errors.includes('permissions.network_external is false but scripts appear to fetch an external origin'));
+
+  errors = validationErrors("fetch('http://127.0.0.1:17787/health');\n");
+  assert(!errors.includes('permissions.network_external is false but scripts appear to fetch an external origin'));
+
+  errors = validationErrors("fetch('http://localhost/health');\n");
+  assert(!errors.includes('permissions.network_external is false but scripts appear to fetch an external origin'));
+
+  errors = validationErrors("fetch('http://[::1]:17787/health');\n");
+  assert(!errors.includes('permissions.network_external is false but scripts appear to fetch an external origin'));
+
+  console.log('extension validator self-tests passed');
+} finally {
+  rmSync(tmpRoot, { recursive: true, force: true });
+}

--- a/scripts/validate-extensions.mjs
+++ b/scripts/validate-extensions.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { validateAllEntries } from './extension-registry-lib.mjs';
+
+const { results } = validateAllEntries();
+const failures = results.filter((result) => result.errors.length);
+
+for (const result of results) {
+  if (!result.errors.length) {
+    console.log(`ok ${result.id}`);
+    continue;
+  }
+  console.error(`fail ${result.id}`);
+  for (const error of result.errors) {
+    console.error(`  - ${error}`);
+  }
+}
+
+if (failures.length) {
+  console.error(`\n${failures.length} extension entr${failures.length === 1 ? 'y' : 'ies'} failed validation.`);
+  process.exit(1);
+}
+
+console.log(`validated ${results.length} extension entr${results.length === 1 ? 'y' : 'ies'}`);


### PR DESCRIPTION
## Summary

Adds the first repo-wide extension validation and registry generation path:

- validates every `extensions/*/extension.json` entry plus its runtime `manifest.json`
- checks required metadata, local asset paths, known shipped capabilities, lifecycle shape, sidecar metadata, and selected permission-vs-code drift
- generates a deterministic `registry.json` with entry metadata, paths, timestamps, file count, and per-file SHA-256 values
- wires GitHub Actions to validate PRs and publish the generated registry artifact / Pages bundle on `main`
- documents the local validation and registry generation commands

## Tracking / cross-references

- Closes #3: registry generator + GitHub Action publish path.
- Addresses #6: first repo-wide PR validator for schema, structure, capabilities, runtime manifest consistency, and selected permissions-vs-code drift.
- Part of #12: extension-system critical path for registry -> delivery -> install UI.
- Builds on #11: validates the first real Desktop Companion entry now that it is merged.
- Unblocks the library side of #9, but does not implement per-extension zip delivery or install-time artifact verification.
- Feeds #4 / core install UI work by producing the registry the gallery/install flow will consume.
- Related but out of scope: deeper malicious-code safety gates in #8 and sidecar proxy work in #5.

## Notes

This intentionally keeps per-extension zip delivery and install-time artifact hash verification out of scope; those remain tracked in the install-delivery work.

## Validation

- `node scripts/validate-extensions.mjs`
- `node scripts/test-extension-validator.mjs`
- `node scripts/generate-registry.mjs --out dist/registry.json`
- `python3 -m json.tool dist/registry.json >/dev/null`
- `node --check scripts/extension-registry-lib.mjs`
- `node --check scripts/validate-extensions.mjs`
- `node --check scripts/generate-registry.mjs`
- `node --check scripts/test-extension-validator.mjs`
- `python3 -m json.tool extensions/desktop-companion/extension.json >/dev/null`
- `python3 -m json.tool extensions/desktop-companion/manifest.json >/dev/null`
- `node scripts/validate-desktop-companion.mjs`
- `git diff --check`
- Claude Code review: no blocking issues after endpoint-regex and external-fetch validator tests were added.
