### PR TITLE
Add external-app-tab extension (pin a compatible self-hosted web app via iframe)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -39,3 +39,6 @@ need it and maintainers agree on the shared contract.
   Appearance picker via the theme-registration API.
 - `mobile-haptics`: short device vibration when an assistant turn finishes
   (Android / Android-PWA; no-ops on desktop and iOS).
+- `external-app-tab`: pin a self-hosted web app (Grafana, Vaultwarden, a
+  dashboard) as a tab inside the WebUI via an iframe (needs the core
+  `HERMES_WEBUI_CSP_FRAME_EXTRA` knob for external origins).

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -39,6 +39,6 @@ need it and maintainers agree on the shared contract.
   Appearance picker via the theme-registration API.
 - `mobile-haptics`: short device vibration when an assistant turn finishes
   (Android / Android-PWA; no-ops on desktop and iOS).
-- `external-app-tab`: pin a self-hosted web app (Grafana, Vaultwarden, a
-  dashboard) as a tab inside the WebUI via an iframe (needs the core
-  `HERMES_WEBUI_CSP_FRAME_EXTRA` knob for external origins).
+- `external-app-tab`: pin a compatible self-hosted web app (Grafana, a
+  dashboard, or another framable tool) as a tab inside the WebUI via an iframe
+  (needs the core `HERMES_WEBUI_CSP_FRAME_EXTRA` knob for external origins).

--- a/extensions/external-app-tab/README.md
+++ b/extensions/external-app-tab/README.md
@@ -91,9 +91,18 @@ This is trusted local code. Current disclosed behavior:
 - does NOT access cookies, loopback sidecars, the filesystem, or native hosts
 - does NOT itself `fetch()` any remote resource — it only sets an iframe `src`
 
-The embedded app runs in its own browsing context (a separate origin in its own
-iframe); it cannot read the WebUI's DOM or session. All user-supplied strings
-(label, URL) are escaped where rendered.
+The embedded app runs in its own `<iframe>` with an explicit `sandbox`
+allow-list: `allow-scripts allow-forms allow-popups
+allow-popups-to-escape-sandbox allow-same-origin allow-downloads`. This lets a
+real web app function (run its scripts, submit forms, open links/downloads)
+while still being a sandboxed frame. **Honest tradeoff:** a functional app
+generally needs both `allow-scripts` and `allow-same-origin`, and that pairing
+relaxes the sandbox's origin barrier — so for a **same-origin** target the frame
+is effectively trusted browser content, not strongly isolated. Treat any app you
+embed as trusted: you opt in per-origin by allow-listing it via
+`HERMES_WEBUI_CSP_FRAME_EXTRA`, and cross-origin targets remain bounded by the
+same-origin policy. All user-supplied strings (label, URL) are escaped where
+rendered.
 
 ## Compatibility
 

--- a/extensions/external-app-tab/README.md
+++ b/extensions/external-app-tab/README.md
@@ -1,9 +1,9 @@
 # External App Tab
 
 External App Tab is a trusted local Hermes WebUI extension that pins a
-self-hosted web app — Grafana, Vaultwarden, Linkwarden, a personal dashboard —
-as a tab inside the WebUI via an `<iframe>`. It adds a button to the left rail
-that opens a full-area panel framing a URL you configure.
+compatible self-hosted web app — Grafana, Vaultwarden, Linkwarden, a personal
+dashboard — as a tab inside the WebUI via an `<iframe>`. It adds a button to
+the left rail that opens a full-area panel framing a URL you configure.
 
 It works best for **framable dashboards, status pages, and local tools** that
 don't require a cross-origin cookie login. It provides an iframe slot — not a

--- a/extensions/external-app-tab/README.md
+++ b/extensions/external-app-tab/README.md
@@ -1,9 +1,14 @@
 # External App Tab
 
-External App Tab is a trusted local Hermes WebUI extension that pins any
+External App Tab is a trusted local Hermes WebUI extension that pins a
 self-hosted web app — Grafana, Vaultwarden, Linkwarden, a personal dashboard —
 as a tab inside the WebUI via an `<iframe>`. It adds a button to the left rail
 that opens a full-area panel framing a URL you configure.
+
+It works best for **framable dashboards, status pages, and local tools** that
+don't require a cross-origin cookie login. It provides an iframe slot — not a
+guarantee that any arbitrary app will work correctly embedded (see **Known
+Limitations** for the third-party-iframe auth/cookie caveats).
 
 ## What It Does
 
@@ -135,7 +140,23 @@ Manual verification:
 
 - External origins require the operator to allow them via
   `HERMES_WEBUI_CSP_FRAME_EXTRA` (PR #5091) — a deliberate security boundary.
+  This is **necessary but not sufficient**: it answers "may Hermes embed this
+  origin?", not "will this app work correctly embedded?"
 - Some sites send `X-Frame-Options: DENY` / their own `frame-ancestors` and
   refuse to be embedded by anyone; those can't be framed (open them in a new tab
   instead). This is the remote site's choice, not a WebUI limitation.
+- **Authenticated apps may fail inside the iframe even when the origin is
+  allow-listed.** An embedded app runs in a third-party (cross-origin) context,
+  so its session cookies may not be sent from inside the iframe — third-party
+  cookie blocking, `SameSite`, `Secure`/HTTPS requirements, and the target app's
+  own frame/cookie policy all apply. A common failure mode: login succeeds
+  (the app creates a server-side session) but the next in-frame request returns
+  401 because the browser withheld the session cookie in the embedded context.
+  This is the normal browser security boundary — the extension can't fix it with
+  frontend JS.
+- **If login succeeds but the embedded app stays logged out / returns 401**, use
+  **Open in new tab**, or configure the target app for iframe use. Stable
+  embedded login usually requires a same-origin reverse proxy, or HTTPS plus
+  appropriate cookie settings (`SameSite=None; Secure`) and a framing policy that
+  permits embedding.
 - One app at a time (single configured URL).

--- a/extensions/external-app-tab/README.md
+++ b/extensions/external-app-tab/README.md
@@ -1,0 +1,132 @@
+# External App Tab
+
+External App Tab is a trusted local Hermes WebUI extension that pins any
+self-hosted web app — Grafana, Vaultwarden, Linkwarden, a personal dashboard —
+as a tab inside the WebUI via an `<iframe>`. It adds a button to the left rail
+that opens a full-area panel framing a URL you configure.
+
+## What It Does
+
+- Adds a rail button (with the content tabs, above Settings).
+- Clicking it opens a full-area overlay with a top bar (title, **Configure**,
+  **Open ↗**, **Close**) and the framed app below.
+- **Configure** dialog: set a label + an `http(s)` URL; stored locally.
+- Falls back to a "no app configured" prompt until you set a URL.
+- Escape or the ✕ closes the overlay; the rail stays accessible.
+
+## ⚠️ CSP dependency (read this)
+
+The WebUI's Content-Security-Policy only allows framing **same-origin** content
+by default. To frame an **external** origin, the operator must allow it via the
+core knob (added in `nesquena/hermes-webui` **PR #5091**):
+
+```bash
+export HERMES_WEBUI_CSP_FRAME_EXTRA="https://your-app.example.com"
+```
+
+- A **same-origin** or **loopback-reverse-proxied** URL works with **no** core
+  change.
+- If the configured URL is blocked by CSP, the browser refuses to load the frame
+  (it stays blank). The overlay shows a hint with the exact
+  `HERMES_WEBUI_CSP_FRAME_EXTRA` value to set.
+- On a WebUI build **without** PR #5091, only same-origin URLs can be framed.
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/external-app-tab.js + .css
+  -> rail button -> full-area overlay -> <iframe src="<your URL>">
+  -> localStorage: hermes-ext-external-app  ({ url, label })
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, or use native host APIs. It does not fetch anything
+itself; it only sets an `<iframe src>`, which the browser loads subject to the
+page's CSP.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+# allow your app's origin to be framed (external origins only):
+HERMES_WEBUI_CSP_FRAME_EXTRA="https://your-app.example.com" \
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/external-app-tab \
+HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json \
+./start.sh
+```
+
+Click the new rail button, **Configure**, enter the URL, and Save.
+
+## Controls
+
+Also on `window.HermesExternalAppTabExtension`:
+
+- `.getConfig()` → `{ url, label }`
+- `.setConfig(url, label)` — set (rejects non-http(s) URLs)
+- `.open()` / `.close()` — toggle the overlay
+
+## Disable And Uninstall
+
+Restart Hermes WebUI without `HERMES_WEBUI_EXTENSION_DIR` /
+`HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the `extensions/external-app-tab/`
+directory. Config lives under the `hermes-ext-external-app` localStorage key.
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- creates extension-owned DOM (a rail button, a full-area overlay, a config
+  dialog)
+- embeds a **user-configured external URL** in an `<iframe>`
+  (`permissions.network_external: true`) — this is the whole point of the
+  extension; the URL is whatever the operator sets and is subject to the page CSP
+- reads and writes `localStorage` under the single key `hermes-ext-external-app`
+- does NOT call WebUI HTTP APIs
+- does NOT access cookies, loopback sidecars, the filesystem, or native hosts
+- does NOT itself `fetch()` any remote resource — it only sets an iframe `src`
+
+The embedded app runs in its own browsing context (a separate origin in its own
+iframe); it cannot read the WebUI's DOM or session. All user-supplied strings
+(label, URL) are escaped where rendered.
+
+## Compatibility
+
+- manifest-bundled extension assets + same-origin serving under `/extensions/`
+- the left rail (`.rail`) to host the button
+- for external origins: the core `HERMES_WEBUI_CSP_FRAME_EXTRA` knob (PR #5091)
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/external-app-tab/assets/external-app-tab.js
+python3 -m json.tool extensions/external-app-tab/extension.json
+python3 -m json.tool extensions/external-app-tab/manifest.json
+```
+
+Manual verification:
+
+- the rail button appears; clicking it opens the overlay
+- with no URL set, the empty-state prompt + Configure appear
+- configuring a same-origin URL frames it immediately
+- configuring an external URL frames it when `HERMES_WEBUI_CSP_FRAME_EXTRA`
+  allows that origin; otherwise the frame is blank and the CSP hint is shown
+- Open ↗ opens the URL in a new tab; Close / Escape closes the overlay
+- the config (label + URL) persists across a reload
+
+## Known Limitations
+
+- External origins require the operator to allow them via
+  `HERMES_WEBUI_CSP_FRAME_EXTRA` (PR #5091) — a deliberate security boundary.
+- Some sites send `X-Frame-Options: DENY` / their own `frame-ancestors` and
+  refuse to be embedded by anyone; those can't be framed (open them in a new tab
+  instead). This is the remote site's choice, not a WebUI limitation.
+- One app at a time (single configured URL).

--- a/extensions/external-app-tab/assets/external-app-tab.css
+++ b/extensions/external-app-tab/assets/external-app-tab.css
@@ -1,0 +1,137 @@
+/* External App Tab extension for Hermes WebUI.
+   Scoped to hwx-extapp-* classes; uses core CSS variables for theme-fit. */
+
+/* Full-area overlay framing the external app (covers the main content area,
+   leaving the rail accessible). */
+.hwx-extapp-overlay {
+  position: fixed;
+  inset: 0 0 0 0;
+  z-index: 60;
+  display: none;
+  flex-direction: column;
+  background: var(--bg, #11131a);
+}
+/* Leave the left rail clickable by insetting the overlay past it where the rail
+   is a fixed-width column. Falls back to full-width on narrow screens. */
+@media (min-width: 641px) {
+  .hwx-extapp-overlay { left: 56px; }
+}
+
+.hwx-extapp-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border, rgba(127,127,127,.3));
+  background: var(--surface, #1a1d27);
+  flex: 0 0 auto;
+}
+.hwx-extapp-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text, #fff);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 50%;
+}
+.hwx-extapp-spacer { flex: 1 1 auto; }
+.hwx-extapp-btn {
+  appearance: none;
+  border: 1px solid var(--border2, rgba(127,127,127,.25));
+  background: var(--code-bg, rgba(127,127,127,.1));
+  color: var(--text, #fff);
+  border-radius: 7px;
+  padding: 5px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background .12s ease, border-color .12s ease;
+}
+.hwx-extapp-btn:hover {
+  background: var(--hover-bg, rgba(127,127,127,.16));
+  border-color: var(--border, rgba(127,127,127,.4));
+}
+.hwx-extapp-close { font-size: 13px; line-height: 1; }
+
+.hwx-extapp-body {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.hwx-extapp-iframe {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+}
+.hwx-extapp-cspnote {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--muted, #888);
+  padding: 6px 12px;
+  border-top: 1px solid var(--border2, rgba(127,127,127,.2));
+  background: var(--surface, #1a1d27);
+}
+.hwx-extapp-cspnote code,
+.hwx-extapp-config-note code {
+  background: var(--code-bg, rgba(127,127,127,.15));
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.hwx-extapp-empty {
+  margin: auto;
+  text-align: center;
+  color: var(--text, #fff);
+  max-width: 360px;
+  padding: 24px;
+}
+.hwx-extapp-empty .hwx-extapp-muted { color: var(--muted, #888); font-size: 13px; }
+.hwx-extapp-empty .hwx-extapp-btn { margin-top: 12px; }
+
+/* Config dialog */
+.hwx-extapp-config-dlg {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,.45);
+}
+.hwx-extapp-config-card {
+  width: min(440px, 92vw);
+  background: var(--surface, #1a1d27);
+  color: var(--text, #fff);
+  border: 1px solid var(--border, rgba(127,127,127,.3));
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0,0,0,.4);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.hwx-extapp-config-title { font-weight: 700; font-size: 15px; }
+.hwx-extapp-field { display: flex; flex-direction: column; gap: 5px; font-size: 12px; color: var(--muted, #888); }
+.hwx-extapp-input {
+  appearance: none;
+  border: 1px solid var(--border2, rgba(127,127,127,.3));
+  background: var(--bg, #11131a);
+  color: var(--text, #fff);
+  border-radius: 7px;
+  padding: 8px 10px;
+  font-size: 13px;
+}
+.hwx-extapp-input:focus { outline: none; border-color: var(--accent, #6366f1); }
+.hwx-extapp-config-note { font-size: 11px; color: var(--muted, #888); line-height: 1.5; }
+.hwx-extapp-config-err { font-size: 12px; color: var(--danger, #e5534b); }
+.hwx-extapp-config-actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .hwx-extapp-btn { transition: none; }
+}

--- a/extensions/external-app-tab/assets/external-app-tab.css
+++ b/extensions/external-app-tab/assets/external-app-tab.css
@@ -11,10 +11,13 @@
   flex-direction: column;
   background: var(--bg, #11131a);
 }
-/* Leave the left rail clickable by insetting the overlay past it where the rail
-   is a fixed-width column. Falls back to full-width on narrow screens. */
+/* Leave the left rail clickable by insetting the overlay past it. Core's rail is
+   48px wide and only shown at min-width:641px (.rail{width:48px} +
+   @media(min-width:641px){.rail{display:flex}}). Match both so the overlay never
+   covers the rail nor leaves a background sliver. Full-width below the breakpoint
+   where the rail is hidden. */
 @media (min-width: 641px) {
-  .hwx-extapp-overlay { left: 56px; }
+  .hwx-extapp-overlay { left: 48px; }
 }
 
 .hwx-extapp-bar {

--- a/extensions/external-app-tab/assets/external-app-tab.js
+++ b/extensions/external-app-tab/assets/external-app-tab.js
@@ -1,0 +1,250 @@
+(() => {
+  'use strict';
+
+  // ── External App Tab extension for Hermes WebUI ──────────────────────────
+  // Pins any self-hosted web app (Grafana, Vaultwarden, a personal dashboard…)
+  // as a tab inside the WebUI via an <iframe>. Adds a rail button that opens a
+  // full-area overlay panel framing a user-configured URL.
+  //
+  // IMPORTANT — CSP dependency:
+  //   The WebUI's Content-Security-Policy only allows framing same-origin
+  //   content by default. To frame an EXTERNAL origin, the operator must allow
+  //   it via the core knob (nesquena/hermes-webui PR #5091):
+  //       export HERMES_WEBUI_CSP_FRAME_EXTRA="https://your-app.example.com"
+  //   A same-origin or loopback-reverse-proxied URL works without any core
+  //   change. If the configured URL is blocked by CSP, the browser refuses to
+  //   load the frame; the extension shows a hint explaining the knob.
+  //
+  // Pure DOM-injection + localStorage. No backend, no network calls of its own
+  // (it only sets an <iframe src>, which the browser loads under the page CSP).
+
+  const EXT = 'external-app-tab';
+  if (window.__hermesExternalAppTabLoaded) return;
+  window.__hermesExternalAppTabLoaded = true;
+
+  const CFG_KEY = 'hermes-ext-external-app';   // { url, label }
+  const RAIL_BTN_ID = 'hwxExtAppRailBtn';
+  const OVERLAY_ID = 'hwxExtAppOverlay';
+
+  let overlayOpen = false;
+
+  function loadCfg() {
+    try {
+      const raw = localStorage.getItem(CFG_KEY);
+      if (!raw) return { url: '', label: 'App' };
+      const c = JSON.parse(raw);
+      return { url: typeof c.url === 'string' ? c.url : '', label: (c && c.label) || 'App' };
+    } catch (_) { return { url: '', label: 'App' }; }
+  }
+  function saveCfg(cfg) {
+    try { localStorage.setItem(CFG_KEY, JSON.stringify(cfg)); } catch (_) {}
+  }
+
+  // Only http(s) absolute URLs are accepted (an iframe src must be http(s)).
+  function validUrl(s) {
+    if (typeof s !== 'string' || !s) return false;
+    try {
+      const u = new URL(s);
+      return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch (_) { return false; }
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  // ── rail button ──────────────────────────────────────────────────────────
+  function railIcon() {
+    return '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+      'stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/>' +
+      '<path d="M15 21V9"/></svg>';
+  }
+
+  function ensureRailButton() {
+    if (document.getElementById(RAIL_BTN_ID)) return document.getElementById(RAIL_BTN_ID);
+    const rail = document.querySelector('.rail');
+    if (!rail) return null;
+    const btn = document.createElement('button');
+    btn.id = RAIL_BTN_ID;
+    btn.type = 'button';
+    btn.className = 'rail-btn nav-tab has-tooltip hwx-extapp-rail';
+    const cfg = loadCfg();
+    btn.dataset.tooltip = cfg.label || 'App';
+    btn.setAttribute('aria-label', cfg.label || 'External app');
+    btn.innerHTML = railIcon();
+    btn.addEventListener('click', (ev) => { ev.preventDefault(); toggleOverlay(); });
+    // Insert just before the rail spacer (so it sits with the content tabs,
+    // above settings), or append if there's no spacer.
+    const spacer = rail.querySelector('.rail-spacer');
+    if (spacer) rail.insertBefore(btn, spacer);
+    else rail.appendChild(btn);
+    return btn;
+  }
+
+  // ── overlay panel with the iframe ────────────────────────────────────────
+  function buildOverlay() {
+    let ov = document.getElementById(OVERLAY_ID);
+    if (ov) return ov;
+    ov = document.createElement('div');
+    ov.id = OVERLAY_ID;
+    ov.className = 'hwx-extapp-overlay';
+    ov.style.display = 'none';
+    ov.innerHTML =
+      '<div class="hwx-extapp-bar">' +
+        '<span class="hwx-extapp-title"></span>' +
+        '<span class="hwx-extapp-spacer"></span>' +
+        '<button type="button" class="hwx-extapp-btn hwx-extapp-config" title="Configure">Configure</button>' +
+        '<button type="button" class="hwx-extapp-btn hwx-extapp-open" title="Open in new tab">Open ↗</button>' +
+        '<button type="button" class="hwx-extapp-btn hwx-extapp-close" title="Close" aria-label="Close">✕</button>' +
+      '</div>' +
+      '<div class="hwx-extapp-body"></div>';
+    document.body.appendChild(ov);
+    ov.querySelector('.hwx-extapp-close').addEventListener('click', () => closeOverlay());
+    ov.querySelector('.hwx-extapp-config').addEventListener('click', () => openConfig());
+    ov.querySelector('.hwx-extapp-open').addEventListener('click', () => {
+      const cfg = loadCfg();
+      if (validUrl(cfg.url)) window.open(cfg.url, '_blank', 'noopener');
+    });
+    return ov;
+  }
+
+  function renderOverlayContent() {
+    const ov = buildOverlay();
+    const cfg = loadCfg();
+    ov.querySelector('.hwx-extapp-title').textContent = cfg.label || 'External app';
+    const body = ov.querySelector('.hwx-extapp-body');
+    body.innerHTML = '';
+    if (!validUrl(cfg.url)) {
+      const empty = document.createElement('div');
+      empty.className = 'hwx-extapp-empty';
+      empty.innerHTML =
+        '<p>No app configured yet.</p>' +
+        '<p class="hwx-extapp-muted">Set a URL to embed a self-hosted web app as a tab.</p>' +
+        '<button type="button" class="hwx-extapp-btn hwx-extapp-config-cta">Configure…</button>';
+      empty.querySelector('.hwx-extapp-config-cta').addEventListener('click', () => openConfig());
+      body.appendChild(empty);
+      return;
+    }
+    const frame = document.createElement('iframe');
+    frame.className = 'hwx-extapp-iframe';
+    frame.src = cfg.url;
+    frame.setAttribute('title', cfg.label || 'External app');
+    // Sandboxed but functional; allow the framed app its own scripts/forms.
+    frame.setAttribute('referrerpolicy', 'no-referrer');
+    // A CSP frame-src block surfaces as a blank frame; show a hint underneath
+    // that the operator may need HERMES_WEBUI_CSP_FRAME_EXTRA.
+    const hint = document.createElement('div');
+    hint.className = 'hwx-extapp-cspnote';
+    hint.innerHTML = 'If this stays blank, the page may be blocked by the WebUI ' +
+      'Content-Security-Policy. Allow it (operator) with ' +
+      '<code>HERMES_WEBUI_CSP_FRAME_EXTRA="' + escapeHtml(originOf(cfg.url)) + '"</code>.';
+    body.appendChild(frame);
+    body.appendChild(hint);
+  }
+
+  function originOf(u) { try { return new URL(u).origin; } catch (_) { return u; } }
+
+  function toggleOverlay() { overlayOpen ? closeOverlay() : openOverlay(); }
+
+  function openOverlay() {
+    renderOverlayContent();
+    const ov = document.getElementById(OVERLAY_ID);
+    ov.style.display = 'flex';
+    overlayOpen = true;
+    const btn = document.getElementById(RAIL_BTN_ID);
+    if (btn) btn.classList.add('active');
+    document.addEventListener('keydown', escClose, true);
+  }
+  function closeOverlay() {
+    const ov = document.getElementById(OVERLAY_ID);
+    if (ov) ov.style.display = 'none';
+    overlayOpen = false;
+    const btn = document.getElementById(RAIL_BTN_ID);
+    if (btn) btn.classList.remove('active');
+    document.removeEventListener('keydown', escClose, true);
+  }
+  function escClose(ev) { if (ev.key === 'Escape') closeOverlay(); }
+
+  // ── config dialog ────────────────────────────────────────────────────────
+  function openConfig() {
+    const cfg = loadCfg();
+    let dlg = document.getElementById('hwxExtAppConfig');
+    if (dlg) dlg.remove();
+    dlg = document.createElement('div');
+    dlg.id = 'hwxExtAppConfig';
+    dlg.className = 'hwx-extapp-config-dlg';
+    dlg.innerHTML =
+      '<div class="hwx-extapp-config-card" role="dialog" aria-label="Configure external app">' +
+        '<div class="hwx-extapp-config-title">External app tab</div>' +
+        '<label class="hwx-extapp-field"><span>Label</span>' +
+          '<input type="text" class="hwx-extapp-input hwx-extapp-label-in" maxlength="24" placeholder="App"></label>' +
+        '<label class="hwx-extapp-field"><span>URL (http/https)</span>' +
+          '<input type="url" class="hwx-extapp-input hwx-extapp-url-in" placeholder="https://app.example.com"></label>' +
+        '<div class="hwx-extapp-config-note">To frame an external origin, the operator must allow it via ' +
+          '<code>HERMES_WEBUI_CSP_FRAME_EXTRA</code>. Same-origin / loopback URLs work without it.</div>' +
+        '<div class="hwx-extapp-config-err" hidden></div>' +
+        '<div class="hwx-extapp-config-actions">' +
+          '<button type="button" class="hwx-extapp-btn hwx-extapp-cancel">Cancel</button>' +
+          '<button type="button" class="hwx-extapp-btn hwx-extapp-save">Save</button>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(dlg);
+    const labelIn = dlg.querySelector('.hwx-extapp-label-in');
+    const urlIn = dlg.querySelector('.hwx-extapp-url-in');
+    const err = dlg.querySelector('.hwx-extapp-config-err');
+    labelIn.value = cfg.label || '';
+    urlIn.value = cfg.url || '';
+    const close = () => dlg.remove();
+    dlg.querySelector('.hwx-extapp-cancel').addEventListener('click', close);
+    dlg.addEventListener('click', (e) => { if (e.target === dlg) close(); });
+    dlg.querySelector('.hwx-extapp-save').addEventListener('click', () => {
+      const url = urlIn.value.trim();
+      const label = (labelIn.value.trim() || 'App').slice(0, 24);
+      if (url && !validUrl(url)) {
+        err.hidden = false;
+        err.textContent = 'Enter a valid http(s) URL (or leave blank to clear).';
+        return;
+      }
+      saveCfg({ url, label });
+      // refresh rail tooltip + overlay
+      const btn = document.getElementById(RAIL_BTN_ID);
+      if (btn) { btn.dataset.tooltip = label; btn.setAttribute('aria-label', label); }
+      if (overlayOpen) renderOverlayContent();
+      close();
+    });
+  }
+
+  function install(attempt) {
+    attempt = attempt || 0;
+    if (document.querySelector('.rail')) {
+      ensureRailButton();
+      window.HermesExternalAppTabExtension = {
+        version: '0.1.0',
+        getConfig: loadCfg,
+        setConfig(url, label) {
+          if (url && !validUrl(url)) return false;
+          saveCfg({ url: url || '', label: (label || 'App').slice(0, 24) });
+          const btn = document.getElementById(RAIL_BTN_ID);
+          if (btn) { const c = loadCfg(); btn.dataset.tooltip = c.label; btn.setAttribute('aria-label', c.label); }
+          if (overlayOpen) renderOverlayContent();
+          return true;
+        },
+        open: openOverlay,
+        close: closeOverlay,
+      };
+      return true;
+    }
+    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
+    console.warn('[' + EXT + '] rail not found; not installed');
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/external-app-tab/assets/external-app-tab.js
+++ b/extensions/external-app-tab/assets/external-app-tab.js
@@ -2,9 +2,9 @@
   'use strict';
 
   // ── External App Tab extension for Hermes WebUI ──────────────────────────
-  // Pins any self-hosted web app (Grafana, Vaultwarden, a personal dashboard…)
-  // as a tab inside the WebUI via an <iframe>. Adds a rail button that opens a
-  // full-area overlay panel framing a user-configured URL.
+  // Pins a compatible self-hosted web app (Grafana, Vaultwarden, a personal
+  // dashboard) as a tab inside the WebUI via an <iframe>. Adds a rail button
+  // that opens a full-area overlay panel framing a user-configured URL.
   //
   // IMPORTANT — CSP dependency:
   //   The WebUI's Content-Security-Policy only allows framing same-origin
@@ -122,7 +122,7 @@
       empty.className = 'hwx-extapp-empty';
       empty.innerHTML =
         '<p>No app configured yet.</p>' +
-        '<p class="hwx-extapp-muted">Set a URL to embed a self-hosted web app as a tab.</p>' +
+        '<p class="hwx-extapp-muted">Set a URL to embed a compatible self-hosted web app as a tab.</p>' +
         '<button type="button" class="hwx-extapp-btn hwx-extapp-config-cta">Configure…</button>';
       empty.querySelector('.hwx-extapp-config-cta').addEventListener('click', () => openConfig());
       body.appendChild(empty);

--- a/extensions/external-app-tab/assets/external-app-tab.js
+++ b/extensions/external-app-tab/assets/external-app-tab.js
@@ -132,7 +132,14 @@
     frame.className = 'hwx-extapp-iframe';
     frame.src = cfg.url;
     frame.setAttribute('title', cfg.label || 'External app');
-    // Sandboxed but functional; allow the framed app its own scripts/forms.
+    // Sandbox the embedded app with an explicit, documented allow-list so it can
+    // function (scripts/forms/popups) while staying constrained (Frank, PR #25:
+    // the previous comment claimed "sandboxed" but never set a sandbox attr).
+    // Tradeoff: a real web app generally needs allow-scripts + allow-same-origin
+    // to work; for a SAME-ORIGIN target that pairing relaxes the origin barrier,
+    // so the README is explicit that an embedded app is trusted browser content
+    // once the operator allow-lists its origin via HERMES_WEBUI_CSP_FRAME_EXTRA.
+    frame.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-downloads');
     frame.setAttribute('referrerpolicy', 'no-referrer');
     // A CSP frame-src block surfaces as a blank frame; show a hint underneath
     // that the operator may need HERMES_WEBUI_CSP_FRAME_EXTRA.

--- a/extensions/external-app-tab/extension.json
+++ b/extensions/external-app-tab/extension.json
@@ -1,7 +1,7 @@
 {
   "id": "external-app-tab",
   "name": "External App Tab",
-  "description": "Pin any self-hosted web app (Grafana, Vaultwarden, a personal dashboard) as a tab inside Hermes WebUI via an iframe. Adds a rail button that opens a full-area panel framing a configurable URL.",
+  "description": "Pin a compatible self-hosted web app (Grafana, a dashboard, or another framable tool) as a tab inside Hermes WebUI via an iframe. Adds a rail button that opens a full-area panel framing a configurable URL.",
   "version": "0.1.0",
   "author": "nesquena-hermes",
   "assets": {

--- a/extensions/external-app-tab/extension.json
+++ b/extensions/external-app-tab/extension.json
@@ -1,0 +1,51 @@
+{
+  "id": "external-app-tab",
+  "name": "External App Tab",
+  "description": "Pin any self-hosted web app (Grafana, Vaultwarden, a personal dashboard) as a tab inside Hermes WebUI via an iframe. Adds a rail button that opens a full-area panel framing a configurable URL.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/external-app-tab.js"
+    ],
+    "stylesheets": [
+      "assets/external-app-tab.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-external-app"
+      ],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": true,
+    "embeds_iframe": true,
+    "requires_csp_frame_extra": true
+  }
+}

--- a/extensions/external-app-tab/manifest.json
+++ b/extensions/external-app-tab/manifest.json
@@ -3,7 +3,7 @@
     {
       "id": "external-app-tab",
       "name": "External App Tab",
-      "description": "Pin a self-hosted web app as a tab inside Hermes WebUI via an iframe.",
+      "description": "Pin a compatible self-hosted web app as a tab inside Hermes WebUI via an iframe.",
       "scripts": [
         "assets/external-app-tab.js"
       ],

--- a/extensions/external-app-tab/manifest.json
+++ b/extensions/external-app-tab/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "external-app-tab",
+      "name": "External App Tab",
+      "description": "Pin a self-hosted web app as a tab inside Hermes WebUI via an iframe.",
+      "scripts": [
+        "assets/external-app-tab.js"
+      ],
+      "stylesheets": [
+        "assets/external-app-tab.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **`external-app-tab`** extension — pin a compatible self-hosted web app (Grafana, Vaultwarden, Linkwarden, a personal dashboard) as a tab inside the WebUI via an `<iframe>`. Adds a left-rail button that opens a full-area overlay framing a URL you configure.

- Rail button → full-area overlay with a top bar (title, **Configure**, **Open ↗**, **Close**).
- **Configure** dialog: label + `http(s)` URL, stored locally; empty-state prompt until set.
- URL validation (http/https only — rejects `javascript:` etc.); config persists in `localStorage`.
- No backend, **no fetches of its own** — it only sets an `<iframe src>`, loaded by the browser under the page CSP.

## ⚠️ Dependency

To frame an **external** origin, the operator must allow it via the core knob **nesquena/hermes-webui#5091** (`HERMES_WEBUI_CSP_FRAME_EXTRA`):

```bash
export HERMES_WEBUI_CSP_FRAME_EXTRA="https://your-app.example.com"
```

Same-origin / loopback-reverse-proxied URLs need no core change. If a frame is blocked by CSP, the overlay shows a hint with the exact env value to set.

## End-to-end verification (live browser, against the #5091 capability)

- ✅ **the core CSP knob works**: the served header carried `frame-src 'self' https://example.com` (enforced + report-only) when `HERMES_WEBUI_CSP_FRAME_EXTRA` was set
- ✅ rail button appears and opens the overlay
- ✅ empty-state prompt + config dialog render cleanly (visually confirmed)
- ✅ configuring a URL creates the iframe with the correct `src` and updates the title
- ✅ URL validation rejects `javascript:`/non-http; config **persists across reload**
- ✅ Open ↗ / Close / Escape behave; repo gates green (validate / safety-scan / registry / self-test)

**Honest test-environment caveat:** whether a *given remote app actually paints* depends on two things beyond this extension — (1) the operator allowing the origin via `HERMES_WEBUI_CSP_FRAME_EXTRA` (verified working), and (2) the **target app's own** `X-Frame-Options` / `frame-ancestors` permitting embedding (the remote site's choice). The WebUI itself sends `X-Frame-Options: DENY`, so it correctly can't be framed by anyone — including this extension. The isolated test box has no outbound network to a real framable site, so I verified the entire WebUI-side chain (CSP header, iframe creation, src, config, validation) rather than a live remote render. Both realities are documented in the README's Known Limitations.

## Permissions disclosure

- `network_external: true` — the whole point is embedding a user-configured external URL in an iframe (subject to CSP); the extension makes no `fetch()` of its own
- `storage.owned: ["hermes-ext-external-app"]`; `dom.owned: true`/`mutates_core_views: true` (rail button + overlay)
- no WebUI API calls, no cookies, no sidecar/native host; user strings escaped where rendered

🤖 Agent-authored; flagging for review, not self-merging.