### PR TITLE
Add custom-avatar extension (custom assistant avatar image)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -16,10 +16,11 @@ Do not add shared runtime code here unless multiple accepted extensions already
 need it and maintainers agree on the shared contract.
 
 ## Entries
-
 - `desktop-companion`: trusted local Desktop Companion entry and first
   sidecar-class extension candidate.
 - `mobile-conversations`: phone-only floating Conversations button, same-location
   drawer close X, and long-press shortcuts for the existing Hermes WebUI mobile drawer.
 - `message-pins`: pin individual messages in a conversation, with a header
   popover, click-to-jump, and client-side per-session persistence.
+- `custom-avatar`: give the assistant a custom avatar image in the chat
+  transcript (downscaled + stored locally; assistant-only).

--- a/extensions/custom-avatar/README.md
+++ b/extensions/custom-avatar/README.md
@@ -1,0 +1,125 @@
+# Custom Assistant Avatar
+
+Custom Assistant Avatar is a trusted local Hermes WebUI extension that lets you
+give the assistant a custom avatar image in the chat transcript. The assistant's
+role badge is normally a single-letter glyph; this swaps in an image of your
+choice.
+
+## What It Does
+
+- Click any assistant avatar badge (`.role-icon.assistant`) to open a small
+  picker: upload an image, or remove the current one.
+- The image is **downscaled to a 64×64 square and stored locally** as a data-URL
+  (`localStorage`), so it stays small and survives reloads.
+- Re-applies after the transcript re-renders (streaming, scrolling, reload) via a
+  `MutationObserver`, so the avatar persists on every assistant message.
+- Falls back to the original letter glyph when no avatar is set or you remove it.
+
+## Scope note (why assistant-only)
+
+The Hermes WebUI deliberately renders **no avatar on user messages** — user
+turns are right-aligned bubbles where position identifies the sender, so there is
+no user-side avatar slot in the DOM to customize. This extension customizes the
+**assistant** avatar badge, which is the avatar element that actually exists.
+
+(Related: closed issue #2677 described "the assistant shows the user's avatar."
+On current master there are no avatar *images* at all — both roles use letter
+glyphs — so that bug does not reproduce on the current build. This extension adds
+the personalization layer rather than fixing a non-present bug.)
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/custom-avatar.js + .css
+  -> swaps .role-icon.assistant glyph for an <img> when an avatar is set
+  -> localStorage: hermes-ext-assistant-avatar (a downscaled data-URL)
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, access external networks, or use native host APIs. Image
+processing happens entirely in the browser (canvas downscale); nothing is
+uploaded anywhere.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/custom-avatar HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+Send a message, then click the assistant's avatar badge on the left of its reply
+and upload an image.
+
+## Controls
+
+Also exposed on `window.HermesCustomAvatarExtension`:
+
+- `.get()` — current avatar data-URL (or empty)
+- `.set(dataUrl)` — set a `data:image/...` avatar
+- `.clear()` — remove it
+- `.refresh()` — re-apply to current rows
+
+## Disable And Uninstall
+
+Restart Hermes WebUI without `HERMES_WEBUI_EXTENSION_DIR` /
+`HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the `extensions/custom-avatar/`
+directory. Your avatar lives under the `hermes-ext-assistant-avatar` localStorage
+key.
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- creates extension-owned DOM (an `<img>` inside the assistant role badge + a
+  picker popover)
+- reads the uploaded image file locally (`FileReader`) and downscales it via a
+  `<canvas>`; the result is a small data-URL
+- reads and writes `localStorage` under the single key
+  `hermes-ext-assistant-avatar`
+- does not call WebUI HTTP APIs
+- does not access cookies
+- does not contact loopback or external network services (the image never leaves
+  the browser)
+- does not use arbitrary filesystem or native host APIs (the file picker is the
+  standard browser `<input type=file>`)
+
+Only validated `data:image/(png|jpeg|gif|webp);base64,...` values are ever
+applied, so a malformed stored value can't inject anything.
+
+## Compatibility
+
+- manifest-bundled extension assets + same-origin serving under `/extensions/`
+- assistant role badge `.role-icon.assistant` in the transcript (the integration
+  contract; a core rename would need an update)
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/custom-avatar/assets/custom-avatar.js
+python3 -m json.tool extensions/custom-avatar/extension.json
+python3 -m json.tool extensions/custom-avatar/manifest.json
+```
+
+Manual verification:
+
+- clicking an assistant avatar opens the picker; uploading an image replaces the
+  glyph with the image on every assistant message
+- the image persists across a reload and re-applies as new replies stream in
+- removing the avatar restores the letter glyph
+- a non-image or oversized file is rejected with a message, not applied
+
+## Known Limitations
+
+- Assistant-only (the user role has no avatar slot in the WebUI by design).
+- Avatars are per-browser (`localStorage`), not synced across devices.
+- Relies on the `.role-icon.assistant` badge; a core rename would need an update.
+- Images are downscaled to 64×64 to keep localStorage small.

--- a/extensions/custom-avatar/assets/custom-avatar.css
+++ b/extensions/custom-avatar/assets/custom-avatar.css
@@ -1,0 +1,64 @@
+/* Custom Avatar extension for Hermes WebUI.
+   Scoped to hwx-avatar-* classes; uses core CSS variables for theme-fit. */
+
+/* The avatar image fills the existing .role-icon badge. */
+.role-icon.assistant.hwx-avatar-set {
+  overflow: hidden;
+  padding: 0;
+}
+.hwx-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+}
+
+/* Picker popover. */
+.hwx-avatar-picker {
+  position: fixed;
+  z-index: 1000;
+  min-width: 180px;
+  background: var(--surface, #fff);
+  color: var(--text, #111);
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, .28);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.hwx-avatar-picker-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--muted, #888);
+}
+.hwx-avatar-btn {
+  appearance: none;
+  border: 1px solid var(--border2, rgba(127, 127, 127, .25));
+  background: var(--code-bg, rgba(127, 127, 127, .1));
+  color: var(--text, #111);
+  border-radius: 7px;
+  padding: 8px 10px;
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background .12s ease, border-color .12s ease;
+}
+.hwx-avatar-btn:hover {
+  background: var(--hover-bg, rgba(127, 127, 127, .16));
+  border-color: var(--border, rgba(127, 127, 127, .4));
+}
+.hwx-avatar-btn--clear {
+  color: var(--danger, #e5534b);
+}
+.hwx-avatar-status {
+  font-size: 11px;
+  color: var(--muted, #888);
+  min-height: 14px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hwx-avatar-btn { transition: none; }
+}

--- a/extensions/custom-avatar/assets/custom-avatar.js
+++ b/extensions/custom-avatar/assets/custom-avatar.js
@@ -1,0 +1,247 @@
+(() => {
+  'use strict';
+
+  // ── Custom Avatar extension for Hermes WebUI ─────────────────────────────
+  // Lets you give the assistant a custom avatar image in the chat transcript.
+  // The assistant role badge (.role-icon.assistant) is normally a single-letter
+  // glyph; this swaps in your chosen image. Click any assistant avatar to open a
+  // small picker (upload / clear). The image is downscaled and stored as a
+  // data-URL in localStorage, and re-applied after the transcript re-renders.
+  //
+  // Scope note: the WebUI deliberately renders no avatar on USER messages
+  // (right-aligned bubble — position identifies the sender), so there is no
+  // user-side avatar slot to customize. This extension customizes the assistant
+  // avatar, which is the badge that actually exists in the DOM.
+  //
+  // Pure DOM-injection, client-side only — no core changes, no backend.
+
+  const EXT = 'custom-avatar';
+  if (window.__hermesCustomAvatarLoaded) return;
+  window.__hermesCustomAvatarLoaded = true;
+
+  const STORAGE_KEY = 'hermes-ext-assistant-avatar';   // stores a data-URL (or empty)
+  const MAX_DIM = 64;                                   // downscale target (px)
+  const MAX_BYTES = 96 * 1024;                          // refuse images that won't downscale small enough
+  const APPLIED_FLAG = 'hwxAvatar';
+
+  let observer = null;
+  let picker = null;
+
+  function getAvatar() {
+    try { return localStorage.getItem(STORAGE_KEY) || ''; } catch (_) { return ''; }
+  }
+  function setAvatar(dataUrl) {
+    try {
+      if (dataUrl) localStorage.setItem(STORAGE_KEY, dataUrl);
+      else localStorage.removeItem(STORAGE_KEY);
+    } catch (_) {}
+    applyAll();
+  }
+
+  function isDataImage(s) {
+    return typeof s === 'string' && /^data:image\/(png|jpeg|jpg|gif|webp);base64,[A-Za-z0-9+/=]+$/.test(s);
+  }
+
+  // ── apply / clear the avatar on assistant role icons ─────────────────────
+  function applyToIcon(icon, dataUrl) {
+    if (!icon) return;
+    if (dataUrl && isDataImage(dataUrl)) {
+      if (icon.dataset[APPLIED_FLAG] !== dataUrl) {
+        // Render the image, hiding the letter glyph. Keep the glyph text as a
+        // fallback child we can restore on clear.
+        if (!icon.dataset.hwxGlyph) icon.dataset.hwxGlyph = icon.textContent || '';
+        icon.textContent = '';
+        let img = icon.querySelector(':scope > img.hwx-avatar-img');
+        if (!img) {
+          img = document.createElement('img');
+          img.className = 'hwx-avatar-img';
+          img.alt = 'assistant avatar';
+          icon.appendChild(img);
+        }
+        img.src = dataUrl;
+        icon.classList.add('hwx-avatar-set');
+        icon.dataset[APPLIED_FLAG] = dataUrl;
+      }
+    } else {
+      // No avatar set: ensure we restore the glyph if we'd replaced it.
+      const img = icon.querySelector(':scope > img.hwx-avatar-img');
+      if (img) img.remove();
+      if (icon.classList.contains('hwx-avatar-set')) {
+        icon.classList.remove('hwx-avatar-set');
+        if (icon.dataset.hwxGlyph && !icon.textContent) icon.textContent = icon.dataset.hwxGlyph;
+      }
+      delete icon.dataset[APPLIED_FLAG];
+    }
+    wireClick(icon);
+  }
+
+  function wireClick(icon) {
+    if (icon.dataset.hwxAvatarWired) return;
+    icon.dataset.hwxAvatarWired = '1';
+    icon.style.cursor = 'pointer';
+    icon.title = 'Click to set a custom assistant avatar';
+    icon.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      openPicker(icon);
+    });
+  }
+
+  function applyAll() {
+    const dataUrl = getAvatar();
+    document.querySelectorAll('.role-icon.assistant').forEach((icon) => applyToIcon(icon, dataUrl));
+  }
+
+  // ── image handling: downscale to a small square data-URL ─────────────────
+  function downscaleToDataUrl(file, cb) {
+    if (!file || !/^image\//.test(file.type)) { cb(null, 'Not an image file.'); return; }
+    if (file.size > 8 * 1024 * 1024) { cb(null, 'Image too large (max 8 MB before downscale).'); return; }
+    const reader = new FileReader();
+    reader.onerror = () => cb(null, 'Could not read the file.');
+    reader.onload = () => {
+      const img = new Image();
+      img.onerror = () => cb(null, 'Could not decode the image.');
+      img.onload = () => {
+        try {
+          const side = Math.min(MAX_DIM, Math.max(img.width, img.height));
+          const canvas = document.createElement('canvas');
+          canvas.width = MAX_DIM; canvas.height = MAX_DIM;
+          const ctx = canvas.getContext('2d');
+          // cover-fit into a square
+          const scale = Math.max(MAX_DIM / img.width, MAX_DIM / img.height);
+          const w = img.width * scale, h = img.height * scale;
+          ctx.drawImage(img, (MAX_DIM - w) / 2, (MAX_DIM - h) / 2, w, h);
+          let out = canvas.toDataURL('image/png');
+          if (out.length > MAX_BYTES) out = canvas.toDataURL('image/jpeg', 0.85);
+          if (out.length > MAX_BYTES) { cb(null, 'Image could not be reduced small enough.'); return; }
+          cb(out, null);
+        } catch (e) { cb(null, 'Image processing failed.'); }
+      };
+      img.src = reader.result;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  // ── picker popover ───────────────────────────────────────────────────────
+  function closePicker() {
+    if (picker) { picker.remove(); picker = null; }
+    document.removeEventListener('pointerdown', outside, true);
+    document.removeEventListener('keydown', esc, true);
+  }
+  function outside(ev) { if (picker && !picker.contains(ev.target)) closePicker(); }
+  function esc(ev) { if (ev.key === 'Escape') closePicker(); }
+
+  function openPicker(anchor) {
+    closePicker();
+    picker = document.createElement('div');
+    picker.className = 'hwx-avatar-picker';
+    picker.setAttribute('role', 'dialog');
+    picker.setAttribute('aria-label', 'Assistant avatar');
+
+    const title = document.createElement('div');
+    title.className = 'hwx-avatar-picker-title';
+    title.textContent = 'Assistant avatar';
+    picker.appendChild(title);
+
+    const fileBtn = document.createElement('button');
+    fileBtn.type = 'button';
+    fileBtn.className = 'hwx-avatar-btn';
+    fileBtn.textContent = getAvatar() ? 'Change image…' : 'Upload image…';
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/png,image/jpeg,image/gif,image/webp';
+    input.style.display = 'none';
+    fileBtn.addEventListener('click', () => input.click());
+    input.addEventListener('change', () => {
+      const f = input.files && input.files[0];
+      if (!f) return;
+      setStatus('Processing…');
+      downscaleToDataUrl(f, (dataUrl, err) => {
+        if (err) { setStatus(err); return; }
+        setAvatar(dataUrl);
+        closePicker();
+      });
+    });
+    picker.appendChild(fileBtn);
+    picker.appendChild(input);
+
+    if (getAvatar()) {
+      const clearBtn = document.createElement('button');
+      clearBtn.type = 'button';
+      clearBtn.className = 'hwx-avatar-btn hwx-avatar-btn--clear';
+      clearBtn.textContent = 'Remove avatar';
+      clearBtn.addEventListener('click', () => { setAvatar(''); closePicker(); });
+      picker.appendChild(clearBtn);
+    }
+
+    const status = document.createElement('div');
+    status.className = 'hwx-avatar-status';
+    status.id = 'hwxAvatarStatus';
+    picker.appendChild(status);
+
+    document.body.appendChild(picker);
+    position(anchor);
+    document.addEventListener('pointerdown', outside, true);
+    document.addEventListener('keydown', esc, true);
+  }
+
+  function setStatus(msg) {
+    const s = document.getElementById('hwxAvatarStatus');
+    if (s) s.textContent = msg || '';
+  }
+
+  function position(anchor) {
+    if (!picker || !anchor) return;
+    const r = anchor.getBoundingClientRect();
+    const w = picker.offsetWidth || 200;
+    let left = r.left;
+    if (left + w > window.innerWidth - 8) left = window.innerWidth - w - 8;
+    if (left < 8) left = 8;
+    picker.style.left = left + 'px';
+    let top = r.bottom + 6;
+    const h = picker.offsetHeight || 0;
+    if (top + h > window.innerHeight - 8) top = Math.max(8, r.top - h - 6);
+    picker.style.top = top + 'px';
+  }
+
+  // ── observe transcript re-renders ────────────────────────────────────────
+  let raf = false;
+  function schedule() {
+    if (raf) return;
+    raf = true;
+    requestAnimationFrame(() => { raf = false; try { applyAll(); } catch (_) {} });
+  }
+
+  function startObserver() {
+    const container = document.getElementById('messages') || document.body;
+    if (observer) return true;
+    observer = new MutationObserver(schedule);
+    observer.observe(container, { childList: true, subtree: true });
+    return true;
+  }
+
+  function install(attempt) {
+    attempt = attempt || 0;
+    if (document.getElementById('messages') || document.querySelector('.role-icon.assistant')) {
+      startObserver();
+      applyAll();
+      window.HermesCustomAvatarExtension = {
+        version: '0.1.0',
+        get: getAvatar,
+        set: (dataUrl) => { if (isDataImage(dataUrl)) setAvatar(dataUrl); return getAvatar(); },
+        clear: () => setAvatar(''),
+        refresh: applyAll,
+      };
+      return true;
+    }
+    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
+    console.warn('[' + EXT + '] messages container not found; not installed');
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/custom-avatar/extension.json
+++ b/extensions/custom-avatar/extension.json
@@ -1,0 +1,49 @@
+{
+  "id": "custom-avatar",
+  "name": "Custom Assistant Avatar",
+  "description": "Give the assistant a custom avatar image in the chat transcript. Click any assistant avatar badge to upload or clear an image; it's downscaled and stored locally and re-applied as the transcript re-renders.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/custom-avatar.js"
+    ],
+    "stylesheets": [
+      "assets/custom-avatar.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-assistant-avatar"
+      ],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false
+  }
+}

--- a/extensions/custom-avatar/manifest.json
+++ b/extensions/custom-avatar/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "custom-avatar",
+      "name": "Custom Assistant Avatar",
+      "description": "Give the assistant a custom avatar image in the chat transcript.",
+      "scripts": [
+        "assets/custom-avatar.js"
+      ],
+      "stylesheets": [
+        "assets/custom-avatar.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **`custom-avatar`** extension — give the assistant a custom avatar image in the chat transcript. The assistant's role badge is normally a single-letter glyph; this swaps in an image of your choice.

- Click any assistant avatar badge (`.role-icon.assistant`) → a small picker to upload or clear an image.
- The image is **downscaled to a 64×64 square** (in-browser `<canvas>`) and stored as a small data-URL in `localStorage`.
- Re-applied to every assistant turn after the transcript re-renders (streaming/scroll/reload) via a `MutationObserver`; falls back to the letter glyph when cleared.
- Pure DOM-injection, image processed entirely in-browser (**never uploaded**) — no core changes, no backend.

## Scope note + why no core bug was filed

This customizes the **assistant** avatar because that's the avatar element that exists. The WebUI deliberately renders **no avatar on user messages** (right-aligned bubble; position identifies the sender), so there's no user-side avatar slot.

The backlog flagged a possible core bug from closed issue #2677 ("assistant shows the user's avatar"). I checked empirically: **on current master there are no avatar images at all** — both roles render letter glyphs — so that bug does not reproduce, and I did **not** file a spurious core issue. This extension adds the personalization layer instead.

## End-to-end verification (live browser)

Tested against real assistant turns (mock provider) via headless Chrome/CDP:

- ✅ extension loads; assistant role badge present after a turn
- ✅ setting an avatar replaces the glyph with an `<img>` (glyph hidden, set-class added)
- ✅ a **new assistant turn also gets the avatar** (MutationObserver re-apply)
- ✅ **persists across full reload** and re-applies to all assistant turns
- ✅ **clear** removes it from storage and **restores the letter glyph** ("H")
- ✅ picker UI opens cleanly under the badge ("Assistant avatar" + Upload button) — visually confirmed
- ✅ repo gates green: validate / safety-scan / registry / validator self-test

## Permissions disclosure (cross-checked against the code)

- `webui_api.read/write: []` — no `fetch`/`/api/*`
- `network_external: false` — the image never leaves the browser (FileReader + canvas only)
- `storage.owned: ["hermes-ext-assistant-avatar"]` — the one key written (a downscaled data-URL)
- `dom.owned: true`, `dom.mutates_core_views: true` — injects an `<img>` into the assistant badge + a picker popover
- only validated `data:image/(png|jpeg|gif|webp);base64,…` values are ever applied

## Known limitations

- Assistant-only (the user role has no avatar slot by design).
- Per-browser (`localStorage`), not synced across devices.
- Relies on the `.role-icon.assistant` badge; a core rename would need an update.

🤖 Agent-authored; flagging for review, not self-merging.
