### PR TITLE
Add mobile conversations extension

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -19,3 +19,5 @@ need it and maintainers agree on the shared contract.
 
 - `desktop-companion`: trusted local Desktop Companion entry and first
   sidecar-class extension candidate.
+- `mobile-conversations`: phone-only floating Conversations button and
+  long-press shortcuts for the existing Hermes WebUI mobile drawer.

--- a/extensions/mobile-conversations/README.md
+++ b/extensions/mobile-conversations/README.md
@@ -1,0 +1,150 @@
+# Mobile Conversations Button
+
+Mobile Conversations Button is a trusted local Hermes WebUI extension that adds
+a phone-only floating **Conversations** button near the chat composer. It opens
+the existing mobile conversations drawer and provides a long-press shortcuts
+menu for common conversation navigation actions.
+
+## What It Does
+
+- Adds a phone-width-only floating Conversations button inside the chat messages
+  shell.
+- Short tap opens or closes the existing mobile conversations/sidebar drawer.
+- Long press opens a menu with shortcuts for:
+  - New conversation
+  - Open sidebar
+  - Go to top
+  - Go to last message
+- Hides the floating button while the mobile drawer is already open.
+- Leaves desktop-width layouts unchanged.
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/mobile-conversations.js
+  -> /extensions/assets/mobile-conversations.css
+  -> existing WebUI mobile sidebar, session, and scroll UI hooks
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, access external networks, read or write local files, or
+use native host APIs.
+
+## Capabilities
+
+This entry declares only capabilities currently available to extension entries:
+
+- `manifest-bundle`
+
+It does not require `loopback-sidecar` or future sidecar proxy support.
+
+## Install For Local Testing
+
+Start Hermes WebUI with this extension directory:
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/mobile-conversations HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+The runtime `manifest.json` injects:
+
+```json
+{
+  "extensions": [
+    {
+      "id": "mobile-conversations",
+      "name": "Mobile Conversations Button",
+      "description": "Phone-only floating Conversations button and shortcut menu for Hermes WebUI.",
+      "scripts": ["assets/mobile-conversations.js"],
+      "stylesheets": ["assets/mobile-conversations.css"]
+    }
+  ]
+}
+```
+
+## Disable And Uninstall
+
+To disable the WebUI extension, restart Hermes WebUI without:
+
+```text
+HERMES_WEBUI_EXTENSION_DIR
+HERMES_WEBUI_EXTENSION_MANIFEST
+HERMES_WEBUI_EXTENSION_STYLESHEET_URLS
+HERMES_WEBUI_EXTENSION_SCRIPT_URLS
+```
+
+To uninstall it from a manual local setup, remove the
+`extensions/mobile-conversations/` directory from the local extensions checkout
+or remove the entry from the aggregate manifest that points at it.
+
+## Trust And Permissions
+
+This is trusted local code. The injected JavaScript runs in the Hermes WebUI
+browser origin and can use the logged-in browser session.
+
+Current disclosed behavior:
+
+- creates extension-owned DOM for the floating button and long-press menu
+- inserts the floating button into the existing `.messages-shell`
+- reads existing mobile layout state through WebUI DOM/classes
+- calls existing WebUI browser functions when available, including
+  `switchPanel`, `closeMobileSidebar`, `newSession`, `renderSessionList`,
+  `jumpToSessionStart`, and `scrollToBottom`
+- toggles existing mobile sidebar classes as a fallback when the public browser
+  helper is unavailable
+- uses pointer, context-menu, keyboard, resize, scroll, and mutation-observer
+  handlers for mobile interaction and accessibility behavior
+- does not call WebUI HTTP APIs
+- does not use localStorage or sessionStorage
+- does not access cookies
+- does not contact loopback or external network services
+- does not use arbitrary filesystem or native host APIs
+
+## Compatibility
+
+Required WebUI surface:
+
+- manifest-bundled extension assets
+- same-origin extension asset serving under `/extensions/`
+- mobile WebUI layout with `.messages-shell`, `.sidebar`, and `#panelChat`
+- existing browser hooks for mobile drawer/session/scroll behavior where
+  available; the extension has DOM fallbacks for older builds
+
+The source local extension was tested against Hermes WebUI versions at or after
+`0.51.545`. The compatibility requirement is better described as the manifest
+bundle plus the mobile sidebar/browser-hook surfaces listed above.
+
+## Verification
+
+From this repository:
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/mobile-conversations/assets/mobile-conversations.js
+python3 -m json.tool extensions/mobile-conversations/extension.json
+python3 -m json.tool extensions/mobile-conversations/manifest.json
+```
+
+Manual mobile verification should confirm:
+
+- at phone width, the floating Conversations button appears near the lower-right
+  chat controls
+- tapping the button opens the existing mobile conversations drawer
+- the button is hidden while the drawer is open
+- long press opens the shortcuts menu
+- the synthetic click after a long press does not also toggle the drawer
+- the next normal tap still works
+- Escape closes the shortcuts menu and returns focus to the button
+- desktop-width layouts do not show the button
+
+## Known Limitations
+
+- No one-click install path is available yet.
+- The extension relies on current WebUI DOM and browser helper names until a
+  formal mobile sidebar extension API exists.
+- The extension is intentionally mobile-only and does not add a desktop control.

--- a/extensions/mobile-conversations/assets/mobile-conversations.css
+++ b/extensions/mobile-conversations/assets/mobile-conversations.css
@@ -1,0 +1,14 @@
+.mobile-conversations-fab.hwx-mobile-conversations-fab{display:none;}
+
+@media(max-width:640px){
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab{position:absolute;right:20px;bottom:60px;z-index:12;width:44px;height:44px;min-width:44px;min-height:44px;border-radius:999px;border:1px solid var(--border2);background:var(--code-bg);color:var(--muted);display:inline-flex!important;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,.25);cursor:pointer;-webkit-tap-highlight-color:transparent;touch-action:manipulation;transition:color .12s,border-color .12s,background .12s,transform .12s;}
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab:hover,
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab:focus-visible{color:var(--text);border-color:var(--border);background:var(--hover-bg);outline:none;}
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab:active{transform:translateY(1px) scale(.98);}
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.active,
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--pressing{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--text);}
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab svg{display:block;}
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--drawer-open{display:none!important;}
+  .mobile-conversations-menu.hwx-mobile-conversations-menu .ws-opt-action{min-height:44px;}
+  .mobile-conversations-menu.hwx-mobile-conversations-menu .ws-opt-name{white-space:nowrap;}
+}

--- a/extensions/mobile-conversations/assets/mobile-conversations.js
+++ b/extensions/mobile-conversations/assets/mobile-conversations.js
@@ -1,0 +1,453 @@
+(() => {
+  'use strict';
+
+  const EXT = 'mobile-conversations';
+  const BUTTON_ID = 'mobileConversationsBtn';
+  const LONG_PRESS_DELAY_MS = 400;
+  const CLICK_IGNORE_MS = 700;
+  const INIT_RETRIES = 80;
+  const INIT_DELAY_MS = 150;
+
+  if (window.__hermesMobileConversationsExtensionLoaded) return;
+  window.__hermesMobileConversationsExtensionLoaded = true;
+
+  let menu = null;
+  let pressTimer = null;
+  let ignoreClickUntil = 0;
+  let pressX = 0;
+  let pressY = 0;
+  let sidebarObserver = null;
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  function isDesktopWidth() {
+    try {
+      if (typeof window._isDesktopWidth === 'function') return window._isDesktopWidth();
+    } catch (_) {}
+    try { return window.matchMedia('(min-width:641px)').matches; }
+    catch (_) { return true; }
+  }
+
+  function translate(key, fallback) {
+    try {
+      if (typeof window.t === 'function') {
+        const value = window.t(key);
+        if (value && value !== key) return value;
+      }
+    } catch (_) {}
+    return fallback;
+  }
+
+  function sidebarOpen() {
+    const sidebar = document.querySelector('.sidebar');
+    return !!(sidebar && sidebar.classList.contains('mobile-open'));
+  }
+
+  function chatPanelActive() {
+    const panel = $('panelChat');
+    if (panel && panel.classList.contains('active')) return true;
+    const main = document.querySelector('main.main');
+    if (!main) return true;
+    return !Array.from(main.classList).some((name) => name.indexOf('showing-') === 0);
+  }
+
+  function syncButton() {
+    const btn = $(BUTTON_ID);
+    if (!btn || btn.dataset.hwxMobileConversations !== '1') return;
+    const open = sidebarOpen();
+    btn.classList.toggle('mobile-conversations-fab--drawer-open', open);
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    btn.setAttribute('aria-label', open ? 'Close conversations' : 'Open conversations');
+    btn.title = open ? 'Close conversations' : 'Conversations';
+  }
+
+  function closeDrawer() {
+    try {
+      if (typeof window.closeMobileSidebar === 'function') {
+        window.closeMobileSidebar();
+        syncButton();
+        return;
+      }
+    } catch (_) {}
+    const sidebar = document.querySelector('.sidebar');
+    const overlay = $('mobileOverlay');
+    if (sidebar) sidebar.classList.remove('mobile-open');
+    if (overlay) overlay.classList.remove('visible');
+    syncButton();
+  }
+
+  function openDrawerDirect() {
+    if (isDesktopWidth()) return false;
+    const sidebar = document.querySelector('.sidebar');
+    const overlay = $('mobileOverlay');
+    if (!sidebar) return false;
+    const layout = document.querySelector('.layout');
+    if (layout) layout.classList.remove('sidebar-collapsed');
+    sidebar.classList.remove('sidebar-collapsed');
+    try { document.documentElement.removeAttribute('data-sidebar-collapsed'); } catch (_) {}
+    sidebar.classList.add('mobile-open');
+    if (overlay) overlay.classList.add('visible');
+    syncButton();
+    return true;
+  }
+
+  async function openChatDrawer() {
+    if (isDesktopWidth()) return false;
+    closeMenu();
+    if (typeof window.switchPanel === 'function') {
+      try {
+        const result = await window.switchPanel('chat', { fromRailClick: true });
+        if (result === false) {
+          syncButton();
+          return false;
+        }
+      } catch (_) {
+        openDrawerDirect();
+      }
+    } else {
+      openDrawerDirect();
+    }
+    if (!sidebarOpen()) openDrawerDirect();
+    syncButton();
+    return sidebarOpen();
+  }
+
+  async function toggleMobileConversationsSidebar() {
+    if (isDesktopWidth()) return false;
+    closeMenu();
+    if (sidebarOpen() && chatPanelActive()) {
+      closeDrawer();
+      return false;
+    }
+    return openChatDrawer();
+  }
+
+  function ignoreNextClick() {
+    ignoreClickUntil = Date.now() + CLICK_IGNORE_MS;
+  }
+
+  function consumeIgnoredClick() {
+    if (!ignoreClickUntil) return false;
+    if (Date.now() > ignoreClickUntil) {
+      ignoreClickUntil = 0;
+      return false;
+    }
+    ignoreClickUntil = 0;
+    return true;
+  }
+
+  function clearClickIgnore() {
+    ignoreClickUntil = 0;
+  }
+
+  function clearPressTimer() {
+    if (pressTimer) {
+      clearTimeout(pressTimer);
+      pressTimer = null;
+    }
+    const btn = $(BUTTON_ID);
+    if (btn) btn.classList.remove('mobile-conversations-fab--pressing');
+  }
+
+  function icon(name) {
+    const attrs = 'width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"';
+    if (name === 'plus') return `<svg ${attrs}><path d="M12 5v14"/><path d="M5 12h14"/></svg>`;
+    if (name === 'message') return `<svg ${attrs}><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`;
+    if (name === 'up') return `<svg ${attrs}><path d="m18 15-6-6-6 6"/></svg>`;
+    return `<svg ${attrs}><path d="m6 9 6 6 6-6"/></svg>`;
+  }
+
+  function actionButton(label, title, iconName, onSelect) {
+    const opt = document.createElement('button');
+    opt.type = 'button';
+    opt.className = 'ws-opt session-action-opt mobile-conversations-menu-opt';
+    opt.setAttribute('role', 'menuitem');
+    opt.tabIndex = -1;
+    if (title) opt.title = title;
+
+    const action = document.createElement('span');
+    action.className = 'ws-opt-action';
+
+    const iconWrap = document.createElement('span');
+    iconWrap.className = 'ws-opt-icon';
+    iconWrap.innerHTML = icon(iconName);
+
+    const copy = document.createElement('span');
+    copy.className = 'session-action-copy';
+    const name = document.createElement('span');
+    name.className = 'ws-opt-name';
+    name.textContent = label;
+    copy.appendChild(name);
+
+    action.appendChild(iconWrap);
+    action.appendChild(copy);
+    opt.appendChild(action);
+
+    opt.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      closeMenu();
+      await onSelect();
+    });
+    return opt;
+  }
+
+  async function newConversation() {
+    const btn = $('btnNewChat');
+    if (btn) {
+      btn.click();
+      return;
+    }
+    if (typeof window.newSession === 'function') {
+      await window.newSession();
+      if (typeof window.renderSessionList === 'function') await window.renderSessionList();
+      const msg = $('msg');
+      if (msg && typeof msg.focus === 'function') msg.focus();
+    }
+  }
+
+  async function goTop() {
+    if (typeof window.jumpToSessionStart === 'function') {
+      await window.jumpToSessionStart();
+      return;
+    }
+    const messages = $('messages');
+    if (messages) messages.scrollTop = 0;
+  }
+
+  function goLast() {
+    if (typeof window.scrollToBottom === 'function') {
+      window.scrollToBottom();
+      return;
+    }
+    const messages = $('messages');
+    if (messages) messages.scrollTop = messages.scrollHeight;
+  }
+
+  function positionMenu() {
+    const btn = $(BUTTON_ID);
+    if (!menu || !btn) return;
+    const rect = btn.getBoundingClientRect();
+    const menuW = Math.min(280, Math.max(220, menu.scrollWidth || 220));
+    let left = rect.right - menuW;
+    if (left < 8) left = 8;
+    if (left + menuW > window.innerWidth - 8) left = window.innerWidth - menuW - 8;
+    menu.style.left = `${left}px`;
+    menu.style.maxHeight = '';
+    const menuH = menu.offsetHeight || 0;
+    const margin = 8;
+    let top = rect.top - menuH - 8;
+    if (top < margin) top = rect.bottom + 8;
+    if (top + menuH > window.innerHeight - margin) top = Math.max(margin, window.innerHeight - margin - menuH);
+    menu.style.top = `${top}px`;
+  }
+
+  function closeMenu() {
+    if (menu) {
+      menu.removeEventListener('keydown', menuKeydown);
+      menu.remove();
+      menu = null;
+    }
+    const btn = $(BUTTON_ID);
+    if (btn) {
+      btn.classList.remove('active', 'mobile-conversations-fab--pressing');
+      btn.setAttribute('aria-haspopup', 'menu');
+    }
+    document.removeEventListener('pointerdown', outsidePointer, true);
+    document.removeEventListener('scroll', scrollClose, true);
+    window.removeEventListener('keydown', keyClose, true);
+    window.removeEventListener('resize', resizeClose);
+    syncButton();
+  }
+
+  function openMenu(anchor) {
+    if (isDesktopWidth()) return false;
+    const btn = anchor || $(BUTTON_ID);
+    if (!btn) return false;
+    try { if (typeof window.closeSessionActionMenu === 'function') window.closeSessionActionMenu(); } catch (_) {}
+    closeMenu();
+
+    menu = document.createElement('div');
+    menu.className = 'session-action-menu mobile-conversations-menu hwx-mobile-conversations-menu';
+    menu.setAttribute('role', 'menu');
+    menu.setAttribute('aria-label', 'Conversation shortcuts');
+    menu.appendChild(actionButton(translate('new_conversation', 'New conversation'), 'New conversation', 'plus', newConversation));
+    menu.appendChild(actionButton('Open sidebar', 'Open conversations sidebar', 'message', openChatDrawer));
+    menu.appendChild(actionButton('Go to top', 'Go to top of this conversation', 'up', goTop));
+    menu.appendChild(actionButton('Go to last message', 'Go to latest message', 'down', goLast));
+    document.body.appendChild(menu);
+
+    btn.classList.add('active');
+    btn.setAttribute('aria-haspopup', 'menu');
+    btn.setAttribute('aria-expanded', 'true');
+    positionMenu();
+    requestAnimationFrame(positionMenu);
+    const first = menu.querySelector('[role="menuitem"]');
+    if (first && typeof first.focus === 'function') setTimeout(() => first.focus({ preventScroll: true }), 0);
+    try { if (typeof window._playSessionActionMenuEntrance === 'function') window._playSessionActionMenuEntrance(menu); } catch (_) {}
+
+    menu.addEventListener('keydown', menuKeydown);
+    document.addEventListener('pointerdown', outsidePointer, true);
+    document.addEventListener('scroll', scrollClose, true);
+    window.addEventListener('keydown', keyClose, true);
+    window.addEventListener('resize', resizeClose);
+    return true;
+  }
+
+  function outsidePointer(event) {
+    const btn = $(BUTTON_ID);
+    if (menu && menu.contains(event.target)) return;
+    if (btn && btn.contains(event.target)) return;
+    closeMenu();
+  }
+
+  function scrollClose(event) {
+    if (menu && menu.contains(event.target)) return;
+    closeMenu();
+  }
+
+  function keyClose(event) {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    closeMenu();
+    const btn = $(BUTTON_ID);
+    if (btn && typeof btn.focus === 'function') btn.focus({ preventScroll: true });
+  }
+
+  function menuKeydown(event) {
+    if (!menu) return;
+    const items = Array.from(menu.querySelectorAll('[role="menuitem"]'));
+    if (!items.length) return;
+    const current = items.indexOf(document.activeElement);
+    let next = -1;
+    if (event.key === 'ArrowDown') next = (current + 1 + items.length) % items.length;
+    else if (event.key === 'ArrowUp') next = (current - 1 + items.length) % items.length;
+    else if (event.key === 'Home') next = 0;
+    else if (event.key === 'End') next = items.length - 1;
+    if (next >= 0) {
+      event.preventDefault();
+      items[next].focus({ preventScroll: true });
+    }
+  }
+
+  function resizeClose() {
+    closeMenu();
+  }
+
+  function buttonSvg() {
+    const svgNamespace = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(svgNamespace, 'svg');
+    svg.setAttribute('width', '20');
+    svg.setAttribute('height', '20');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '2');
+    svg.setAttribute('stroke-linecap', 'round');
+    svg.setAttribute('stroke-linejoin', 'round');
+    svg.setAttribute('aria-hidden', 'true');
+    const path = document.createElementNS(svgNamespace, 'path');
+    path.setAttribute('d', 'M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z');
+    svg.appendChild(path);
+    return svg;
+  }
+
+  function ensureButton() {
+    let btn = $(BUTTON_ID);
+    if (btn && btn.dataset.hwxMobileConversations !== '1') {
+      // Core WebUI owns this affordance on newer builds; leave it alone.
+      return null;
+    }
+    if (!btn) {
+      const shell = document.querySelector('.messages-shell');
+      if (!shell) return null;
+      btn = document.createElement('button');
+      btn.id = BUTTON_ID;
+      btn.type = 'button';
+      btn.className = 'mobile-conversations-fab hwx-mobile-conversations-fab';
+      btn.dataset.hwxMobileConversations = '1';
+      btn.setAttribute('aria-label', 'Open conversations');
+      btn.setAttribute('aria-controls', 'panelChat');
+      btn.setAttribute('aria-haspopup', 'menu');
+      btn.setAttribute('aria-expanded', 'false');
+      btn.title = 'Conversations';
+      btn.appendChild(buttonSvg());
+      const before = $('jumpToSessionStartBtn') || $('scrollToBottomBtn') || shell.firstElementChild;
+      shell.insertBefore(btn, before || null);
+    }
+    return btn;
+  }
+
+  function wireButton(btn) {
+    if (!btn || btn.__hwxMobileConversationsWired) return;
+    btn.__hwxMobileConversationsWired = true;
+    btn.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (consumeIgnoredClick()) return;
+      await toggleMobileConversationsSidebar();
+    });
+    btn.addEventListener('pointerdown', (event) => {
+      if (isDesktopWidth()) return;
+      if (event.pointerType === 'mouse' || (event.button && event.button !== 0)) return;
+      clearPressTimer();
+      clearClickIgnore();
+      pressX = event.clientX;
+      pressY = event.clientY;
+      btn.classList.add('mobile-conversations-fab--pressing');
+      pressTimer = setTimeout(() => {
+        pressTimer = null;
+        ignoreNextClick();
+        btn.classList.remove('mobile-conversations-fab--pressing');
+        openMenu(btn);
+      }, LONG_PRESS_DELAY_MS);
+    });
+    btn.addEventListener('pointermove', (event) => {
+      if (!pressTimer) return;
+      if (Math.abs(event.clientX - pressX) > 10 || Math.abs(event.clientY - pressY) > 10) clearPressTimer();
+    });
+    ['pointerup', 'pointercancel', 'pointerleave'].forEach((name) => btn.addEventListener(name, clearPressTimer));
+    btn.addEventListener('contextmenu', (event) => {
+      if (isDesktopWidth()) return;
+      event.preventDefault();
+      clearPressTimer();
+      ignoreNextClick();
+      openMenu(btn);
+    });
+  }
+
+  function observeSidebar() {
+    if (sidebarObserver) return;
+    const sidebar = document.querySelector('.sidebar');
+    if (!sidebar) return;
+    sidebarObserver = new MutationObserver(syncButton);
+    sidebarObserver.observe(sidebar, { attributes: true, attributeFilter: ['class'] });
+  }
+
+  function install(attempt = 0) {
+    const btn = ensureButton();
+    if (btn) {
+      wireButton(btn);
+      observeSidebar();
+      syncButton();
+      window.HermesMobileConversationsExtension = {
+        version: '0.1.0',
+        sync: syncButton,
+        openMenu,
+        toggle: toggleMobileConversationsSidebar,
+      };
+      return true;
+    }
+    if (attempt < INIT_RETRIES) setTimeout(() => install(attempt + 1), INIT_DELAY_MS);
+    else console.warn(`[${EXT}] messages shell not found; mobile conversations button not installed`);
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/mobile-conversations/extension.json
+++ b/extensions/mobile-conversations/extension.json
@@ -1,0 +1,47 @@
+{
+  "id": "mobile-conversations",
+  "name": "Mobile Conversations Button",
+  "description": "Phone-only floating Conversations button for Hermes WebUI that opens the existing mobile conversations drawer and exposes long-press shortcuts.",
+  "version": "0.1.0",
+  "author": "santastabber",
+  "assets": {
+    "scripts": [
+      "assets/mobile-conversations.js"
+    ],
+    "stylesheets": [
+      "assets/mobile-conversations.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": true,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false
+  }
+}

--- a/extensions/mobile-conversations/manifest.json
+++ b/extensions/mobile-conversations/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "mobile-conversations",
+      "name": "Mobile Conversations Button",
+      "description": "Phone-only floating Conversations button and shortcut menu for Hermes WebUI.",
+      "scripts": [
+        "assets/mobile-conversations.js"
+      ],
+      "stylesheets": [
+        "assets/mobile-conversations.css"
+      ]
+    }
+  ]
+}

--- a/scripts/scan-extension-safety.mjs
+++ b/scripts/scan-extension-safety.mjs
@@ -38,7 +38,12 @@ const JS_DANGER_PATTERNS = [
   { label: 'remote script element loader', pattern: /createElement\s*\(\s*['"`]script['"`]\s*\)[\s\S]{0,500}\.src\s*=\s*['"`]https?:\/\// }
 ];
 
-function isLoopbackUrl(value) {
+const SAFE_LITERAL_URLS = new Set([
+  'http://www.w3.org/2000/svg'
+]);
+
+function isAllowedNetworkLiteral(value) {
+  if (SAFE_LITERAL_URLS.has(value)) return true;
   try {
     const url = new URL(value);
     return ['127.0.0.1', 'localhost', '::1'].includes(url.hostname);
@@ -89,7 +94,7 @@ function scanJavaScriptFile(entry, file, text, errors) {
   const networkExternal = permissions.network_external === true;
   const urls = [...text.matchAll(/['"`](https?:\/\/[^'"`\s)]+)['"`]/g)].map((match) => match[1]);
   for (const url of urls) {
-    if (!isLoopbackUrl(url) && !networkExternal) {
+    if (!isAllowedNetworkLiteral(url) && !networkExternal) {
       errors.push(`${repoRelative(file.path)} contains external URL literal while permissions.network_external is false: ${url}`);
     }
   }

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -113,18 +113,31 @@ try {
     publishedAt: '2026-01-01T00:00:00.000Z',
     artifactBaseUrl: 'https://example.test/extensions/'
   });
-  assert.equal(first.registry.extensions.length, 1);
+  assert(first.registry.extensions.length >= 1);
+  assert.equal(first.artifacts.length, first.registry.extensions.length);
+  assert.equal(second.artifacts.length, first.artifacts.length);
+  for (const entry of first.registry.extensions) {
+    const artifact = first.artifacts.find((item) => item.id === entry.id);
+    const secondArtifact = second.artifacts.find((item) => item.id === entry.id);
+    assert(artifact, `${entry.id} artifact is present`);
+    assert(secondArtifact, `${entry.id} second artifact is present`);
+    assert.equal(entry.download, `https://example.test/extensions/artifacts/${entry.id}-${entry.version}.zip`);
+    assert.match(entry.sha256, /^[0-9a-f]{64}$/);
+    assert.equal(artifact.name, `${entry.id}-${entry.version}.zip`);
+    assert.equal(artifact.sha256, entry.sha256);
+    assert.equal(artifact.sha256, secondArtifact.sha256);
+    assert(artifact.buffer.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04])));
+    assert(artifact.buffer.includes(Buffer.from(`${entry.id}/extension.json`)));
+  }
   const desktopCompanion = first.registry.extensions.find((entry) => entry.id === 'desktop-companion');
   assert(desktopCompanion);
-  assert.equal(desktopCompanion.download, 'https://example.test/extensions/artifacts/desktop-companion-0.1.0.zip');
-  assert.match(desktopCompanion.sha256, /^[0-9a-f]{64}$/);
-  assert.equal(first.artifacts.length, 1);
-  assert.equal(first.artifacts[0].name, 'desktop-companion-0.1.0.zip');
-  assert.equal(first.artifacts[0].sha256, desktopCompanion.sha256);
-  assert.equal(first.artifacts[0].sha256, second.artifacts[0].sha256);
-  assert(first.artifacts[0].buffer.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04])));
-  assert(first.artifacts[0].buffer.includes(Buffer.from('desktop-companion/extension.json')));
-  assert(first.artifacts[0].buffer.includes(Buffer.from('desktop-companion/assets/companion-adapter.js')));
+  const desktopArtifact = first.artifacts.find((item) => item.id === 'desktop-companion');
+  assert(desktopArtifact.buffer.includes(Buffer.from('desktop-companion/assets/companion-adapter.js')));
+
+  const mobileConversations = first.registry.extensions.find((entry) => entry.id === 'mobile-conversations');
+  assert(mobileConversations);
+  const mobileArtifact = first.artifacts.find((item) => item.id === 'mobile-conversations');
+  assert(mobileArtifact.buffer.includes(Buffer.from('mobile-conversations/assets/mobile-conversations.js')));
 
   const validateFromScripts = spawnSync(process.execPath, ['validate-extensions.mjs'], {
     cwd: scriptsDir,
@@ -132,7 +145,7 @@ try {
     timeout: 30000
   });
   assert.equal(validateFromScripts.status, 0, validateFromScripts.stderr || validateFromScripts.stdout);
-  assert.match(validateFromScripts.stdout, /validated 1 extension entry/);
+  assert.match(validateFromScripts.stdout, /validated \d+ extension entr(?:y|ies)/);
 
   const safetyScanFromScripts = spawnSync(process.execPath, ['scan-extension-safety.mjs'], {
     cwd: scriptsDir,
@@ -140,7 +153,7 @@ try {
     timeout: 30000
   });
   assert.equal(safetyScanFromScripts.status, 0, safetyScanFromScripts.stderr || safetyScanFromScripts.stdout);
-  assert.match(safetyScanFromScripts.stdout, /safety scan passed for 1 extension entry/);
+  assert.match(safetyScanFromScripts.stdout, /safety scan passed for \d+ extension entr(?:y|ies)/);
 
   console.log('extension validator self-tests passed');
 } finally {


### PR DESCRIPTION
## Summary

- Add a `mobile-conversations` extension entry with README, metadata, runtime manifest, and bundled JS/CSS assets.
- Document the trust model, permissions, install/disable/uninstall flow, compatibility surface, and manual verification steps.
- Update the extension index and make validator self-tests support multiple registry entries.
- Allow the standard SVG namespace literal in the safety scan without enabling external-network literals.

## Verification

- `node scripts/validate-extensions.mjs`
- `node scripts/scan-extension-safety.mjs`
- `node scripts/generate-registry.mjs --out dist/registry.json`
- `node scripts/test-extension-validator.mjs`
- `node --check extensions/mobile-conversations/assets/mobile-conversations.js`
- `node --check scripts/scan-extension-safety.mjs`
- `node --check scripts/test-extension-validator.mjs`
- `python3 -m json.tool extensions/mobile-conversations/extension.json`
- `python3 -m json.tool extensions/mobile-conversations/manifest.json`
- `git diff --check origin/main...HEAD`

## Notes

This is a trusted local static UI extension. It does not add backend routes, sidecars, native hosts, external network access, storage writes, or filesystem access.
