### PR TITLE
Add message-pins extension (client-side message pinning)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -21,3 +21,5 @@ need it and maintainers agree on the shared contract.
   sidecar-class extension candidate.
 - `mobile-conversations`: phone-only floating Conversations button, same-location
   drawer close X, and long-press shortcuts for the existing Hermes WebUI mobile drawer.
+- `message-pins`: pin individual messages in a conversation, with a header
+  popover, click-to-jump, and client-side per-session persistence.

--- a/extensions/message-pins/README.md
+++ b/extensions/message-pins/README.md
@@ -1,0 +1,181 @@
+# Message Pins
+
+Message Pins is a trusted local Hermes WebUI extension that lets you pin
+individual messages in a conversation. It adds a pin button to each message, a
+header popover that lists your pinned messages with click-to-jump, and a small
+badge showing the pin count. Pins are saved locally in your browser, per
+session.
+
+## What It Does
+
+- Adds a pin button to each message (in the hover action bar, with a floating
+  fallback for messages that have no action bar).
+- Pinning a message records it; pinning is capped at 3 messages per conversation
+  with a polite over-cap notice (unpin one to pin another).
+- Adds a pin button near the top-right of the chat area with a count badge.
+  Clicking it opens a popover listing the pinned messages.
+- Clicking a pinned message in the popover scrolls to it and briefly highlights
+  it. If that message has been virtualized out of the loaded transcript window,
+  the extension tells you to scroll up to load it first rather than silently
+  doing nothing.
+- Each popover entry has an unpin control.
+- Pins are stored per `session_id`, so each conversation keeps its own set, and
+  switching conversations swaps the displayed pins.
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/message-pins.js
+  -> /extensions/assets/message-pins.css
+  -> existing WebUI message rows ([data-msg-idx]) + .messages-shell
+  -> localStorage (key: hermes-ext-message-pins)
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, access external networks, read or write files, or use
+native host APIs. Persistence is client-side `localStorage`, so pins are
+per-browser and not synced across devices.
+
+## Capabilities
+
+This entry declares only capabilities currently available to extension entries:
+
+- `manifest-bundle`
+
+It does not require `loopback-sidecar` or future sidecar proxy support.
+
+## Install For Local Testing
+
+Start Hermes WebUI with this extension directory:
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/message-pins HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+The runtime `manifest.json` injects:
+
+```json
+{
+  "extensions": [
+    {
+      "id": "message-pins",
+      "name": "Message Pins",
+      "description": "Pin individual messages in a conversation, with a header popover and click-to-jump.",
+      "scripts": ["assets/message-pins.js"],
+      "stylesheets": ["assets/message-pins.css"]
+    }
+  ]
+}
+```
+
+Once the in-app extensions gallery is available, this entry can also be browsed
+and installed from Settings -> Extensions.
+
+## Disable And Uninstall
+
+To disable the WebUI extension, restart Hermes WebUI without:
+
+```text
+HERMES_WEBUI_EXTENSION_DIR
+HERMES_WEBUI_EXTENSION_MANIFEST
+HERMES_WEBUI_EXTENSION_STYLESHEET_URLS
+HERMES_WEBUI_EXTENSION_SCRIPT_URLS
+```
+
+To uninstall it from a manual local setup, remove the
+`extensions/message-pins/` directory from the local extensions checkout or
+remove the entry from the aggregate manifest that points at it.
+
+Your saved pins live under the `hermes-ext-message-pins` key in your browser's
+localStorage. Clearing that key (or your site data) removes all saved pins.
+
+## Trust And Permissions
+
+This is trusted local code. The injected JavaScript runs in the Hermes WebUI
+browser origin and can use the logged-in browser session.
+
+Current disclosed behavior:
+
+- creates extension-owned DOM for the pin buttons, header button, popover, and a
+  small toast
+- inserts the pin button into each message's existing `.msg-actions` bar, with a
+  floating fallback appended to the message row when no action bar exists
+- inserts the header button into the existing `.messages-shell`
+- reads message rows via the existing `data-msg-idx`, `data-raw-text`, and
+  `data-session-id` attributes already present on the page
+- reads the active session id from a rendered message's `data-session-id` (or
+  from the `/session/<id>` URL as a fallback)
+- uses a `MutationObserver` on the messages container to re-apply pin
+  decorations after the transcript re-renders
+- reads and writes `localStorage` under the single key `hermes-ext-message-pins`
+- does not call WebUI HTTP APIs
+- does not access cookies
+- does not contact loopback or external network services
+- does not use arbitrary filesystem or native host APIs
+
+All message text rendered into the popover and previews is inserted via
+`textContent` (or escaped), so message content cannot inject markup.
+
+## Compatibility
+
+Required WebUI surface:
+
+- manifest-bundled extension assets
+- same-origin extension asset serving under `/extensions/`
+- message rows carrying `data-msg-idx` (and, where available, `data-raw-text`
+  and `data-session-id`), inside `#messages` / `.messages-shell`
+
+This entry targets Hermes WebUI builds that render message rows with
+`data-msg-idx` and the `.msg-actions` hover bar. The compatibility requirement is
+better described as the manifest bundle plus the message-row DOM surface above.
+
+## Verification
+
+From this repository:
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/message-pins/assets/message-pins.js
+python3 -m json.tool extensions/message-pins/extension.json
+python3 -m json.tool extensions/message-pins/manifest.json
+```
+
+Manual verification should confirm:
+
+- hovering a message shows a pin button; clicking it pins the message and the
+  header badge count increases
+- the header pin button opens a popover listing the pinned messages
+- clicking a pinned entry scrolls to and highlights that message
+- the unpin control in the popover removes a pin
+- pinning a 4th message shows the over-cap notice instead of pinning
+- reloading the page keeps the pins for that conversation
+- switching to another conversation shows that conversation's own pins
+- a pin whose message is scrolled out of the virtualized window shows the
+  "scroll up to load it" notice instead of doing nothing
+
+## Known Limitations
+
+- Pins are stored per browser via `localStorage`; they are not synced across
+  devices or browsers (a deliberate consequence of being a client-side-only
+  extension with no backend).
+- The extension relies on the current message-row DOM (`data-msg-idx`,
+  `.msg-actions`) until a formal message-decoration extension API exists.
+- Jump-to-pin requires the target message to be within the loaded transcript
+  window; very old messages in a long conversation may need to be scrolled into
+  range first.
+
+## Credit
+
+The pin UX in this extension — a per-message pin button, a header popover with a
+count badge, click-to-jump, and a 3-pin cap — follows the design from closed
+core PR [#2534](https://github.com/nesquena/hermes-webui/pull/2534) by
+**@Michaelyklam** (originally requested in issue #2508). That PR implemented
+pinning with a new core API and server-side persistence; it was a good idea that
+did not fit core's scope, so it was reimagined here as an opt-in extension that
+persists pins client-side and needs no core changes. Thanks to @Michaelyklam for
+the original concept and design.

--- a/extensions/message-pins/assets/message-pins.css
+++ b/extensions/message-pins/assets/message-pins.css
@@ -1,0 +1,187 @@
+/* Message Pins extension for Hermes WebUI.
+   Scoped to hwx-pin-* classes so it cannot collide with core styles.
+   Uses core CSS variables (with fallbacks) so it adapts to light/dark themes. */
+
+/* ── per-message pin button ────────────────────────────────────────────── */
+.hwx-pin-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--muted, #888);
+  background: transparent;
+  border: none;
+  transition: color .12s ease, opacity .12s ease, transform .12s ease;
+}
+.hwx-pin-btn:hover { color: var(--text, #111); }
+.hwx-pin-btn--active { color: var(--accent, #3b82f6); }
+.hwx-pin-btn--active:hover { color: var(--accent, #3b82f6); opacity: .85; }
+
+/* Floating fallback button (when a row has no .msg-actions bar). */
+.hwx-pin-host { position: relative; }
+.hwx-pin-btn--float {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: var(--code-bg, rgba(127, 127, 127, .12));
+  border: 1px solid var(--border2, rgba(127, 127, 127, .25));
+  opacity: 0;
+  z-index: 4;
+}
+[data-msg-idx]:hover .hwx-pin-btn--float,
+.hwx-pin-btn--float:focus-visible { opacity: 1; }
+/* A pinned row keeps its floating button visible even when not hovered. */
+.hwx-pinned-row .hwx-pin-btn--float { opacity: 1; }
+
+/* Subtle marker on a pinned row. */
+.hwx-pinned-row { position: relative; }
+
+/* ── jump flash highlight ──────────────────────────────────────────────── */
+.hwx-pin-flash {
+  animation: hwx-pin-flash-kf 1.4s ease;
+  border-radius: 8px;
+}
+@keyframes hwx-pin-flash-kf {
+  0%   { box-shadow: 0 0 0 0 var(--accent, #3b82f6); }
+  20%  { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #3b82f6) 45%, transparent); }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+
+/* ── header button + badge ─────────────────────────────────────────────── */
+.hwx-pin-header-btn {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 1px solid var(--border2, rgba(127, 127, 127, .25));
+  background: var(--code-bg, rgba(127, 127, 127, .1));
+  color: var(--muted, #888);
+  cursor: pointer;
+  z-index: 11;
+  transition: color .12s ease, border-color .12s ease, background .12s ease, transform .12s ease;
+}
+.hwx-pin-header-btn:hover {
+  color: var(--text, #111);
+  border-color: var(--border, rgba(127, 127, 127, .4));
+  transform: translateY(-1px);
+}
+.hwx-pin-header-btn--has-pins { color: var(--accent, #3b82f6); }
+.hwx-pin-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--accent, #3b82f6);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+}
+
+/* ── popover ───────────────────────────────────────────────────────────── */
+.hwx-pin-popover {
+  position: fixed;
+  z-index: 1000;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--surface, #fff);
+  color: var(--text, #111);
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, .28);
+  padding: 6px;
+}
+.hwx-pin-popover-head {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--muted, #888);
+  padding: 6px 8px 8px;
+}
+.hwx-pin-popover-empty {
+  font-size: 12px;
+  color: var(--muted, #888);
+  padding: 4px 8px 10px;
+  line-height: 1.4;
+}
+.hwx-pin-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 8px 8px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text, #111);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background .12s ease;
+}
+.hwx-pin-item:hover { background: var(--hover-bg, rgba(127, 127, 127, .12)); }
+.hwx-pin-item-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hwx-pin-item-remove {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  color: var(--muted, #888);
+  font-size: 16px;
+  line-height: 1;
+}
+.hwx-pin-item-remove:hover {
+  color: var(--text, #111);
+  background: var(--border2, rgba(127, 127, 127, .25));
+}
+
+/* ── toast ─────────────────────────────────────────────────────────────── */
+.hwx-pin-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 84px;
+  transform: translateX(-50%) translateY(8px);
+  max-width: min(420px, 90vw);
+  padding: 10px 16px;
+  border-radius: 8px;
+  background: var(--surface, #1f2330);
+  color: var(--text, #fff);
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  box-shadow: 0 6px 20px rgba(0, 0, 0, .3);
+  font-size: 13px;
+  z-index: 1100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .18s ease, transform .18s ease;
+}
+.hwx-pin-toast--show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hwx-pin-btn,
+  .hwx-pin-header-btn,
+  .hwx-pin-toast,
+  .hwx-pin-item { transition: none; }
+  .hwx-pin-flash { animation: none; }
+}

--- a/extensions/message-pins/assets/message-pins.css
+++ b/extensions/message-pins/assets/message-pins.css
@@ -12,18 +12,35 @@
   background: transparent;
   border: none;
   transition: color .12s ease, opacity .12s ease, transform .12s ease;
+  /* Reliable hit target (Frank, PR #19 round 2): core keeps .msg-actions quiet
+     with pointer-events:none at rest, and a tiny/variable-size button made the
+     unpin click resolve to .msg-foot or the SVG child instead of the button.
+     Force a stable 24x24 clickable button and make the SVG non-interactive so
+     elementFromPoint() always lands on the BUTTON. */
+  position: relative;
+  z-index: 2;
+  pointer-events: auto;
+  flex: 0 0 auto;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  padding: 0;
+  line-height: 1;
+  border-radius: 6px;
 }
+.hwx-pin-btn svg { pointer-events: none; }
 .hwx-pin-btn:hover { color: var(--text, #111); }
 /* Active (pinned) state: make it clearly, obviously "on" — filled accent chip,
    not just a color swap, so success is discoverable right where the user clicked
-   (Frank, PR #19: active feedback was too subtle). */
+   (Frank, PR #19: active feedback was too subtle). Keep the size stable so the
+   hit target doesn't shift between pin/unpin. */
 .hwx-pin-btn--active {
   color: var(--accent-contrast, #fff);
   background: var(--accent, #3b82f6);
   border-radius: 6px;
 }
 .hwx-pin-btn--active:hover { color: var(--accent-contrast, #fff); opacity: .9; }
-.hwx-pin-btn--inline.hwx-pin-btn--active { padding: 2px 4px; }
+.hwx-pin-btn--inline.hwx-pin-btn--active { padding: 0; }
 
 /* Floating fallback button (when a row has no .msg-actions bar). */
 .hwx-pin-host { position: relative; }

--- a/extensions/message-pins/assets/message-pins.css
+++ b/extensions/message-pins/assets/message-pins.css
@@ -14,8 +14,16 @@
   transition: color .12s ease, opacity .12s ease, transform .12s ease;
 }
 .hwx-pin-btn:hover { color: var(--text, #111); }
-.hwx-pin-btn--active { color: var(--accent, #3b82f6); }
-.hwx-pin-btn--active:hover { color: var(--accent, #3b82f6); opacity: .85; }
+/* Active (pinned) state: make it clearly, obviously "on" — filled accent chip,
+   not just a color swap, so success is discoverable right where the user clicked
+   (Frank, PR #19: active feedback was too subtle). */
+.hwx-pin-btn--active {
+  color: var(--accent-contrast, #fff);
+  background: var(--accent, #3b82f6);
+  border-radius: 6px;
+}
+.hwx-pin-btn--active:hover { color: var(--accent-contrast, #fff); opacity: .9; }
+.hwx-pin-btn--inline.hwx-pin-btn--active { padding: 2px 4px; }
 
 /* Floating fallback button (when a row has no .msg-actions bar). */
 .hwx-pin-host { position: relative; }
@@ -36,8 +44,21 @@
 /* A pinned row keeps its floating button visible even when not hovered. */
 .hwx-pinned-row .hwx-pin-btn--float { opacity: 1; }
 
-/* Subtle marker on a pinned row. */
+/* Pinned row marker — a visible accent rail on the left so a pinned message is
+   obvious at a glance, not just via the button state (Frank, PR #19). */
 .hwx-pinned-row { position: relative; }
+.hwx-pinned-row::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--accent, #3b82f6);
+  opacity: .8;
+  pointer-events: none;
+}
 
 /* ── jump flash highlight ──────────────────────────────────────────────── */
 .hwx-pin-flash {
@@ -51,10 +72,11 @@
 }
 
 /* ── header button + badge ─────────────────────────────────────────────── */
+/* NOTE: top/right are set in JS (positionHeaderButton) so the button never
+   overlaps core's #jumpToSessionStartBtn — do not hard-code them here. */
 .hwx-pin-header-btn {
   position: absolute;
-  top: 12px;
-  right: 16px;
+  top: 16px;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/extensions/message-pins/assets/message-pins.js
+++ b/extensions/message-pins/assets/message-pins.js
@@ -225,14 +225,35 @@
     }
   }
 
+  // A [data-msg-idx] node is only a REAL, decoratable message row if it is
+  // actually visible and carries renderable content. Core also tags hidden
+  // anchor/worklog segments with data-msg-idx (assistant-segment-anchor /
+  // assistant-segment-worklog-source are display:none) — decorating those
+  // created floating/hidden pin buttons on non-message nodes (Frank, PR #19).
+  function isRealMessageRow(row) {
+    if (!row || !row.classList) return false;
+    if (row.classList.contains('assistant-segment-anchor') ||
+        row.classList.contains('assistant-segment-worklog-source')) return false;
+    // must have a real content/action surface
+    const hasContent = row.querySelector(':scope .msg-body') ||
+                       row.querySelector(':scope .msg-foot .msg-actions') ||
+                       row.querySelector(':scope .msg-actions');
+    if (!hasContent) return false;
+    // must be visibly laid out (skips display:none anchors + collapsed nodes)
+    const rect = row.getBoundingClientRect();
+    if (rect.height <= 1) return false;
+    return true;
+  }
+
   function redecorate() {
     const container = $('messages');
     if (!container) return;
     const pins = loadPins();
     const seen = new Set();
     container.querySelectorAll('[data-msg-idx]').forEach((row) => {
+      if (!isRealMessageRow(row)) return;       // skip hidden anchor/worklog segments
       const idx = rowIdx(row);
-      if (idx == null || seen.has(idx)) return; // decorate first node per idx
+      if (idx == null || seen.has(idx)) return; // decorate first real node per idx
       seen.add(idx);
       decorateRow(row, pins);
     });
@@ -259,7 +280,32 @@
       togglePopover(btn);
     });
     shell.appendChild(btn);
+    positionHeaderButton(btn);
     return btn;
+  }
+
+  // Reserve a non-overlapping slot. Core's #jumpToSessionStartBtn
+  // (.session-jump-btn--start) sits at top:16px; right:20px; height:32px in the
+  // same .messages-shell and only appears in long, session-nav-enabled
+  // conversations. When it's visible, place the pins button to its LEFT
+  // (computed from its width); otherwise use the default top-right slot.
+  // (Frank, PR #19: the two controls collided in the top-right corner.)
+  function positionHeaderButton(btn) {
+    btn = btn || $('hwxMessagePinsHeaderBtn');
+    if (!btn) return;
+    const GAP = 8;
+    const DEFAULT_RIGHT = 20;   // align to core's right:20px
+    const startBtn = document.getElementById('jumpToSessionStartBtn');
+    let right = DEFAULT_RIGHT;
+    const startVisible = startBtn &&
+      getComputedStyle(startBtn).display !== 'none' &&
+      startBtn.getBoundingClientRect().width > 0;
+    if (startVisible) {
+      // sit to the left of the Start button: its width + the gap + its own right offset
+      right = DEFAULT_RIGHT + startBtn.getBoundingClientRect().width + GAP;
+    }
+    btn.style.right = right + 'px';
+    btn.style.top = '16px';      // match core's vertical slot
   }
 
   function refreshHeader() {
@@ -272,6 +318,7 @@
       badge.hidden = pins.length === 0;
     }
     btn.classList.toggle('hwx-pin-header-btn--has-pins', pins.length > 0);
+    positionHeaderButton(btn);   // recompute slot (session-nav / Start btn may have toggled)
   }
 
   function togglePopover(anchor) {
@@ -416,6 +463,28 @@
     if (!container || observer) return !!observer;
     observer = new MutationObserver(scheduleSync);
     observer.observe(container, { childList: true, subtree: true });
+    // The core Start button (#jumpToSessionStartBtn) toggles its display on
+    // scroll in long, session-nav-enabled conversations — that does NOT cause a
+    // #messages childList mutation, so observe its attribute flips directly and
+    // reposition the pins header button so the two never overlap (Frank, PR #19).
+    const startBtn = document.getElementById('jumpToSessionStartBtn');
+    if (startBtn && !startBtn.dataset.hwxPinObserved) {
+      startBtn.dataset.hwxPinObserved = '1';
+      const so = new MutationObserver(() => positionHeaderButton());
+      so.observe(startBtn, { attributes: true, attributeFilter: ['style', 'class'] });
+    }
+    // Also reposition on scroll within the shell (cheap, rAF-throttled).
+    const shell = document.querySelector('.messages-shell');
+    if (shell && !shell.dataset.hwxPinScroll) {
+      shell.dataset.hwxPinScroll = '1';
+      let posRaf = false;
+      const onScroll = () => {
+        if (posRaf) return;
+        posRaf = true;
+        requestAnimationFrame(() => { posRaf = false; positionHeaderButton(); });
+      };
+      shell.addEventListener('scroll', onScroll, { passive: true, capture: true });
+    }
     return true;
   }
 

--- a/extensions/message-pins/assets/message-pins.js
+++ b/extensions/message-pins/assets/message-pins.js
@@ -1,0 +1,450 @@
+(() => {
+  'use strict';
+
+  // ── Message Pins extension for Hermes WebUI ──────────────────────────────
+  // Trusted local static-UI extension. Pins individual messages within a
+  // conversation, persisting the pin set client-side (localStorage) per
+  // session. No backend, no network, no core API calls.
+  //
+  // Design reference: closed core PR #2534 by @Michaelyklam (per-message pin
+  // button, header popover with badge, click-to-jump, 3-pin cap). That PR
+  // persisted server-side via a new core endpoint; this extension persists in
+  // the browser instead, so it needs no core changes.
+
+  const EXT = 'message-pins';
+  if (window.__hermesMessagePinsLoaded) return;
+  window.__hermesMessagePinsLoaded = true;
+
+  const STORAGE_KEY = 'hermes-ext-message-pins';
+  const MAX_PINS = 3;
+  const PREVIEW_LEN = 120;
+  const PIN_FLAG = 'hwxPinned';          // dataset flag on a decorated row
+  const BTN_FLAG = 'hwxPinWired';        // dataset flag on a wired button
+
+  let observer = null;
+  let popover = null;
+  let toastTimer = null;
+  let lastSessionId = null;
+
+  // ── small DOM helpers ────────────────────────────────────────────────────
+  function $(id) { return document.getElementById(id); }
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // Resolve the active session id without relying on the page's module-scoped
+  // `S` global (not exposed to extensions). Rendered message turns carry a
+  // `data-session-id`; the route is also `/session/<id>`. Prefer the DOM
+  // (path-base agnostic), fall back to the URL.
+  function currentSessionId() {
+    const tagged = document.querySelector('#messages [data-session-id]');
+    if (tagged && tagged.dataset.sessionId) return tagged.dataset.sessionId;
+    const m = location.pathname.match(/\/session\/([^/?#]+)/);
+    return m ? decodeURIComponent(m[1]) : null;
+  }
+
+  // ── persistence ──────────────────────────────────────────────────────────
+  function loadAll() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      return (parsed && typeof parsed === 'object') ? parsed : {};
+    } catch (_) { return {}; }
+  }
+
+  function saveAll(all) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(all)); }
+    catch (_) { /* quota / disabled storage — degrade silently */ }
+  }
+
+  // Pins for the active session: array of { idx:number, preview:string }.
+  function loadPins() {
+    const sid = currentSessionId();
+    if (!sid) return [];
+    const entry = loadAll()[sid];
+    return Array.isArray(entry) ? entry.filter((p) => p && Number.isFinite(p.idx)) : [];
+  }
+
+  function savePins(pins) {
+    const sid = currentSessionId();
+    if (!sid) return;
+    const all = loadAll();
+    if (pins.length) all[sid] = pins;
+    else delete all[sid];
+    saveAll(all);
+  }
+
+  function isPinned(idx, pins) { return pins.some((p) => p.idx === idx); }
+
+  // ── toast (self-owned, does not touch core toast state) ──────────────────
+  function toast(message) {
+    let el = $('hwxMessagePinsToast');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'hwxMessagePinsToast';
+      el.className = 'hwx-pin-toast';
+      el.setAttribute('role', 'status');
+      el.setAttribute('aria-live', 'polite');
+      document.body.appendChild(el);
+    }
+    el.textContent = message;
+    el.classList.add('hwx-pin-toast--show');
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => el.classList.remove('hwx-pin-toast--show'), 3200);
+  }
+
+  // ── message-row inspection ───────────────────────────────────────────────
+  function rowIdx(row) {
+    const v = parseInt(row.getAttribute('data-msg-idx'), 10);
+    return Number.isFinite(v) ? v : null;
+  }
+
+  function rowPreview(row) {
+    const raw = row.getAttribute('data-raw-text');
+    let text = raw && raw.trim();
+    if (!text) {
+      const body = row.querySelector('.msg-body');
+      text = body ? body.textContent : '';
+    }
+    text = (text || '').replace(/\s+/g, ' ').trim();
+    if (!text) text = 'Message #' + (rowIdx(row) != null ? rowIdx(row) : '?');
+    return text.length > PREVIEW_LEN ? text.slice(0, PREVIEW_LEN - 1) + '\u2026' : text;
+  }
+
+  // Find the canonical row element for a given msg-idx that is actually
+  // visible (assistant turns can render multiple segment nodes, some hidden).
+  function findRow(idx) {
+    const container = $('messages');
+    if (!container) return null;
+    const all = container.querySelectorAll('[data-msg-idx="' + idx + '"]');
+    for (const el of all) {
+      if (el.getClientRects && el.getClientRects().length > 0) return el;
+    }
+    return all.length ? all[0] : null;
+  }
+
+  // ── pin / unpin ──────────────────────────────────────────────────────────
+  function togglePin(idx, row) {
+    let pins = loadPins();
+    if (isPinned(idx, pins)) {
+      pins = pins.filter((p) => p.idx !== idx);
+      savePins(pins);
+      toast('Message unpinned');
+    } else {
+      if (pins.length >= MAX_PINS) {
+        toast('You can pin up to ' + MAX_PINS + ' messages. Unpin one first.');
+        return;
+      }
+      pins.push({ idx: idx, preview: rowPreview(row) });
+      pins.sort((a, b) => a.idx - b.idx);
+      savePins(pins);
+      toast('Message pinned');
+    }
+    redecorate();
+    refreshHeader();
+    if (popover) renderPopover();
+  }
+
+  function jumpTo(idx) {
+    closePopover();
+    const row = findRow(idx);
+    if (row && row.getClientRects && row.getClientRects().length > 0) {
+      row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      row.classList.add('hwx-pin-flash');
+      setTimeout(() => row.classList.remove('hwx-pin-flash'), 1400);
+      return;
+    }
+    // Long transcripts virtualize rows out of the DOM; an off-window pin can't
+    // be scrolled to without core's virtual-scroll internals. Tell the user
+    // plainly rather than silently no-op.
+    toast('That message is outside the loaded part of the transcript. Scroll up to load it, then try again.');
+  }
+
+  // ── per-row decoration ───────────────────────────────────────────────────
+  function pinButtonSvg(filled) {
+    // Inline SVG pin icon (created as a static string; no user data).
+    const fill = filled ? 'currentColor' : 'none';
+    return '<svg width="13" height="13" viewBox="0 0 24 24" fill="' + fill +
+      '" stroke="currentColor" stroke-width="2" stroke-linecap="round" ' +
+      'stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/></svg>';
+  }
+
+  function makePinButton(idx, pinned) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'msg-action-btn hwx-pin-btn' + (pinned ? ' hwx-pin-btn--active' : '');
+    btn.setAttribute('aria-pressed', pinned ? 'true' : 'false');
+    btn.title = pinned ? 'Unpin message' : 'Pin message';
+    btn.setAttribute('aria-label', pinned ? 'Unpin message' : 'Pin message');
+    btn.innerHTML = pinButtonSvg(pinned);
+    btn.dataset[BTN_FLAG] = '1';
+    btn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      togglePin(idx, btn.closest('[data-msg-idx]') || findRow(idx));
+    });
+    return btn;
+  }
+
+  function decorateRow(row, pins) {
+    const idx = rowIdx(row);
+    if (idx == null) return;
+    const pinned = isPinned(idx, pins);
+    row.dataset[PIN_FLAG] = pinned ? '1' : '0';
+    row.classList.toggle('hwx-pinned-row', pinned);
+
+    let btn = row.querySelector(':scope .hwx-pin-btn');
+    if (!btn) {
+      // Prefer the existing hover action bar; fall back to a floating button.
+      const actions = row.querySelector(':scope .msg-foot .msg-actions') ||
+                      row.querySelector(':scope .msg-actions');
+      btn = makePinButton(idx, pinned);
+      if (actions) {
+        btn.classList.add('hwx-pin-btn--inline');
+        actions.appendChild(btn);
+      } else {
+        btn.classList.add('hwx-pin-btn--float');
+        if (getComputedStyle(row).position === 'static') row.classList.add('hwx-pin-host');
+        row.appendChild(btn);
+      }
+    } else {
+      // Update existing button state in place.
+      btn.classList.toggle('hwx-pin-btn--active', pinned);
+      btn.setAttribute('aria-pressed', pinned ? 'true' : 'false');
+      btn.title = pinned ? 'Unpin message' : 'Pin message';
+      btn.setAttribute('aria-label', pinned ? 'Unpin message' : 'Pin message');
+      btn.innerHTML = pinButtonSvg(pinned);
+    }
+  }
+
+  function redecorate() {
+    const container = $('messages');
+    if (!container) return;
+    const pins = loadPins();
+    const seen = new Set();
+    container.querySelectorAll('[data-msg-idx]').forEach((row) => {
+      const idx = rowIdx(row);
+      if (idx == null || seen.has(idx)) return; // decorate first node per idx
+      seen.add(idx);
+      decorateRow(row, pins);
+    });
+  }
+
+  // ── header button + popover ──────────────────────────────────────────────
+  function ensureHeaderButton() {
+    let btn = $('hwxMessagePinsHeaderBtn');
+    if (btn) return btn;
+    const shell = document.querySelector('.messages-shell');
+    if (!shell) return null;
+    btn = document.createElement('button');
+    btn.id = 'hwxMessagePinsHeaderBtn';
+    btn.type = 'button';
+    btn.className = 'hwx-pin-header-btn';
+    btn.setAttribute('aria-haspopup', 'true');
+    btn.setAttribute('aria-expanded', 'false');
+    btn.title = 'Pinned messages';
+    btn.setAttribute('aria-label', 'Pinned messages');
+    btn.innerHTML = pinButtonSvg(true) + '<span class="hwx-pin-badge" hidden>0</span>';
+    btn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      togglePopover(btn);
+    });
+    shell.appendChild(btn);
+    return btn;
+  }
+
+  function refreshHeader() {
+    const btn = ensureHeaderButton();
+    if (!btn) return;
+    const pins = loadPins();
+    const badge = btn.querySelector('.hwx-pin-badge');
+    if (badge) {
+      badge.textContent = String(pins.length);
+      badge.hidden = pins.length === 0;
+    }
+    btn.classList.toggle('hwx-pin-header-btn--has-pins', pins.length > 0);
+  }
+
+  function togglePopover(anchor) {
+    if (popover) { closePopover(); return; }
+    openPopover(anchor);
+  }
+
+  function openPopover(anchor) {
+    const btn = anchor || $('hwxMessagePinsHeaderBtn');
+    if (!btn) return;
+    popover = document.createElement('div');
+    popover.className = 'hwx-pin-popover';
+    popover.setAttribute('role', 'menu');
+    popover.setAttribute('aria-label', 'Pinned messages');
+    document.body.appendChild(popover);
+    renderPopover();
+    positionPopover(btn);
+    btn.setAttribute('aria-expanded', 'true');
+    document.addEventListener('pointerdown', outsidePointer, true);
+    document.addEventListener('keydown', escClose, true);
+    window.addEventListener('resize', closePopover);
+    window.addEventListener('scroll', closePopover, true);
+  }
+
+  function renderPopover() {
+    if (!popover) return;
+    const pins = loadPins();
+    popover.innerHTML = '';
+
+    const head = document.createElement('div');
+    head.className = 'hwx-pin-popover-head';
+    head.textContent = pins.length ? 'Pinned messages (' + pins.length + ')' : 'Pinned messages';
+    popover.appendChild(head);
+
+    if (!pins.length) {
+      const empty = document.createElement('div');
+      empty.className = 'hwx-pin-popover-empty';
+      empty.textContent = 'No pinned messages yet. Hover a message and click the pin icon.';
+      popover.appendChild(empty);
+      return;
+    }
+
+    pins.forEach((p) => {
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'hwx-pin-item';
+      item.setAttribute('role', 'menuitem');
+
+      const text = document.createElement('span');
+      text.className = 'hwx-pin-item-text';
+      text.textContent = p.preview || ('Message #' + p.idx);
+      item.appendChild(text);
+
+      const remove = document.createElement('span');
+      remove.className = 'hwx-pin-item-remove';
+      remove.title = 'Unpin';
+      remove.setAttribute('aria-label', 'Unpin this message');
+      remove.innerHTML = '\u00d7';
+      item.appendChild(remove);
+
+      item.addEventListener('click', (ev) => {
+        if (ev.target === remove || remove.contains(ev.target)) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          togglePin(p.idx, findRow(p.idx));
+          return;
+        }
+        jumpTo(p.idx);
+      });
+      popover.appendChild(item);
+    });
+  }
+
+  function positionPopover(btn) {
+    if (!popover) return;
+    const r = btn.getBoundingClientRect();
+    const w = Math.min(320, Math.max(240, popover.offsetWidth || 280));
+    let left = r.right - w;
+    if (left < 8) left = 8;
+    if (left + w > window.innerWidth - 8) left = window.innerWidth - w - 8;
+    popover.style.width = w + 'px';
+    popover.style.left = left + 'px';
+    let top = r.bottom + 8;
+    const h = popover.offsetHeight || 0;
+    if (top + h > window.innerHeight - 8) top = Math.max(8, r.top - h - 8);
+    popover.style.top = top + 'px';
+  }
+
+  function closePopover() {
+    if (!popover) return;
+    popover.remove();
+    popover = null;
+    const btn = $('hwxMessagePinsHeaderBtn');
+    if (btn) btn.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('pointerdown', outsidePointer, true);
+    document.removeEventListener('keydown', escClose, true);
+    window.removeEventListener('resize', closePopover);
+    window.removeEventListener('scroll', closePopover, true);
+  }
+
+  function outsidePointer(ev) {
+    const btn = $('hwxMessagePinsHeaderBtn');
+    if (popover && popover.contains(ev.target)) return;
+    if (btn && btn.contains(ev.target)) return;
+    closePopover();
+  }
+
+  function escClose(ev) {
+    if (ev.key !== 'Escape') return;
+    closePopover();
+    const btn = $('hwxMessagePinsHeaderBtn');
+    if (btn && typeof btn.focus === 'function') btn.focus();
+  }
+
+  // ── re-render handling ───────────────────────────────────────────────────
+  // renderMessages() wipes #msgInner innerHTML on every rebuild, so injected
+  // buttons and decorations are lost. A MutationObserver re-applies them after
+  // each rebuild. We also detect a session switch (the data-session-id flips)
+  // and refresh the header badge for the new session's pin set.
+  function onMutations() {
+    const sid = currentSessionId();
+    if (sid !== lastSessionId) {
+      lastSessionId = sid;
+      closePopover();
+    }
+    redecorate();
+    refreshHeader();
+  }
+
+  let rafScheduled = false;
+  function scheduleSync() {
+    if (rafScheduled) return;
+    rafScheduled = true;
+    requestAnimationFrame(() => {
+      rafScheduled = false;
+      try { onMutations(); } catch (_) {}
+    });
+  }
+
+  function startObserver() {
+    const container = $('messages');
+    if (!container || observer) return !!observer;
+    observer = new MutationObserver(scheduleSync);
+    observer.observe(container, { childList: true, subtree: true });
+    return true;
+  }
+
+  // ── boot ─────────────────────────────────────────────────────────────────
+  function install(attempt) {
+    attempt = attempt || 0;
+    const container = $('messages');
+    const shell = document.querySelector('.messages-shell');
+    if (container && shell) {
+      lastSessionId = currentSessionId();
+      startObserver();
+      ensureHeaderButton();
+      refreshHeader();
+      redecorate();
+      window.HermesMessagePinsExtension = {
+        version: '0.1.0',
+        refresh: () => { redecorate(); refreshHeader(); },
+        pinsForCurrentSession: loadPins,
+      };
+      return true;
+    }
+    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
+    console.warn('[' + EXT + '] messages container not found; not installed');
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/message-pins/assets/message-pins.js
+++ b/extensions/message-pins/assets/message-pins.js
@@ -156,7 +156,10 @@
     closePopover();
     const row = findRow(idx);
     if (row && row.getClientRects && row.getClientRects().length > 0) {
-      row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      // Jump to the START of the pinned row, not its center — for long
+      // assistant/final-answer messages, block:'center' landed mid-message which
+      // doesn't feel like "jump to this pinned thing" (Frank, PR #19 round 2).
+      row.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' });
       row.classList.add('hwx-pin-flash');
       setTimeout(() => row.classList.remove('hwx-pin-flash'), 1400);
       return;

--- a/extensions/message-pins/extension.json
+++ b/extensions/message-pins/extension.json
@@ -1,0 +1,49 @@
+{
+  "id": "message-pins",
+  "name": "Message Pins",
+  "description": "Pin individual messages in a conversation. Adds a pin button to each message, a header popover listing pinned messages with click-to-jump, and a small badge with the pin count. Pins persist locally per session.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/message-pins.js"
+    ],
+    "stylesheets": [
+      "assets/message-pins.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-message-pins"
+      ],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false
+  }
+}

--- a/extensions/message-pins/manifest.json
+++ b/extensions/message-pins/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "message-pins",
+      "name": "Message Pins",
+      "description": "Pin individual messages in a conversation, with a header popover and click-to-jump.",
+      "scripts": [
+        "assets/message-pins.js"
+      ],
+      "stylesheets": [
+        "assets/message-pins.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a **`message-pins`** extension: pin individual messages in a conversation.

- Per-message **pin button** in each message's hover action bar (with a floating fallback for rows that have no action bar).
- A **header button** near the top-right of the chat area with a **count badge**; clicking it opens a **popover** listing the pinned messages, each with **click-to-jump** and an unpin control.
- **3-pin cap** per conversation with a polite over-cap toast.
- **Client-side persistence** via `localStorage`, keyed per `session_id`, so each conversation keeps its own pins and switching conversations swaps them.
- A **`MutationObserver`** re-applies pin decorations after the transcript re-renders (the message list rebuilds `innerHTML`), so pins survive streaming, scrolling, and reloads.

This is a `static-ui` / `manifest-bundle` entry: no backend routes, no sidecar, no network, no filesystem, no core changes. The only state it writes is the single `localStorage` key `hermes-ext-message-pins`.

## Design reference / credit

The pin UX here follows closed core PR **nesquena/hermes-webui#2534** by **@Michaelyklam** (originally requested in issue #2508) — the per-message pin button, header popover with badge, click-to-jump, and 3-pin cap are his design. That PR implemented pinning with a new core API and server-side persistence, which didn't fit core's scope; this reimagines it as an opt-in extension that persists pins in the browser and needs no core changes. Co-authored to preserve attribution. Thanks @Michaelyklam.

## Verification

Repo gates (all green, 3 entries now):

```
node scripts/validate-extensions.mjs       # validated 3 extension entries
node scripts/scan-extension-safety.mjs     # safety scan passed for 3 extension entries
node scripts/test-extension-validator.mjs  # self-tests passed
node scripts/generate-registry.mjs --out dist/registry.json   # wrote 3 entries + artifacts
node --check extensions/message-pins/assets/message-pins.js
```

**Live end-to-end test** (isolated WebUI server with the extension loaded via `HERMES_WEBUI_EXTENSION_DIR` + `HERMES_WEBUI_EXTENSION_MANIFEST`, seeded session with 8 messages, driven via headless Chrome/CDP):

- extension boots; header button injected; **8 message rows → 8 pin buttons**; session id read correctly from the DOM
- pinning messages 0/2/4 → stored `[0,2,4]`, badge `3`, 3 active buttons
- 4th pin → **capped**, stays `[0,2,4]`, polite toast shown
- popover opens, lists 3 pins with correct message-text previews
- click-to-jump scrolls to the row and flashes it, closing the popover
- **reload** → pins persist (`[0,2,4]`), buttons re-decorate, badge `3` (MutationObserver re-apply confirmed)
- unpin via popover → `[2,4]`, badge `2`
- forced transcript re-render → all pin buttons re-applied, active state preserved
- assets served 200, zero extension errors in the server log

## Permissions disclosure (cross-checked against the code)

- `webui_api.read/write: []` — no `fetch`, no `/api/*` calls
- `network_external: false` — no external URLs
- `storage.owned: ["hermes-ext-message-pins"]` — the one and only localStorage key written
- `dom.owned: true`, `dom.mutates_core_views: true` — injects the pin buttons / header button / popover and toggles its own decoration classes on message rows
- `webui_navigation: false` — scrolls within the transcript only; no panel/route navigation
- no eval, no cookies, no loopback/native host; all message text rendered via `textContent` (XSS-safe)

## Notes

- Pins are per-browser (client-side only), not synced across devices — the deliberate trade-off for a no-backend extension.
- Jump-to-pin requires the target message to be within the loaded transcript window; for a very long conversation an off-window pin shows a "scroll up to load it" notice rather than silently doing nothing.
- Relies on the current message-row DOM (`data-msg-idx`, `.msg-actions`, `data-session-id`) until a formal message-decoration extension API exists.
