### PR TITLE
Add mobile-haptics extension (turn-complete vibration, Android)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -37,3 +37,5 @@ need it and maintainers agree on the shared contract.
 - `skin-pack`: popular editor-inspired color themes (Dracula, Gruvbox, One Dark,
   Tokyo Night, Rosé Pine, Solarized Dark) that register into the native
   Appearance picker via the theme-registration API.
+- `mobile-haptics`: short device vibration when an assistant turn finishes
+  (Android / Android-PWA; no-ops on desktop and iOS).

--- a/extensions/mobile-haptics/README.md
+++ b/extensions/mobile-haptics/README.md
@@ -1,0 +1,131 @@
+# Mobile Haptics
+
+Mobile Haptics is a trusted local Hermes WebUI extension that gives your phone a
+short vibration when an assistant turn finishes — so if you fire off a long task
+and set the device down, you get a physical "it's done" cue.
+
+## What It Does
+
+- Watches for the end of an assistant turn and triggers a short
+  `navigator.vibrate()` buzz.
+- Opt-in preference stored locally (`hermes-ext-haptics-enabled`); on by default
+  where vibration is supported.
+- Ignores sub-600ms blips so only real turns buzz.
+
+## Platform support (important)
+
+`navigator.vibrate` is a **mobile** API:
+
+- ✅ **Android / Android-PWA (Chrome, Edge, etc.)** — works.
+- ⛔ **Desktop browsers** — the call is a silent no-op (no vibration hardware).
+- ⛔ **iOS Safari / iOS PWA** — Apple does not support `navigator.vibrate`, so
+  this has no effect on iPhone/iPad.
+
+The extension detects support and degrades silently (it logs an informational
+note in the console when vibration isn't available). This is, by design, an
+Android-leaning feature.
+
+## How it detects "turn complete"
+
+Extensions can't see the server's streaming (SSE) events, so this reads the DOM
+instead: the composer send button (`#btnSend`) carries a busy action
+(`stop` / `steer` / `interrupt`) while the assistant is generating and returns
+to the idle `send` action when the turn finishes. A `MutationObserver` on that
+button's `class` / `data-action` catches the busy → idle transition and fires
+the buzz.
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/mobile-haptics.js
+  -> MutationObserver on #btnSend (busy -> idle) -> navigator.vibrate()
+  -> localStorage: hermes-ext-haptics-enabled
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, access external networks, read or write files, or use
+native host APIs. It creates no DOM.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/mobile-haptics HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+Open the WebUI on an Android device (or Android-PWA), send a message, and feel a
+short buzz when the reply completes.
+
+## Controls
+
+A small JS control surface is exposed on `window.HermesMobileHapticsExtension`:
+
+- `.supported` — whether `navigator.vibrate` exists on this device
+- `.isEnabled()` — current opt-in state
+- `.setEnabled(true|false)` — toggle and persist
+- `.test()` — fire a test buzz (returns false if unsupported)
+
+## Disable And Uninstall
+
+Set `HermesMobileHapticsExtension.setEnabled(false)` to turn off buzzing while
+keeping the extension installed, or restart Hermes WebUI without
+`HERMES_WEBUI_EXTENSION_DIR` / `HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the
+`extensions/mobile-haptics/` directory.
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- calls `navigator.vibrate()` when an assistant turn completes (if enabled +
+  supported)
+- observes the `#btnSend` button's `class` / `data-action` via a
+  `MutationObserver` (read-only)
+- reads and writes `localStorage` under the single key
+  `hermes-ext-haptics-enabled`
+- creates NO DOM
+- does not call WebUI HTTP APIs
+- does not access cookies
+- does not contact loopback or external network services
+- does not use arbitrary filesystem or native host APIs
+
+## Compatibility
+
+- manifest-bundled extension assets + same-origin serving under `/extensions/`
+- the composer send button `#btnSend` with its `data-action` / busy-class
+  contract (used to detect turn completion)
+- a device with `navigator.vibrate` (Android) for any actual effect
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/mobile-haptics/assets/mobile-haptics.js
+python3 -m json.tool extensions/mobile-haptics/extension.json
+python3 -m json.tool extensions/mobile-haptics/manifest.json
+```
+
+Functional verification (the busy → idle detection is the testable core; the
+actual vibration only fires on Android hardware):
+
+- on a desktop browser, `HermesMobileHapticsExtension.supported` is `false` and
+  no error occurs
+- sending a message flips `#btnSend` to a busy action and back; the extension's
+  state machine logs/triggers on the idle transition
+- on an Android device, completing a turn produces a short buzz when enabled
+
+## Known Limitations
+
+- No effect on desktop or iOS (platform limitation of `navigator.vibrate`).
+- Detects turn completion from the send-button state, so it relies on the
+  current `#btnSend` `data-action` / busy-class contract.
+- Browsers may suppress vibration until the user has interacted with the page
+  (a standard mobile-browser gesture requirement); sending a message satisfies
+  that.

--- a/extensions/mobile-haptics/README.md
+++ b/extensions/mobile-haptics/README.md
@@ -10,7 +10,8 @@ and set the device down, you get a physical "it's done" cue.
   `navigator.vibrate()` buzz.
 - Opt-in preference stored locally (`hermes-ext-haptics-enabled`); on by default
   where vibration is supported.
-- Ignores sub-600ms blips so only real turns buzz.
+- Ignores sub-100ms flickers; the real "a turn happened" gate is observing a
+  genuine busy action (stop/steer/interrupt), so only real turns buzz.
 
 ## Platform support (important)
 

--- a/extensions/mobile-haptics/assets/mobile-haptics.js
+++ b/extensions/mobile-haptics/assets/mobile-haptics.js
@@ -60,7 +60,13 @@
       if (!sawBusy) { sawBusy = true; busyStartedAt = Date.now(); }
       return;
     }
-    // Not a busy action. If we had seen a busy action this turn, the turn is done.
+    // 'queue' is NOT completion: core sets #btnSend.dataset.action to 'queue' while
+    // an assistant turn is STILL active and the user has typed/queued a follow-up
+    // (static/ui.js getComposerPrimaryAction). Treat it as a holding state so a
+    // mid-turn stop->queue transition does not fire a premature buzz (and then a
+    // second one on the real completion). (Codex gate, PR #22.)
+    if (sawBusy && action === 'queue') return;
+    // Not a busy/holding action. If we had seen a busy action this turn, it's done.
     if (sawBusy) {
       const ranFor = Date.now() - busyStartedAt;
       sawBusy = false;

--- a/extensions/mobile-haptics/assets/mobile-haptics.js
+++ b/extensions/mobile-haptics/assets/mobile-haptics.js
@@ -1,0 +1,110 @@
+(() => {
+  'use strict';
+
+  // ── Mobile Haptics extension for Hermes WebUI ────────────────────────────
+  // Gives a short device vibration when an assistant turn finishes, so a phone
+  // user who set the device down gets a physical "it's done" cue. Opt-in and
+  // mobile-only by nature (navigator.vibrate is a no-op on desktop and is not
+  // supported on iOS Safari — so this is effectively an Android / Android-PWA
+  // feature; it degrades silently everywhere else).
+  //
+  // It cannot see SSE events, so it detects "turn complete" purely from the DOM:
+  // the composer send button (#btnSend) carries a busy action (stop / steer /
+  // interrupt) while the assistant is generating, and returns to the idle 'send'
+  // action when the turn finishes. The busy -> idle transition is the trigger.
+
+  const EXT = 'mobile-haptics';
+  if (window.__hermesMobileHapticsLoaded) return;
+  window.__hermesMobileHapticsLoaded = true;
+
+  const PREF_KEY = 'hermes-ext-haptics-enabled';      // '1' (default on) | '0'
+  const COMPLETE_PATTERN = [18];                       // short single buzz on turn-complete
+  const BUSY_ACTIONS = new Set(['stop', 'steer', 'interrupt']);
+  const MIN_BUSY_MS = 100;                            // tiny floor: filters pure flicker; the sawBusy flag is the real "a turn happened" gate
+
+  let sawBusy = false;        // have we observed a genuine busy (stop/steer/interrupt) action this turn?
+  let busyStartedAt = 0;      // when the busy period began
+  let observer = null;
+
+  function hapticsSupported() {
+    return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
+  }
+
+  function enabled() {
+    try {
+      const v = localStorage.getItem(PREF_KEY);
+      return v === null ? true : v === '1';   // default ON when supported
+    } catch (_) { return true; }
+  }
+
+  function sendBtnAction() {
+    const btn = document.getElementById('btnSend');
+    if (!btn) return null;
+    const a = btn.dataset ? btn.dataset.action : null;
+    if (a) return a;
+    for (const cls of BUSY_ACTIONS) if (btn.classList.contains(cls)) return cls;
+    return 'send';
+  }
+
+  // Turn lifecycle as reflected by #btnSend's action:
+  //   send  -> (busy: stop/steer/interrupt, possibly interleaved with 'disabled'
+  //             while the composer is empty mid-stream) -> back to send/disabled idle.
+  // The reliable "turn complete" signal is: we saw a genuine busy action, and the
+  // button has now returned to the idle 'send'/'disabled' state. 'disabled' alone
+  // is NOT busy (empty composer) and NOT a completion on its own — only the
+  // transition OUT of a confirmed-busy turn counts.
+  function onStateMaybeChanged() {
+    const action = sendBtnAction();
+    const busy = BUSY_ACTIONS.has(action);
+    if (busy) {
+      if (!sawBusy) { sawBusy = true; busyStartedAt = Date.now(); }
+      return;
+    }
+    // Not a busy action. If we had seen a busy action this turn, the turn is done.
+    if (sawBusy) {
+      const ranFor = Date.now() - busyStartedAt;
+      sawBusy = false;
+      if (ranFor >= MIN_BUSY_MS && enabled() && hapticsSupported()) {
+        try { navigator.vibrate(COMPLETE_PATTERN); } catch (_) {}
+      }
+    }
+  }
+
+  function startObserver() {
+    const btn = document.getElementById('btnSend');
+    if (!btn || observer) return !!observer;
+    // Watch the send button's class + data-action for the busy/idle flip.
+    observer = new MutationObserver(onStateMaybeChanged);
+    observer.observe(btn, { attributes: true, attributeFilter: ['class', 'data-action'] });
+    sawBusy = BUSY_ACTIONS.has(sendBtnAction());
+    if (sawBusy) busyStartedAt = Date.now();
+    return true;
+  }
+
+  function install(attempt) {
+    attempt = attempt || 0;
+    if (document.getElementById('btnSend')) {
+      startObserver();
+      window.HermesMobileHapticsExtension = {
+        version: '0.1.0',
+        supported: hapticsSupported(),
+        isEnabled: enabled,
+        setEnabled(on) { try { localStorage.setItem(PREF_KEY, on ? '1' : '0'); } catch (_) {} },
+        test() { if (hapticsSupported()) { try { navigator.vibrate(COMPLETE_PATTERN); return true; } catch (_) {} } return false; }
+      };
+      if (!hapticsSupported()) {
+        console.info('[' + EXT + '] navigator.vibrate not supported on this device (desktop / iOS Safari); haptics inactive.');
+      }
+      return true;
+    }
+    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
+    console.warn('[' + EXT + '] send button (#btnSend) not found; haptics not installed');
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/mobile-haptics/extension.json
+++ b/extensions/mobile-haptics/extension.json
@@ -1,0 +1,48 @@
+{
+  "id": "mobile-haptics",
+  "name": "Mobile Haptics",
+  "description": "A short device vibration when an assistant turn finishes, so a phone user who set the device down gets a physical \"it's done\" cue. Opt-in; Android / Android-PWA only (no-ops on desktop and iOS Safari).",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/mobile-haptics.js"
+    ],
+    "stylesheets": []
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": false,
+      "mutates_core_views": false
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-haptics-enabled"
+      ],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false,
+    "device_vibration": true
+  }
+}

--- a/extensions/mobile-haptics/manifest.json
+++ b/extensions/mobile-haptics/manifest.json
@@ -1,0 +1,13 @@
+{
+  "extensions": [
+    {
+      "id": "mobile-haptics",
+      "name": "Mobile Haptics",
+      "description": "Short device vibration when an assistant turn finishes (Android / Android-PWA).",
+      "scripts": [
+        "assets/mobile-haptics.js"
+      ],
+      "stylesheets": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **`mobile-haptics`** extension — a short device vibration when an assistant turn finishes, so a phone user who set the device down gets a physical "it's done" cue.

- Opt-in preference in `localStorage` (`hermes-ext-haptics-enabled`), on by default where supported.
- Detects "turn complete" from the DOM (extensions can't see SSE): a `MutationObserver` on the composer send button (`#btnSend`) watches its busy action (`stop`/`steer`/`interrupt`) return to idle.
- Creates **no DOM**; one localStorage key; no network/filesystem/sidecar.
- Exposes a small control surface on `window.HermesMobileHapticsExtension` (`supported` / `isEnabled()` / `setEnabled()` / `test()`).

## Platform support (honest)

`navigator.vibrate` is a mobile API: ✅ **Android / Android-PWA**, ⛔ **desktop** (silent no-op), ⛔ **iOS Safari / iOS PWA** (Apple doesn't support it). The extension detects support and degrades silently. This is, by design, an Android-leaning feature.

## End-to-end verification (live browser)

Tested against a real mock-provider turn, with `navigator.vibrate` instrumented to count calls and the busy/idle cycle measured:

- ✅ fires **exactly once per turn** (pattern `[18]`) on the busy → idle transition
- ✅ **no double-fire** across consecutive turns (1 turn → 1, 2 turns → 2)
- ✅ **disable suppresses** it and the preference persists across reload
- ✅ `.test()` fires through the vibrate path; `supported` flag correct
- ✅ repo gates green: validate / safety-scan / registry / validator self-test

### A real bug the live testing caught (and the fix)

The first implementation measured the busy window from when the `stop` action *first appeared*. But mid-stream the send button interleaves a `disabled` state (empty composer), so the observed `stop` window could be <350ms and got filtered by a duration guard — the buzz silently never fired on fast turns. Fixed the state machine to gate on a **confirmed busy action seen this turn** (`sawBusy`) rather than raw `stop` duration, and dropped the duration floor to a tiny flicker filter (100ms). Re-verified: now fires reliably on real turns. (Also re-confirmed the `?v=` asset-cache trap was masking the fix until a cache-bust reload — a test-env artifact, not a code issue.)

## Notes

- Detects completion via the `#btnSend` `data-action`/busy-class contract.
- 🤖 Agent-authored; flagging for review, not self-merging.
