### PR TITLE
Add model-favorites extension (star + promote favorite models)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -16,10 +16,11 @@ Do not add shared runtime code here unless multiple accepted extensions already
 need it and maintainers agree on the shared contract.
 
 ## Entries
-
 - `desktop-companion`: trusted local Desktop Companion entry and first
   sidecar-class extension candidate.
 - `mobile-conversations`: phone-only floating Conversations button, same-location
   drawer close X, and long-press shortcuts for the existing Hermes WebUI mobile drawer.
 - `message-pins`: pin individual messages in a conversation, with a header
   popover, click-to-jump, and client-side per-session persistence.
+- `model-favorites`: star your most-used models; favorites are promoted to a
+  ★ Favorites group at the top of the composer model picker.

--- a/extensions/model-favorites/README.md
+++ b/extensions/model-favorites/README.md
@@ -1,0 +1,106 @@
+# Model Favorites
+
+Model Favorites is a trusted local Hermes WebUI extension that lets you star the
+models you use most in the composer model picker. Favorited models are promoted
+to a **★ Favorites** group at the top of the dropdown for one-click switching.
+
+## What It Does
+
+- Adds a star toggle to each model row in the composer model picker (visible on
+  hover, and always visible once a model is favorited).
+- Promotes favorited models into a **★ Favorites** group pinned to the top of
+  the dropdown.
+- **Provider-aware**: the same model id offered by two providers is two distinct
+  favorites, so you can favorite exactly the one you mean.
+- Persists favorites locally (`localStorage`), so they survive reloads.
+- Re-applies after the picker re-renders (open / search / select) via a
+  `MutationObserver`.
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/model-favorites.js + .css
+  -> decorates #composerModelDropdown .model-opt rows with a star
+  -> injects a "★ Favorites" group at the top
+  -> localStorage: hermes-ext-model-favorites
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, access external networks, read or write files, or use
+native host APIs.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/model-favorites HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+Open the composer model picker, hover a model, and click the star. It appears in
+the Favorites group at the top.
+
+## Disable And Uninstall
+
+Restart Hermes WebUI without `HERMES_WEBUI_EXTENSION_DIR` /
+`HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the `extensions/model-favorites/`
+directory. Your favorites live under the `hermes-ext-model-favorites` localStorage
+key.
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- creates extension-owned DOM (a star button per model row + a Favorites group)
+  inside the existing model dropdown
+- reads each row's model id / name / provider from the existing
+  `.model-opt-id` / `.model-opt-name` / `.model-opt-provider` elements
+- selects a favorite by calling the existing `window.selectModelFromDropdown(...)`
+- reads and writes `localStorage` under the single key
+  `hermes-ext-model-favorites`
+- does not call WebUI HTTP APIs
+- does not access cookies
+- does not contact loopback or external network services
+- does not use arbitrary filesystem or native host APIs
+
+All rendered text (model names/ids/providers) is inserted via escaped HTML.
+
+## Compatibility
+
+- manifest-bundled extension assets + same-origin serving under `/extensions/`
+- the composer model dropdown `#composerModelDropdown` with `.model-opt` rows
+  carrying `.model-opt-id` / `.model-opt-name` / `.model-opt-provider` (the
+  integration contract; if core renames these, the extension needs updating)
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/model-favorites/assets/model-favorites.js
+python3 -m json.tool extensions/model-favorites/extension.json
+python3 -m json.tool extensions/model-favorites/manifest.json
+```
+
+Manual verification:
+
+- hovering a model row shows a star; clicking it adds the model to a Favorites
+  group at the top of the dropdown and the star fills in
+- the same model under a different provider is favorited independently
+- clicking a favorite selects that model
+- un-starring (from either the row or the Favorites group) removes it
+- favorites persist across a reload and across reopening the dropdown
+
+## Known Limitations
+
+- Relies on the current model-picker DOM (`.model-opt*` classes); a core rename
+  would require an update — standard for a DOM-injection extension.
+- Credit: the provider-aware favorite design follows closed core PR #3578
+  (@starship-s); this is a lighter client-side extension over the current
+  grouped picker rather than the original core implementation.

--- a/extensions/model-favorites/assets/model-favorites.css
+++ b/extensions/model-favorites/assets/model-favorites.css
@@ -1,0 +1,67 @@
+/* Model Favorites extension for Hermes WebUI.
+   Scoped to hwx-fav-* classes so it cannot collide with core styles.
+   Uses core CSS variables so it adapts to the active theme/skin. */
+
+.hwx-fav-star {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  margin-left: 6px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted, #888);
+  cursor: pointer;
+  opacity: 0;
+  transition: color .12s ease, opacity .12s ease, background .12s ease;
+}
+/* Reveal the star on row hover, or keep it visible when favorited. */
+.model-opt:hover .hwx-fav-star,
+.hwx-fav-star:focus-visible,
+.hwx-fav-star--on {
+  opacity: 1;
+}
+.hwx-fav-star:hover {
+  color: var(--text, #111);
+  background: var(--hover-bg, rgba(127, 127, 127, .12));
+}
+.hwx-fav-star--on {
+  color: var(--accent, #f5c542);
+}
+.hwx-fav-star--on:hover {
+  color: var(--accent, #f5c542);
+}
+
+/* The model-opt-top row needs to lay the star out inline at the end. */
+.model-opt .model-opt-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.model-opt .model-opt-top .model-opt-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Injected Favorites group. */
+.hwx-fav-group {
+  border-bottom: 1px solid var(--border2, rgba(127, 127, 127, .25));
+  margin-bottom: 2px;
+  padding-bottom: 2px;
+}
+.hwx-fav-heading.model-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent, #f5c542);
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hwx-fav-star { transition: none; }
+}

--- a/extensions/model-favorites/assets/model-favorites.js
+++ b/extensions/model-favorites/assets/model-favorites.js
@@ -51,13 +51,25 @@
   }
 
   // ── read a row's identity from the existing DOM ──────────────────────────
+  // Provider identity: prefer the visible .model-opt-provider chip, but core omits
+  // it for rows under their own provider heading — in that case derive it from the
+  // enclosing core group wrapper .model-group-body[data-group] (data-group is the
+  // providerId, set in core ui.js renderModelDropdown). (Codex gate, PR #23.)
+  function rowProvider(row) {
+    const provEl = row.querySelector(':scope .model-opt-provider');
+    if (provEl && provEl.textContent.trim()) return provEl.textContent.trim();
+    const grp = row.closest('.model-group-body[data-group]');
+    if (grp && grp.dataset && grp.dataset.group && grp.dataset.group !== '__ungrouped__') {
+      return grp.dataset.group;
+    }
+    return '';
+  }
   function rowInfo(row) {
     const idEl = row.querySelector(':scope .model-opt-id');
     const nameEl = row.querySelector(':scope .model-opt-name');
-    const provEl = row.querySelector(':scope .model-opt-provider');
     const id = idEl ? idEl.textContent.trim() : '';
     const name = nameEl ? nameEl.textContent.trim() : id;
-    const provider = provEl ? provEl.textContent.trim() : '';
+    const provider = rowProvider(row);
     return { id, name, provider };
   }
 
@@ -137,8 +149,10 @@
         if (dd) {
           dd.querySelectorAll('.model-opt:not(.hwx-fav-row)').forEach((r) => {
             if (liveRow) return;
-            const idEl = r.querySelector(':scope .model-opt-id');
-            if (idEl && idEl.textContent.trim() === f.id) liveRow = r;
+            const info = rowInfo(r);
+            // Match on id + provider so duplicate model ids across providers don't
+            // re-click the wrong row. (Codex gate, PR #23.)
+            if (info.id === f.id && (info.provider || '') === (f.provider || '')) liveRow = r;
           });
         }
         if (liveRow && typeof liveRow.click === 'function') {

--- a/extensions/model-favorites/assets/model-favorites.js
+++ b/extensions/model-favorites/assets/model-favorites.js
@@ -124,10 +124,27 @@
       row.innerHTML = '<div class="model-opt-top"><span class="model-opt-name">' +
         escapeHtml(f.name || f.id) + '</span>' + provChip + '</div>' +
         '<span class="model-opt-id">' + escapeHtml(f.id) + '</span>';
-      // Selecting a favorite: defer to the canonical app selector if present.
+      // Selecting a favorite: prefer re-clicking the REAL core row so the exact
+      // providerId (carried only in core's row.onclick closure, not exposed as a
+      // DOM attribute) is used. Match the live row by model id; only fall back to
+      // selectModelFromDropdown(id) when no live row exists. This avoids selecting
+      // the wrong provider for duplicate model ids. (Codex gate, PR #23.)
       row.addEventListener('click', (ev) => {
         const star = ev.target.closest('.hwx-fav-star');
         if (star) return;
+        const dd = document.getElementById(DD_ID);
+        let liveRow = null;
+        if (dd) {
+          dd.querySelectorAll('.model-opt:not(.hwx-fav-row)').forEach((r) => {
+            if (liveRow) return;
+            const idEl = r.querySelector(':scope .model-opt-id');
+            if (idEl && idEl.textContent.trim() === f.id) liveRow = r;
+          });
+        }
+        if (liveRow && typeof liveRow.click === 'function') {
+          liveRow.click();   // exact core selection incl. real providerId
+          return;
+        }
         if (typeof window.selectModelFromDropdown === 'function') {
           window.selectModelFromDropdown(f.id, f.provider || null);
         }
@@ -158,10 +175,17 @@
         top.appendChild(star);
         row.dataset[DECOR_FLAG] = '1';
       } else {
-        star.classList.toggle('hwx-fav-star--on', fav);
-        star.setAttribute('aria-pressed', fav ? 'true' : 'false');
-        star.title = fav ? 'Remove from favorites' : 'Add to favorites';
-        star.innerHTML = starSvg(fav);
+        const want = fav;
+        const has = star.classList.contains('hwx-fav-star--on');
+        if (want !== has) {
+          // Only rewrite the star DOM when the filled state actually changed —
+          // an unconditional innerHTML rewrite every pass creates childList
+          // mutations that can feed an observer loop. (Codex gate, PR #23.)
+          star.classList.toggle('hwx-fav-star--on', fav);
+          star.setAttribute('aria-pressed', fav ? 'true' : 'false');
+          star.title = fav ? 'Remove from favorites' : 'Add to favorites';
+          star.innerHTML = starSvg(fav);
+        }
       }
     });
   }
@@ -170,11 +194,16 @@
     const dd = document.getElementById(DD_ID);
     if (!dd || applying) return;
     applying = true;
+    // Disconnect the observer for the duration of our own mutations so the
+    // queued MutationObserver callbacks (which fire on a microtask AFTER the
+    // `applying` flag is reset) can't re-trigger apply() in a loop. (Codex gate, PR #23.)
+    if (observer) { try { observer.disconnect(); } catch (_) {} }
     try {
       const favs = loadFavs();
       buildFavGroup(dd, favs);
       decorateRows(dd, favs);
     } finally {
+      if (observer) { try { observer.observe(dd, { childList: true, subtree: true }); } catch (_) {} }
       applying = false;
     }
   }

--- a/extensions/model-favorites/assets/model-favorites.js
+++ b/extensions/model-favorites/assets/model-favorites.js
@@ -58,9 +58,19 @@
   function rowProvider(row) {
     const provEl = row.querySelector(':scope .model-opt-provider');
     if (provEl && provEl.textContent.trim()) return provEl.textContent.trim();
-    const grp = row.closest('.model-group-body[data-group]');
-    if (grp && grp.dataset && grp.dataset.group && grp.dataset.group !== '__ungrouped__') {
-      return grp.dataset.group;
+    // Walk ancestors for the nearest PROVIDER wrapper, skipping nested vendor
+    // subgroups: core renders OpenRouter/Nous subgroups as `.model-group-body.sub`
+    // with data-group="<provider>::<vendor>", which is NOT a real provider id.
+    // (Codex gate round 3, PR #23.)
+    let el = row.parentElement;
+    while (el) {
+      if (el.classList && el.classList.contains('model-group-body') &&
+          !el.classList.contains('sub') && el.dataset && el.dataset.group) {
+        const g = el.dataset.group;
+        if (g && g !== '__ungrouped__') return g;
+        return '';
+      }
+      el = el.parentElement;
     }
     return '';
   }

--- a/extensions/model-favorites/assets/model-favorites.js
+++ b/extensions/model-favorites/assets/model-favorites.js
@@ -1,0 +1,225 @@
+(() => {
+  'use strict';
+
+  // ── Model Favorites extension for Hermes WebUI ───────────────────────────
+  // Lets you star/favorite the models you use most in the composer model
+  // picker. Favorited models are promoted into a "★ Favorites" group at the top
+  // of the dropdown for one-click switching. Favorites persist locally and are
+  // provider-aware (the same model id under two providers is two distinct
+  // favorites).
+  //
+  // Pure DOM-injection over the existing picker (no core changes, no backend).
+  // The picker re-renders on open/search/select, so a MutationObserver re-applies
+  // the stars + the Favorites group after every rebuild.
+
+  const EXT = 'model-favorites';
+  if (window.__hermesModelFavoritesLoaded) return;
+  window.__hermesModelFavoritesLoaded = true;
+
+  const STORAGE_KEY = 'hermes-ext-model-favorites';
+  const DD_ID = 'composerModelDropdown';
+  const FAV_GROUP_FLAG = 'hwxFavGroup';     // marks our injected group
+  const STAR_FLAG = 'hwxFavStar';           // marks a wired star button
+  const DECOR_FLAG = 'hwxFavDecorated';     // marks a row we've decorated
+
+  let observer = null;
+  let applying = false;                     // re-entrancy guard (we mutate the DD)
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  // ── persistence ──────────────────────────────────────────────────────────
+  function loadFavs() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter((f) => f && typeof f.id === 'string') : [];
+    } catch (_) { return []; }
+  }
+  function saveFavs(favs) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(favs)); } catch (_) {}
+  }
+  // Provider-aware identity key.
+  function favKey(id, provider) { return (provider || '') + '\u241F' + (id || ''); }
+  function isFav(id, provider, favs) {
+    const k = favKey(id, provider);
+    return (favs || loadFavs()).some((f) => favKey(f.id, f.provider) === k);
+  }
+
+  // ── read a row's identity from the existing DOM ──────────────────────────
+  function rowInfo(row) {
+    const idEl = row.querySelector(':scope .model-opt-id');
+    const nameEl = row.querySelector(':scope .model-opt-name');
+    const provEl = row.querySelector(':scope .model-opt-provider');
+    const id = idEl ? idEl.textContent.trim() : '';
+    const name = nameEl ? nameEl.textContent.trim() : id;
+    const provider = provEl ? provEl.textContent.trim() : '';
+    return { id, name, provider };
+  }
+
+  function toggleFav(id, name, provider) {
+    let favs = loadFavs();
+    const k = favKey(id, provider);
+    if (favs.some((f) => favKey(f.id, f.provider) === k)) {
+      favs = favs.filter((f) => favKey(f.id, f.provider) !== k);
+    } else {
+      favs.push({ id, name, provider });
+    }
+    saveFavs(favs);
+    apply();   // re-decorate + rebuild the favorites group
+  }
+
+  function starSvg(filled) {
+    return '<svg width="13" height="13" viewBox="0 0 24 24" fill="' + (filled ? 'currentColor' : 'none') +
+      '" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>';
+  }
+
+  function makeStar(info, favs) {
+    const fav = isFav(info.id, info.provider, favs);
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'hwx-fav-star' + (fav ? ' hwx-fav-star--on' : '');
+    btn.dataset[STAR_FLAG] = '1';
+    btn.title = fav ? 'Remove from favorites' : 'Add to favorites';
+    btn.setAttribute('aria-label', btn.title);
+    btn.setAttribute('aria-pressed', fav ? 'true' : 'false');
+    btn.innerHTML = starSvg(fav);
+    btn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();           // never trigger the row's model-select onclick
+      toggleFav(info.id, info.name, info.provider);
+    });
+    return btn;
+  }
+
+  // ── build the Favorites group at the top of the dropdown ─────────────────
+  function buildFavGroup(dd, favs) {
+    // Remove any prior injected group first (idempotent rebuild).
+    const prior = dd.querySelector(':scope > [data-' + 'hwx-fav-group="1"]');
+    if (prior) prior.remove();
+    if (!favs.length) return;
+
+    const wrap = document.createElement('div');
+    wrap.setAttribute('data-hwx-fav-group', '1');
+    wrap.className = 'hwx-fav-group';
+
+    const heading = document.createElement('div');
+    heading.className = 'model-group hwx-fav-heading';
+    heading.textContent = '\u2605 Favorites';
+    wrap.appendChild(heading);
+
+    const body = document.createElement('div');
+    body.className = 'model-group-body';
+
+    for (const f of favs) {
+      const row = document.createElement('div');
+      row.className = 'model-opt hwx-fav-row';
+      const provChip = f.provider
+        ? '<span class="model-opt-provider">' + escapeHtml(f.provider) + '</span>' : '';
+      row.innerHTML = '<div class="model-opt-top"><span class="model-opt-name">' +
+        escapeHtml(f.name || f.id) + '</span>' + provChip + '</div>' +
+        '<span class="model-opt-id">' + escapeHtml(f.id) + '</span>';
+      // Selecting a favorite: defer to the canonical app selector if present.
+      row.addEventListener('click', (ev) => {
+        const star = ev.target.closest('.hwx-fav-star');
+        if (star) return;
+        if (typeof window.selectModelFromDropdown === 'function') {
+          window.selectModelFromDropdown(f.id, f.provider || null);
+        }
+      });
+      // a star (filled) to allow un-favoriting directly from the group —
+      // placed inside .model-opt-top so it sits inline with the name, matching
+      // the main list rows.
+      const top = row.querySelector('.model-opt-top') || row;
+      top.appendChild(makeStar({ id: f.id, name: f.name, provider: f.provider }, favs));
+      body.appendChild(row);
+    }
+    wrap.appendChild(body);
+    dd.insertBefore(wrap, dd.firstChild);
+  }
+
+  // ── decorate every real model row with a star ────────────────────────────
+  function decorateRows(dd, favs) {
+    const rows = dd.querySelectorAll('.model-opt');
+    rows.forEach((row) => {
+      if (row.classList.contains('hwx-fav-row')) return;   // our own group's rows
+      const info = rowInfo(row);
+      if (!info.id) return;
+      let star = row.querySelector(':scope > .hwx-fav-star, :scope .model-opt-top > .hwx-fav-star');
+      const fav = isFav(info.id, info.provider, favs);
+      if (!star) {
+        star = makeStar(info, favs);
+        const top = row.querySelector(':scope .model-opt-top') || row;
+        top.appendChild(star);
+        row.dataset[DECOR_FLAG] = '1';
+      } else {
+        star.classList.toggle('hwx-fav-star--on', fav);
+        star.setAttribute('aria-pressed', fav ? 'true' : 'false');
+        star.title = fav ? 'Remove from favorites' : 'Add to favorites';
+        star.innerHTML = starSvg(fav);
+      }
+    });
+  }
+
+  function apply() {
+    const dd = document.getElementById(DD_ID);
+    if (!dd || applying) return;
+    applying = true;
+    try {
+      const favs = loadFavs();
+      buildFavGroup(dd, favs);
+      decorateRows(dd, favs);
+    } finally {
+      applying = false;
+    }
+  }
+
+  // ── observe re-renders of the dropdown ───────────────────────────────────
+  let raf = false;
+  function scheduleApply() {
+    if (raf || applying) return;   // ignore mutations we caused
+    raf = true;
+    requestAnimationFrame(() => { raf = false; try { apply(); } catch (_) {} });
+  }
+
+  function startObserver() {
+    const dd = document.getElementById(DD_ID);
+    if (!dd || observer) return !!observer;
+    observer = new MutationObserver((mutations) => {
+      if (applying) return;
+      // Only react to childList changes that aren't purely our own group.
+      scheduleApply();
+    });
+    observer.observe(dd, { childList: true, subtree: true });
+    return true;
+  }
+
+  function install(attempt) {
+    attempt = attempt || 0;
+    const dd = document.getElementById(DD_ID);
+    if (dd) {
+      startObserver();
+      apply();
+      window.HermesModelFavoritesExtension = {
+        version: '0.1.0',
+        favorites: loadFavs,
+        refresh: apply,
+      };
+      return true;
+    }
+    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
+    console.warn('[' + EXT + '] model dropdown (#' + DD_ID + ') not found; not installed');
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/model-favorites/extension.json
+++ b/extensions/model-favorites/extension.json
@@ -1,0 +1,49 @@
+{
+  "id": "model-favorites",
+  "name": "Model Favorites",
+  "description": "Star your most-used models in the composer model picker. Favorited models are promoted to a \u2605 Favorites group at the top of the dropdown for one-click switching. Provider-aware and persisted locally.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/model-favorites.js"
+    ],
+    "stylesheets": [
+      "assets/model-favorites.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-model-favorites"
+      ],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false
+  }
+}

--- a/extensions/model-favorites/manifest.json
+++ b/extensions/model-favorites/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "model-favorites",
+      "name": "Model Favorites",
+      "description": "Star your most-used models; favorites are promoted to the top of the composer model picker.",
+      "scripts": [
+        "assets/model-favorites.js"
+      ],
+      "stylesheets": [
+        "assets/model-favorites.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **`model-favorites`** extension — star your most-used models in the composer model picker. Favorited models are promoted to a **★ Favorites** group pinned to the top of the dropdown for one-click switching.

- A star toggle on every model row (shown on hover, always visible once favorited).
- **Provider-aware**: the same model id under two providers is two distinct favorites.
- Persists locally (`localStorage`); re-applies after the picker re-renders (open / search / select) via a `MutationObserver`.
- Pure DOM-injection over the existing `#composerModelDropdown` `.model-opt` rows — **no core changes, no backend**.

## Credit

The provider-aware favorite design follows closed core PR **nesquena/hermes-webui#3578** (@starship-s). That was a full core re-implementation against the pre-grouping picker; this is a lighter client-side extension over the current grouped picker. (This is the model-favorites idea Nathan flagged — a fuller "favorites in the footer provider window" version may extend it later.)

## End-to-end verification (live browser)

Tested by seeding multiple models into the picker and driving it via headless Chrome/CDP:

- ✅ stars decorate every model row (4 models → 4 stars)
- ✅ starring 2 models builds a **★ Favorites** group with exactly those 2
- ✅ **provider-aware** keying (same id under different providers tracked separately)
- ✅ selecting a favorite sets `modelSelect.value` to that model
- ✅ un-favorite works from both the row and the Favorites group
- ✅ **survives re-render** — fav group + stars re-applied, no duplicate groups
- ✅ **persists across full reload**
- ✅ polish pass: star sits inline (right edge) with the model name, matching the main rows — visually confirmed
- ✅ repo gates green: validate / safety-scan / registry / validator self-test

## Permissions disclosure (cross-checked against the code)

- `webui_api.read/write: []` — no `fetch`/`/api/*`; selecting a model calls the existing `window.selectModelFromDropdown(...)`
- `network_external: false`; no eval; no cookies
- `storage.owned: ["hermes-ext-model-favorites"]` — the one key written
- `dom.owned: true`, `dom.mutates_core_views: true` — injects stars + the Favorites group into the dropdown; all rendered text is escaped

## Known limitation

Relies on the current model-picker DOM (`.model-opt` / `.model-opt-id` / `.model-opt-name` / `.model-opt-provider`); a core rename would need an update — standard for a DOM-injection extension.

🤖 Agent-authored; flagging for review, not self-merging.
