### PR TITLE
Add post-install guidance metadata

### DIFF
--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -114,6 +114,34 @@ document:
 
 Sidecars should bind to localhost by default and avoid public network exposure.
 
+## Post-Install Guidance
+
+Extensions that need a local app, sidecar, or native host should include
+`post_install` so gallery UIs can tell users what to do after clicking Install.
+This is user-facing guidance; lifecycle remains the machine-readable source for
+what must start.
+
+Example:
+
+```json
+{
+  "post_install": {
+    "summary": "Install enables the WebUI bridge. In the Desktop Companion repo, run npm run start:pet to launch the desktop pet.",
+    "docs_url": "https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install",
+    "requires_local_app": true,
+    "local_app_label": "Desktop Companion app"
+  }
+}
+```
+
+Suggested fields:
+
+- `summary`: one short sentence shown after install
+- `docs_url`: an http(s) link with setup/start instructions
+- `requires_local_app`: `true` when the extension needs a local app or native
+  host for its visible behavior
+- `local_app_label`: the reader-facing name of that local app or host
+
 ## Compatibility Notes
 
 Because the WebUI extension API is still evolving, extension READMEs should

--- a/extensions/desktop-companion/README.md
+++ b/extensions/desktop-companion/README.md
@@ -49,6 +49,24 @@ It does not declare `sidecar-proxy`. Direct browser-to-loopback access is the
 current integration model. A same-origin sidecar proxy can be added later if
 Hermes WebUI core ships that capability.
 
+## Install From Gallery
+
+In Hermes WebUI, open Settings -> Extensions -> Gallery and install
+Desktop Companion.
+
+Gallery install enables the WebUI bridge only. To show and use the desktop pet,
+open the Desktop Companion source repo and run the local start command:
+
+```bash
+git clone https://github.com/franksong2702/hermes-webui-desktop-companion
+cd hermes-webui-desktop-companion
+npm install
+npm run start:pet
+```
+
+The setup guide link opens the source repo's `After Gallery install` section,
+which starts with the same command for an existing local clone.
+
 ## Install For Local Testing
 
 Start Hermes WebUI with this extension directory:
@@ -60,8 +78,8 @@ HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json \
 ./start.sh
 ```
 
-Start the companion sidecar from the source repo when desktop behavior is
-needed:
+If you are testing without Gallery install, start the companion sidecar from the
+source repo when desktop behavior is needed:
 
 ```bash
 git clone https://github.com/franksong2702/hermes-webui-desktop-companion
@@ -70,8 +88,8 @@ npm install
 npm run dev
 ```
 
-Start the native desktop pet host from the same source repo to show and use the
-desktop pet surface:
+Then start the native desktop pet host from the same source repo to show and use
+the desktop pet surface:
 
 ```bash
 npm install --prefix desktop-pet

--- a/extensions/desktop-companion/extension.json
+++ b/extensions/desktop-companion/extension.json
@@ -26,6 +26,12 @@
     "native_host_start_required": true,
     "native_host_autostart": "extension_owned"
   },
+  "post_install": {
+    "summary": "Install enables the WebUI bridge. In the Desktop Companion repo, run npm run start:pet to launch the desktop pet.",
+    "docs_url": "https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install",
+    "requires_local_app": true,
+    "local_app_label": "Desktop Companion app"
+  },
   "screenshots": [],
   "permissions": {
     "webui_api": {

--- a/scripts/extension-registry-lib.mjs
+++ b/scripts/extension-registry-lib.mjs
@@ -78,6 +78,16 @@ function isSemver(value) {
   return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(String(value || ''));
 }
 
+function isHttpUrl(value) {
+  if (!isNonEmptyString(value)) return false;
+  try {
+    const url = new URL(value);
+    return ['http:', 'https:'].includes(url.protocol);
+  } catch (_) {
+    return false;
+  }
+}
+
 function isSafeLocalPath(value) {
   if (!isNonEmptyString(value)) return false;
   if (value.startsWith('/') || value.startsWith('\\')) return false;
@@ -389,6 +399,27 @@ function validateLifecycle(entry, errors) {
   }
 }
 
+function validatePostInstall(entry, errors) {
+  if (entry.post_install === undefined) return;
+  if (!isPlainObject(entry.post_install)) {
+    errors.push('post_install must be an object');
+    return;
+  }
+  assertString(entry.post_install.summary, 'post_install.summary', errors);
+  if (entry.post_install.docs_url !== undefined && !isHttpUrl(entry.post_install.docs_url)) {
+    errors.push('post_install.docs_url must be an http(s) URL');
+  }
+  if (entry.post_install.requires_local_app !== undefined) {
+    assertBoolean(entry.post_install.requires_local_app, 'post_install.requires_local_app', errors);
+  }
+  if (entry.post_install.local_app_label !== undefined) {
+    assertString(entry.post_install.local_app_label, 'post_install.local_app_label', errors);
+  }
+  if (entry.post_install.requires_local_app === true && !isNonEmptyString(entry.post_install.local_app_label)) {
+    errors.push('post_install.local_app_label is required when post_install.requires_local_app is true');
+  }
+}
+
 function validateSidecar(entry, errors) {
   const hasCapability = Array.isArray(entry.capabilities) && entry.capabilities.includes('loopback-sidecar');
   if (!hasCapability) return;
@@ -448,6 +479,7 @@ export function validateEntry(discovered) {
   validateRuntimeManifest(entry, assets, errors);
   validateCapabilities(entry, errors);
   validateLifecycle(entry, errors);
+  validatePostInstall(entry, errors);
   validateSidecar(entry, errors);
 
   const scriptText = assets.scripts

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -131,6 +131,12 @@ try {
   }
   const desktopCompanion = first.registry.extensions.find((entry) => entry.id === 'desktop-companion');
   assert(desktopCompanion);
+  assert.equal(desktopCompanion.post_install.requires_local_app, true);
+  assert.match(desktopCompanion.post_install.summary, /npm run start:pet/);
+  assert.equal(
+    desktopCompanion.post_install.docs_url,
+    'https://github.com/franksong2702/hermes-webui-desktop-companion#after-gallery-install'
+  );
   const desktopArtifact = first.artifacts.find((item) => item.id === 'desktop-companion');
   assert(desktopArtifact.buffer.includes(Buffer.from('desktop-companion/assets/companion-adapter.js')));
 


### PR DESCRIPTION
## Thinking Path

- Gallery install is now real file delivery, but sidecar/native extensions still need a user-visible next step.
- Desktop Companion is the first concrete case: installing the WebUI bridge does not launch the desktop pet.
- The extension registry should expose this as entry metadata instead of forcing WebUI core to hardcode Desktop Companion behavior.

## What Changed

- Adds optional `post_install` metadata validation.
- Adds Desktop Companion post-install guidance pointing users to the source repo setup path.
- Documents the `post_install` shape in the extension entry contract.
- Extends validator self-tests to assert the registry preserves Desktop Companion guidance.

## Why It Matters

Users should not click Install and then wonder why no desktop pet appears. The gallery can now explain that install enabled the WebUI bridge and that a local app/sidecar still has to start.

Fixes #17.
Refs nesquena/hermes-webui#4959.
Refs nesquena/hermes-webui#4964.
Refs franksong2702/hermes-webui-desktop-companion#7.
Refs franksong2702/hermes-webui-desktop-companion#8.

## Merge Order

Merge franksong2702/hermes-webui-desktop-companion#8 before this PR, or the `#after-gallery-install` setup-guide anchor will not exist on the Desktop Companion repo default branch yet.

## Verification

- `node scripts/validate-extensions.mjs`
- `node scripts/scan-extension-safety.mjs`
- `node --check scripts/extension-registry-lib.mjs && node scripts/test-extension-validator.mjs`
- `node scripts/generate-registry.mjs --out dist/registry.json`

## Risks / Follow-ups

- This only publishes metadata. WebUI rendering is handled separately in nesquena/hermes-webui#4964.
- It does not add native host autostart or sidecar management.

## Model Used

OpenAI GPT-5 Codex with local shell/test tooling.