### PR TITLE
Add theme-creator extension (build-your-own-theme editor)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -26,3 +26,5 @@ need it and maintainers agree on the shared contract.
   ★ Favorites group at the top of the composer model picker.
 - `custom-avatar`: give the assistant a custom avatar image in the chat
   transcript (downscaled + stored locally; assistant-only).
+- `theme-creator`: build your own theme with a live color editor; custom themes
+  register into the native Appearance picker (needs core theme-registration).

--- a/extensions/theme-creator/README.md
+++ b/extensions/theme-creator/README.md
@@ -31,6 +31,18 @@ still sent through the core `registerHermesSkin` **sanitizer**, so an invalid or
 malicious color value can never be applied — the core capability is the single
 security chokepoint.
 
+## Code / chat surface coverage
+
+The core `registerHermesSkin()` allowlist excludes a few code/chat-surface tokens
+(`--strong`, `--code-inline-bg`, `--pre-text`, `--input-bg`) and emits no
+dark-mode variant, so on a mismatched base theme a custom theme's inline code and
+code blocks would inherit the base-theme values and could render unreadable. To
+cover that, the extension emits its own managed `<style>` (id
+`hwxThemeCreatorCodeStyles`) with those tokens derived from each saved theme's
+(and the live preview's) own palette, under both `:root[data-skin]` and
+`:root.dark[data-skin]`, so a custom theme composes cleanly in Light, Dark, and
+System Default base modes. The block is refreshed on register/save/preview/delete.
+
 ## Dependency
 
 Requires the core **theme-registration capability** (`window.registerHermesSkin`),

--- a/extensions/theme-creator/README.md
+++ b/extensions/theme-creator/README.md
@@ -101,14 +101,22 @@ This is trusted local code. Current disclosed behavior:
 
 - creates extension-owned DOM (a rail button + the editor panel)
 - calls `window.registerHermesSkin(...)` with derived, sanitized color tokens
+- injects a small extension-managed `<style>` (`hwxThemeCreatorCodeStyles`) for
+  per-theme code/chat token coverage, using validated hex/rgba values only
 - reads/writes `localStorage`:
-  - **owned:** `hermes-ext-custom-themes` (your saved themes)
+  - **owned:** `hermes-ext-custom-themes` (your saved themes; validated on read,
+    capped at 50 themes / 256 KB)
   - **shared:** `hermes-skin` — the core skin-selection key, written to apply a
     theme (the same key the built-in Appearance picker uses)
-- does NOT call WebUI HTTP APIs, access cookies, contact any network, or use the
-  filesystem / native hosts
-- all rendered text (theme names) is escaped; all colors are validated hex and
-  re-sanitized by the core registration API
+- applies a theme through the core `window._pickSkin()` path when available, which
+  commits the appearance change immediately — i.e. core **autosaves appearance via
+  an authenticated `POST /api/settings`** as a side effect (disclosed as
+  `webui_api.write: ["settings"]`). The extension itself issues no other HTTP calls.
+- does NOT access cookies, contact any external network, or use the filesystem /
+  native hosts
+- all rendered text (theme names) is escaped; theme records are validated on read
+  (key grammar + hex base colors); all colors are validated hex and re-sanitized by
+  the core registration API
 
 ## Compatibility
 

--- a/extensions/theme-creator/README.md
+++ b/extensions/theme-creator/README.md
@@ -1,0 +1,135 @@
+# Theme Creator
+
+Theme Creator is a trusted local Hermes WebUI extension that lets you **build your
+own theme**. Pick colors for the key design tokens, watch a live preview, name
+it, and save — your custom theme registers into the **native Settings →
+Appearance** skin picker, selectable and persisted like a built-in skin. Create,
+edit, and delete as many themes as you like.
+
+This is the extension form of the closed core PR #1589 ("user-defined custom
+themes" by @Michaelyklam), which was declined for core on curation grounds —
+custom user themes are exactly the kind of opt-in, local personalization the
+extension system is for.
+
+## What It Does
+
+- Adds a rail button that opens the Theme Creator panel.
+- A curated set of color inputs (background, surfaces, text, muted, accent,
+  borders, your-message bubble), each with a color picker + hex field.
+- **Live preview** applies the in-progress theme to the whole app; **Stop
+  preview** reverts to your previous skin.
+- **Save** registers the theme into the native Appearance picker and applies it.
+- **Saved themes** list: apply / edit / delete each.
+- Everything is stored locally (`hermes-ext-custom-themes`); nothing is uploaded.
+
+## How it stays usable (and safe)
+
+Rather than expose ~30 raw CSS tokens, the editor offers a handful of primary
+colors and **derives** the rest (the full accent family, secondary surfaces,
+borders, code background, etc.) with simple color math. Every derived value is
+still sent through the core `registerHermesSkin` **sanitizer**, so an invalid or
+malicious color value can never be applied — the core capability is the single
+security chokepoint.
+
+## Dependency
+
+Requires the core **theme-registration capability** (`window.registerHermesSkin`),
+added in `nesquena/hermes-webui` **PR #5083**. Without it, the panel still opens
+and you can design a theme, but a notice explains it can't be applied yet (the
+extension does nothing destructive).
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/theme-creator.js + .css
+  -> rail button -> editor panel (color pickers + live preview)
+  -> window.registerHermesSkin({...derived tokens...})  -> native Appearance picker
+  -> localStorage: hermes-ext-custom-themes (your saved themes)
+                   hermes-skin (the core skin-selection key, to apply a theme)
+```
+
+This extension is `static-ui` / manifest-bundle only — no backend, no sidecar,
+no network, no native host. Color processing is pure in-browser math.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/theme-creator HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+Click the Theme Creator rail button, design a theme, Live preview, then Save. It
+appears in Settings → Appearance.
+
+## Controls
+
+Also on `window.HermesThemeCreatorExtension`:
+
+- `.themes()` — your saved themes
+- `.open()` — open the editor
+- `.registerAll()` — re-register saved themes into the picker
+
+## Disable And Uninstall
+
+Restart Hermes WebUI without `HERMES_WEBUI_EXTENSION_DIR` /
+`HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the `extensions/theme-creator/`
+directory. Your themes live under `hermes-ext-custom-themes`. If a custom theme
+was the active skin, switch to another skin in Appearance (a removed skin falls
+back to default).
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- creates extension-owned DOM (a rail button + the editor panel)
+- calls `window.registerHermesSkin(...)` with derived, sanitized color tokens
+- reads/writes `localStorage`:
+  - **owned:** `hermes-ext-custom-themes` (your saved themes)
+  - **shared:** `hermes-skin` — the core skin-selection key, written to apply a
+    theme (the same key the built-in Appearance picker uses)
+- does NOT call WebUI HTTP APIs, access cookies, contact any network, or use the
+  filesystem / native hosts
+- all rendered text (theme names) is escaped; all colors are validated hex and
+  re-sanitized by the core registration API
+
+## Compatibility
+
+- manifest-bundled extension assets + same-origin serving under `/extensions/`
+- the left rail (`.rail`) to host the button
+- the core theme-registration capability (`window.registerHermesSkin`, PR #5083)
+- uses the core `_pickSkin()` to apply when available, falling back to setting
+  `data-skin` + `hermes-skin` directly
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/theme-creator/assets/theme-creator.js
+python3 -m json.tool extensions/theme-creator/extension.json
+python3 -m json.tool extensions/theme-creator/manifest.json
+```
+
+Manual verification (on a WebUI build with PR #5083):
+
+- the rail button opens the editor; color pickers + hex fields stay in sync
+- Live preview applies the theme app-wide; Stop preview reverts
+- Save registers the theme into Settings → Appearance and applies it
+- saved themes can be applied / edited / deleted
+- themes persist across a reload and re-register into the picker on load
+
+## Known Limitations
+
+- Requires the core theme-registration capability (PR #5083).
+- Curated inputs with derived tokens (not every raw token is individually
+  editable) — a deliberate usability trade-off.
+- Themes are per-browser (`localStorage`), not synced across devices.
+- The brand logo glyph keeps its gold gradient (hardcoded in core; no skin
+  recolors it).

--- a/extensions/theme-creator/README.md
+++ b/extensions/theme-creator/README.md
@@ -34,7 +34,7 @@ security chokepoint.
 ## Dependency
 
 Requires the core **theme-registration capability** (`window.registerHermesSkin`),
-added in `nesquena/hermes-webui` **PR #5083**. Without it, the panel still opens
+added in `nesquena/hermes-webui` **PR #5100**. Without it, the panel still opens
 and you can design a theme, but a notice explains it can't be applied yet (the
 extension does nothing destructive).
 
@@ -102,7 +102,7 @@ This is trusted local code. Current disclosed behavior:
 
 - manifest-bundled extension assets + same-origin serving under `/extensions/`
 - the left rail (`.rail`) to host the button
-- the core theme-registration capability (`window.registerHermesSkin`, PR #5083)
+- the core theme-registration capability (`window.registerHermesSkin`, PR #5100)
 - uses the core `_pickSkin()` to apply when available, falling back to setting
   `data-skin` + `hermes-skin` directly
 
@@ -117,7 +117,7 @@ python3 -m json.tool extensions/theme-creator/extension.json
 python3 -m json.tool extensions/theme-creator/manifest.json
 ```
 
-Manual verification (on a WebUI build with PR #5083):
+Manual verification (on a WebUI build with PR #5100):
 
 - the rail button opens the editor; color pickers + hex fields stay in sync
 - Live preview applies the theme app-wide; Stop preview reverts
@@ -127,7 +127,7 @@ Manual verification (on a WebUI build with PR #5083):
 
 ## Known Limitations
 
-- Requires the core theme-registration capability (PR #5083).
+- Requires the core theme-registration capability (PR #5100).
 - Curated inputs with derived tokens (not every raw token is individually
   editable) — a deliberate usability trade-off.
 - Themes are per-browser (`localStorage`), not synced across devices.

--- a/extensions/theme-creator/assets/theme-creator.css
+++ b/extensions/theme-creator/assets/theme-creator.css
@@ -1,0 +1,104 @@
+/* Theme Creator extension for Hermes WebUI.
+   Scoped to hwx-tc-* classes; uses core CSS variables for theme-fit. */
+
+.hwx-tc-panel {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, .45);
+}
+.hwx-tc-card {
+  width: min(560px, 94vw);
+  max-height: 90vh;
+  overflow: auto;
+  background: var(--surface, #16161f);
+  color: var(--text, #f5f5f5);
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 14px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, .45);
+  padding: 16px 18px;
+}
+.hwx-tc-head {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.hwx-tc-title { font-weight: 700; font-size: 16px; flex: 1 1 auto; }
+.hwx-tc-x {
+  appearance: none; border: none; background: transparent;
+  color: var(--muted, #888); font-size: 15px; cursor: pointer;
+  width: 28px; height: 28px; border-radius: 7px;
+}
+.hwx-tc-x:hover { background: var(--hover-bg, rgba(127,127,127,.15)); color: var(--text, #fff); }
+
+.hwx-tc-warn {
+  font-size: 12px; color: var(--warning, #d98f3a);
+  background: var(--code-bg, rgba(127,127,127,.1));
+  border: 1px solid var(--border2, rgba(127,127,127,.25));
+  border-radius: 8px; padding: 8px 10px; margin-bottom: 12px;
+}
+
+.hwx-tc-section-title { font-weight: 650; font-size: 13px; margin: 8px 0; color: var(--muted, #9aa0b5); }
+
+.hwx-tc-namerow, .hwx-tc-row {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 8px; font-size: 13px;
+}
+.hwx-tc-namerow > span, .hwx-tc-row > span:first-child { flex: 0 0 150px; color: var(--text2, #ddd); }
+.hwx-tc-name, .hwx-tc-hex {
+  appearance: none;
+  border: 1px solid var(--border2, rgba(127,127,127,.3));
+  background: var(--bg, #0d0d1a);
+  color: var(--text, #fff);
+  border-radius: 7px; padding: 7px 9px; font-size: 13px;
+}
+.hwx-tc-name { flex: 1 1 auto; }
+.hwx-tc-swatchwrap { display: flex; align-items: center; gap: 8px; flex: 1 1 auto; }
+.hwx-tc-color {
+  appearance: none; -webkit-appearance: none;
+  width: 38px; height: 30px; padding: 0;
+  border: 1px solid var(--border2, rgba(127,127,127,.3));
+  border-radius: 7px; background: transparent; cursor: pointer; flex: 0 0 auto;
+}
+.hwx-tc-color::-webkit-color-swatch-wrapper { padding: 2px; }
+.hwx-tc-color::-webkit-color-swatch { border: none; border-radius: 5px; }
+.hwx-tc-hex { width: 96px; font-family: ui-monospace, monospace; }
+
+.hwx-tc-actions { display: flex; align-items: center; gap: 8px; margin-top: 14px; }
+.hwx-tc-spacer { flex: 1 1 auto; }
+.hwx-tc-btn {
+  appearance: none;
+  border: 1px solid var(--border2, rgba(127,127,127,.3));
+  background: var(--code-bg, rgba(127,127,127,.12));
+  color: var(--text, #fff);
+  border-radius: 8px; padding: 7px 14px; font-size: 13px; cursor: pointer;
+  transition: background .12s ease, border-color .12s ease;
+}
+.hwx-tc-btn:hover { background: var(--hover-bg, rgba(127,127,127,.18)); border-color: var(--border, rgba(127,127,127,.4)); }
+.hwx-tc-save { background: var(--accent-bg, rgba(99,102,241,.15)); border-color: var(--accent, #6366f1); color: var(--accent-text, var(--text)); }
+
+.hwx-tc-err { font-size: 12px; color: var(--danger, #e5534b); margin-top: 8px; }
+
+.hwx-tc-saved { margin-top: 18px; border-top: 1px solid var(--border2, rgba(127,127,127,.2)); padding-top: 10px; }
+.hwx-tc-muted { font-size: 12px; color: var(--muted, #888); }
+.hwx-tc-saved-row { display: flex; align-items: center; gap: 10px; padding: 7px 0; font-size: 13px; }
+.hwx-tc-swatches { display: inline-flex; gap: 3px; flex: 0 0 auto; }
+.hwx-tc-mini { width: 14px; height: 14px; border-radius: 4px; border: 1px solid rgba(127,127,127,.35); display: inline-block; }
+.hwx-tc-saved-name { flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.hwx-tc-link {
+  appearance: none; border: none; background: transparent;
+  color: var(--accent-text, var(--accent, #6366f1)); cursor: pointer;
+  font-size: 12px; padding: 3px 6px; border-radius: 6px;
+}
+.hwx-tc-link:hover { background: var(--hover-bg, rgba(127,127,127,.15)); }
+.hwx-tc-del { color: var(--danger, #e5534b); }
+
+@media (prefers-reduced-motion: reduce) {
+  .hwx-tc-btn { transition: none; }
+}
+@media (max-width: 560px) {
+  .hwx-tc-namerow > span, .hwx-tc-row > span:first-child { flex-basis: 110px; }
+}

--- a/extensions/theme-creator/assets/theme-creator.js
+++ b/extensions/theme-creator/assets/theme-creator.js
@@ -40,16 +40,46 @@
   ];
 
   // ── helpers ────────────────────────────────────────────────────────────
+  const MAX_THEMES = 50;                            // cap saved themes (storage-growth guard)
+  const MAX_STORE_BYTES = 256 * 1024;               // hard byte ceiling for the whole store
+
+  // Validate a stored theme record before any CSS/HTML rendering consumes it.
+  // Stored data is user-controlled (localStorage), so a tampered record must not
+  // be able to inject CSS via the selector key or a non-hex base value. (Codex gate, PR #26.)
+  function validTheme(t) {
+    if (!t || typeof t !== 'object') return null;
+    const key = String(t.key || '');
+    // key grammar: custom- prefix + slug chars only (safe as data-skin attr + CSS attr selector)
+    if (!/^custom-[a-z0-9_-]+$/.test(key)) return null;
+    if (!t.base || typeof t.base !== 'object') return null;
+    const base = {};
+    for (const f of FIELDS) {
+      const v = t.base[f.id];
+      if (!isHex(v)) return null;                   // every base color must be a valid hex
+      base[f.id] = v;
+    }
+    return { key: key, name: String(t.name || key).slice(0, 28), base: base };
+  }
+
   function loadThemes() {
     try {
       const raw = localStorage.getItem(STORE_KEY);
       if (!raw) return [];
       const arr = JSON.parse(raw);
-      return Array.isArray(arr) ? arr.filter((t) => t && t.key && t.base) : [];
+      if (!Array.isArray(arr)) return [];
+      const out = [];
+      for (const t of arr) { const v = validTheme(t); if (v) out.push(v); }
+      return out;
     } catch (_) { return []; }
   }
   function saveThemes(themes) {
-    try { localStorage.setItem(STORE_KEY, JSON.stringify(themes)); } catch (_) {}
+    try {
+      const capped = (themes || []).slice(0, MAX_THEMES);
+      const json = JSON.stringify(capped);
+      if (json.length > MAX_STORE_BYTES) return false;   // refuse oversized writes
+      localStorage.setItem(STORE_KEY, json);
+      return true;
+    } catch (_) { return false; }
   }
   function hasCapability() { return typeof window.registerHermesSkin === 'function'; }
 
@@ -362,8 +392,18 @@
     const key = editing ? editing.key : slugify(name);
     const existingIdx = themes.findIndex((t) => t.key === key);
     const rec = { key, name: name.slice(0, 28), base };
-    if (existingIdx >= 0) themes[existingIdx] = rec; else themes.push(rec);
-    saveThemes(themes);
+    if (existingIdx >= 0) themes[existingIdx] = rec;
+    else {
+      if (themes.length >= MAX_THEMES) {
+        showErr('Theme limit reached (' + MAX_THEMES + '). Delete one before adding another.');
+        return;
+      }
+      themes.push(rec);
+    }
+    if (!saveThemes(themes)) {
+      showErr('Could not save — theme storage is full. Delete a theme and try again.');
+      return;
+    }
     // register + apply it
     if (hasCapability()) {
       try { window.registerHermesSkin(descriptorFor(rec)); } catch (_) {}

--- a/extensions/theme-creator/assets/theme-creator.js
+++ b/extensions/theme-creator/assets/theme-creator.js
@@ -1,0 +1,401 @@
+(() => {
+  'use strict';
+
+  // ── Theme Creator extension for Hermes WebUI ─────────────────────────────
+  // A build-your-own-theme editor. Pick colors for the key design tokens, see a
+  // live preview, name it, and save — the theme is registered into the NATIVE
+  // Settings -> Appearance skin picker (selectable + persisted like a built-in
+  // skin) via the core theme-registration capability.
+  //
+  // Create, edit, and delete multiple custom themes. Everything is stored
+  // locally; nothing is uploaded.
+  //
+  // DEPENDENCY: requires the core registerHermesSkin capability
+  // (nesquena/hermes-webui PR #5083). Without it the extension shows a notice and
+  // does nothing destructive.
+  //
+  // Design note: rather than expose ~30 raw tokens, the editor offers a curated
+  // set of primary colors and DERIVES the accent family + surfaces from them, so
+  // a usable theme is a few clicks. The derived values are still sent through the
+  // core registerHermesSkin sanitizer, so an invalid color can never be applied.
+
+  const EXT = 'theme-creator';
+  if (window.__hermesThemeCreatorLoaded) return;
+  window.__hermesThemeCreatorLoaded = true;
+
+  const STORE_KEY = 'hermes-ext-custom-themes';   // [{key,name,base:{...}}]
+  const KEY_PREFIX = 'custom-';                    // skin key namespace
+  const RAIL_BTN_ID = 'hwxThemeCreatorRailBtn';
+  const PANEL_ID = 'hwxThemeCreatorPanel';
+
+  // Curated, human-friendly inputs. Everything else is derived from these.
+  const FIELDS = [
+    { id: 'bg', label: 'Background', def: '#0d0d1a' },
+    { id: 'surface', label: 'Panels / surfaces', def: '#16161f' },
+    { id: 'text', label: 'Text', def: '#f5f5f5' },
+    { id: 'muted', label: 'Muted text', def: '#9aa0b5' },
+    { id: 'accent', label: 'Accent', def: '#f5c542' },
+    { id: 'border', label: 'Borders', def: '#2a2a3a' },
+    { id: 'userBubble', label: 'Your message bubble', def: '#26314a' },
+  ];
+
+  // ── helpers ────────────────────────────────────────────────────────────
+  function loadThemes() {
+    try {
+      const raw = localStorage.getItem(STORE_KEY);
+      if (!raw) return [];
+      const arr = JSON.parse(raw);
+      return Array.isArray(arr) ? arr.filter((t) => t && t.key && t.base) : [];
+    } catch (_) { return []; }
+  }
+  function saveThemes(themes) {
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(themes)); } catch (_) {}
+  }
+  function hasCapability() { return typeof window.registerHermesSkin === 'function'; }
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+  function slugify(name) {
+    return KEY_PREFIX + String(name || 'theme').toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 32) || (KEY_PREFIX + 'theme');
+  }
+
+  // colour math (hex <-> rgb, mix, contrast)
+  function hexToRgb(hex) {
+    let h = String(hex || '').trim().replace('#', '');
+    if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+    if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+    return { r: parseInt(h.slice(0, 2), 16), g: parseInt(h.slice(2, 4), 16), b: parseInt(h.slice(4, 6), 16) };
+  }
+  function rgbStr(hex) { const c = hexToRgb(hex); return c ? c.r + ', ' + c.g + ', ' + c.b : '0, 0, 0'; }
+  function clamp(n) { return Math.max(0, Math.min(255, Math.round(n))); }
+  function toHex(c) { return '#' + [c.r, c.g, c.b].map((v) => clamp(v).toString(16).padStart(2, '0')).join(''); }
+  function mix(hexA, hexB, t) {
+    const a = hexToRgb(hexA), b = hexToRgb(hexB);
+    if (!a || !b) return hexA;
+    return toHex({ r: a.r + (b.r - a.r) * t, g: a.g + (b.g - a.g) * t, b: a.b + (b.b - a.b) * t });
+  }
+  function luminance(hex) {
+    const c = hexToRgb(hex); if (!c) return 0;
+    return (0.2126 * c.r + 0.7152 * c.g + 0.0722 * c.b) / 255;
+  }
+  function readableOn(hex) { return luminance(hex) > 0.5 ? '#111111' : '#ffffff'; }
+
+  function isHex(s) { return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(String(s || '').trim()); }
+
+  // Derive a full token set from the curated base inputs.
+  function deriveTokens(base) {
+    const dark = luminance(base.bg) < 0.5;
+    const surface2 = mix(base.surface, dark ? '#ffffff' : '#000000', 0.06);
+    const accentText = base.accent;
+    const accentContrast = readableOn(base.accent);
+    return {
+      '--bg': base.bg,
+      '--surface': base.surface,
+      '--surface2': surface2,
+      '--surface-subtle': surface2,
+      '--text': base.text,
+      '--text2': mix(base.text, base.bg, 0.15),
+      '--muted': base.muted,
+      '--accent': base.accent,
+      '--accent2': base.accent,
+      '--accent-hover': mix(base.accent, dark ? '#ffffff' : '#000000', 0.18),
+      '--accent-text': accentText,
+      '--accent-contrast': accentContrast,
+      '--accent-bg': 'rgba(' + rgbStr(base.accent) + ', 0.14)',
+      '--accent-bg-strong': 'rgba(' + rgbStr(base.accent) + ', 0.26)',
+      '--accent-rgb': rgbStr(base.accent),
+      '--border': base.border,
+      '--border2': mix(base.border, base.text, 0.18),
+      '--hover-bg': mix(base.surface, base.text, 0.08),
+      '--code-bg': mix(base.bg, dark ? '#ffffff' : '#000000', 0.04),
+      '--code-text': base.text,
+      '--sidebar': base.surface,
+      '--sidebar-text': base.text,
+      '--user-bubble': base.userBubble,
+      '--assistant-bubble': base.surface,
+      '--link': base.accent,
+    };
+  }
+
+  function descriptorFor(theme) {
+    return {
+      name: theme.name,
+      value: theme.key,
+      colors: [theme.base.accent, theme.base.bg, theme.base.surface],
+      tokens: deriveTokens(theme.base),
+    };
+  }
+
+  // Register all saved themes into the native picker.
+  function registerAll() {
+    if (!hasCapability()) return 0;
+    let n = 0;
+    for (const t of loadThemes()) {
+      try { if (window.registerHermesSkin(descriptorFor(t))) n++; } catch (_) {}
+    }
+    return n;
+  }
+
+  // ── rail button ────────────────────────────────────────────────────────
+  function railIcon() {
+    return '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+      'stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<circle cx="13.5" cy="6.5" r="2.5"/><circle cx="6.5" cy="11.5" r="2.5"/>' +
+      '<circle cx="16.5" cy="14.5" r="2.5"/><path d="M3 21h18"/></svg>';
+  }
+  function ensureRailButton() {
+    if (document.getElementById(RAIL_BTN_ID)) return;
+    const rail = document.querySelector('.rail');
+    if (!rail) return;
+    const btn = document.createElement('button');
+    btn.id = RAIL_BTN_ID;
+    btn.type = 'button';
+    btn.className = 'rail-btn nav-tab has-tooltip hwx-tc-rail';
+    btn.dataset.tooltip = 'Theme Creator';
+    btn.setAttribute('aria-label', 'Theme Creator');
+    btn.innerHTML = railIcon();
+    btn.addEventListener('click', (ev) => { ev.preventDefault(); openPanel(); });
+    const spacer = rail.querySelector('.rail-spacer');
+    if (spacer) rail.insertBefore(btn, spacer); else rail.appendChild(btn);
+  }
+
+  // ── editor panel ─────────────────────────────────────────────────────────
+  let editing = null;        // {key,name,base} being edited (or null for new)
+  let previewKey = null;     // skin key currently used for live preview
+  let prevSkinBeforePreview = null;
+
+  function defaultBase() {
+    const b = {};
+    FIELDS.forEach((f) => { b[f.id] = f.def; });
+    return b;
+  }
+
+  function openPanel() {
+    closePanel();
+    editing = null;
+    const panel = document.createElement('div');
+    panel.id = PANEL_ID;
+    panel.className = 'hwx-tc-panel';
+    panel.innerHTML =
+      '<div class="hwx-tc-card" role="dialog" aria-label="Theme Creator">' +
+        '<div class="hwx-tc-head"><span class="hwx-tc-title">Theme Creator</span>' +
+          '<button type="button" class="hwx-tc-x" aria-label="Close">✕</button></div>' +
+        (hasCapability() ? '' :
+          '<div class="hwx-tc-warn">The theme-registration capability isn\u2019t available in this WebUI build ' +
+          '(needs core PR #5083). You can still design a theme, but it can\u2019t be applied yet.</div>') +
+        '<div class="hwx-tc-body">' +
+          '<div class="hwx-tc-editor"></div>' +
+          '<div class="hwx-tc-saved"></div>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(panel);
+    panel.querySelector('.hwx-tc-x').addEventListener('click', () => closePanel());
+    panel.addEventListener('click', (e) => { if (e.target === panel) closePanel(); });
+    document.addEventListener('keydown', escClose, true);
+    renderEditor();
+    renderSaved();
+  }
+  function escClose(ev) { if (ev.key === 'Escape') closePanel(); }
+  function closePanel() {
+    cancelPreview();
+    const p = document.getElementById(PANEL_ID);
+    if (p) p.remove();
+    document.removeEventListener('keydown', escClose, true);
+  }
+
+  function currentBaseFromInputs() {
+    const panel = document.getElementById(PANEL_ID);
+    const base = {};
+    FIELDS.forEach((f) => {
+      const inp = panel.querySelector('.hwx-tc-color-' + f.id);
+      base[f.id] = inp && isHex(inp.value) ? inp.value : f.def;
+    });
+    return base;
+  }
+
+  function renderEditor() {
+    const panel = document.getElementById(PANEL_ID);
+    if (!panel) return;
+    const host = panel.querySelector('.hwx-tc-editor');
+    const base = editing ? editing.base : defaultBase();
+    const nameVal = editing ? editing.name : '';
+    let rows = '';
+    FIELDS.forEach((f) => {
+      const v = base[f.id] || f.def;
+      rows +=
+        '<label class="hwx-tc-row"><span>' + escapeHtml(f.label) + '</span>' +
+          '<span class="hwx-tc-swatchwrap">' +
+            '<input type="color" class="hwx-tc-color hwx-tc-color-' + f.id + '" value="' + escapeHtml(v) + '">' +
+            '<input type="text" class="hwx-tc-hex hwx-tc-hex-' + f.id + '" value="' + escapeHtml(v) + '" maxlength="7">' +
+          '</span></label>';
+    });
+    host.innerHTML =
+      '<div class="hwx-tc-section-title">' + (editing ? 'Edit theme' : 'New theme') + '</div>' +
+      '<label class="hwx-tc-namerow"><span>Name</span>' +
+        '<input type="text" class="hwx-tc-name" maxlength="28" placeholder="My Theme" value="' + escapeHtml(nameVal) + '"></label>' +
+      rows +
+      '<div class="hwx-tc-actions">' +
+        '<button type="button" class="hwx-tc-btn hwx-tc-preview">Live preview</button>' +
+        '<button type="button" class="hwx-tc-btn hwx-tc-stoppreview" hidden>Stop preview</button>' +
+        '<span class="hwx-tc-spacer"></span>' +
+        (editing ? '<button type="button" class="hwx-tc-btn hwx-tc-newbtn">New</button>' : '') +
+        '<button type="button" class="hwx-tc-btn hwx-tc-save">' + (editing ? 'Update' : 'Save') + '</button>' +
+      '</div>' +
+      '<div class="hwx-tc-err" hidden></div>';
+
+    // wire colour <-> hex sync + live preview update
+    FIELDS.forEach((f) => {
+      const color = host.querySelector('.hwx-tc-color-' + f.id);
+      const hex = host.querySelector('.hwx-tc-hex-' + f.id);
+      color.addEventListener('input', () => { hex.value = color.value; if (previewKey) updatePreview(); });
+      hex.addEventListener('input', () => { if (isHex(hex.value)) { color.value = hex.value.length === 4 ? expand(hex.value) : hex.value; if (previewKey) updatePreview(); } });
+    });
+    host.querySelector('.hwx-tc-preview').addEventListener('click', startPreview);
+    host.querySelector('.hwx-tc-stoppreview').addEventListener('click', cancelPreview);
+    host.querySelector('.hwx-tc-save').addEventListener('click', saveCurrent);
+    const nb = host.querySelector('.hwx-tc-newbtn');
+    if (nb) nb.addEventListener('click', () => { editing = null; cancelPreview(); renderEditor(); });
+  }
+
+  function expand(h) { h = h.replace('#', ''); return '#' + h.split('').map((c) => c + c).join(''); }
+
+  // ── live preview (register under a temp key + apply) ─────────────────────
+  function startPreview() {
+    if (!hasCapability()) return;
+    const base = currentBaseFromInputs();
+    previewKey = KEY_PREFIX + 'preview';
+    if (prevSkinBeforePreview === null) {
+      try { prevSkinBeforePreview = localStorage.getItem('hermes-skin') || 'default'; } catch (_) { prevSkinBeforePreview = 'default'; }
+    }
+    try {
+      window.registerHermesSkin({ name: 'Preview', value: previewKey, colors: [base.accent, base.bg, base.surface], tokens: deriveTokens(base) });
+      applySkin(previewKey);
+    } catch (_) {}
+    togglePreviewButtons(true);
+  }
+  function updatePreview() {
+    if (!previewKey || !hasCapability()) return;
+    const base = currentBaseFromInputs();
+    try { window.registerHermesSkin({ name: 'Preview', value: previewKey, colors: [base.accent, base.bg, base.surface], tokens: deriveTokens(base) }); applySkin(previewKey); } catch (_) {}
+  }
+  function cancelPreview() {
+    if (previewKey && prevSkinBeforePreview !== null) {
+      try { applySkin(prevSkinBeforePreview); } catch (_) {}
+    }
+    previewKey = null;
+    prevSkinBeforePreview = null;
+    togglePreviewButtons(false);
+  }
+  function togglePreviewButtons(on) {
+    const panel = document.getElementById(PANEL_ID);
+    if (!panel) return;
+    const p = panel.querySelector('.hwx-tc-preview');
+    const s = panel.querySelector('.hwx-tc-stoppreview');
+    if (p) p.hidden = on;
+    if (s) s.hidden = !on;
+  }
+  function applySkin(key) {
+    // Use the core picker path if present; else set the attribute directly.
+    if (typeof window._pickSkin === 'function') { try { window._pickSkin(key); return; } catch (_) {} }
+    document.documentElement.dataset.skin = key === 'default' ? '' : key;
+    try { localStorage.setItem('hermes-skin', key); } catch (_) {}
+    if (!document.documentElement.dataset.skin) delete document.documentElement.dataset.skin;
+  }
+
+  // ── save / manage ────────────────────────────────────────────────────────
+  function showErr(msg) {
+    const panel = document.getElementById(PANEL_ID);
+    const e = panel && panel.querySelector('.hwx-tc-err');
+    if (e) { e.hidden = !msg; e.textContent = msg || ''; }
+  }
+  function saveCurrent() {
+    const panel = document.getElementById(PANEL_ID);
+    const name = (panel.querySelector('.hwx-tc-name').value || '').trim();
+    if (!name) { showErr('Give your theme a name.'); return; }
+    const base = currentBaseFromInputs();
+    for (const f of FIELDS) { if (!isHex(base[f.id])) { showErr('“' + f.label + '” is not a valid colour.'); return; } }
+    let themes = loadThemes();
+    const key = editing ? editing.key : slugify(name);
+    const existingIdx = themes.findIndex((t) => t.key === key);
+    const rec = { key, name: name.slice(0, 28), base };
+    if (existingIdx >= 0) themes[existingIdx] = rec; else themes.push(rec);
+    saveThemes(themes);
+    // register + apply it
+    if (hasCapability()) {
+      try { window.registerHermesSkin(descriptorFor(rec)); } catch (_) {}
+      cancelPreview();
+      applySkin(key);
+    }
+    editing = rec;
+    showErr('');
+    renderEditor();
+    renderSaved();
+  }
+
+  function renderSaved() {
+    const panel = document.getElementById(PANEL_ID);
+    if (!panel) return;
+    const host = panel.querySelector('.hwx-tc-saved');
+    const themes = loadThemes();
+    if (!themes.length) { host.innerHTML = '<div class="hwx-tc-section-title">Saved themes</div><div class="hwx-tc-muted">No custom themes yet.</div>'; return; }
+    let items = '';
+    themes.forEach((t) => {
+      const sw = (c) => '<span class="hwx-tc-mini" style="background:' + escapeHtml(c) + '"></span>';
+      items +=
+        '<div class="hwx-tc-saved-row" data-key="' + escapeHtml(t.key) + '">' +
+          '<span class="hwx-tc-swatches">' + sw(t.base.bg) + sw(t.base.surface) + sw(t.base.accent) + '</span>' +
+          '<span class="hwx-tc-saved-name">' + escapeHtml(t.name) + '</span>' +
+          '<span class="hwx-tc-spacer"></span>' +
+          '<button type="button" class="hwx-tc-link hwx-tc-apply">Apply</button>' +
+          '<button type="button" class="hwx-tc-link hwx-tc-edit">Edit</button>' +
+          '<button type="button" class="hwx-tc-link hwx-tc-del">Delete</button>' +
+        '</div>';
+    });
+    host.innerHTML = '<div class="hwx-tc-section-title">Saved themes</div>' + items;
+    host.querySelectorAll('.hwx-tc-saved-row').forEach((row) => {
+      const key = row.dataset.key;
+      row.querySelector('.hwx-tc-apply').addEventListener('click', () => { if (hasCapability()) { applySkin(key); } });
+      row.querySelector('.hwx-tc-edit').addEventListener('click', () => {
+        const t = loadThemes().find((x) => x.key === key);
+        if (t) { editing = JSON.parse(JSON.stringify(t)); cancelPreview(); renderEditor(); }
+      });
+      row.querySelector('.hwx-tc-del').addEventListener('click', () => {
+        let themes = loadThemes().filter((x) => x.key !== key);
+        saveThemes(themes);
+        if (editing && editing.key === key) editing = null;
+        // if the deleted theme was active, revert to default
+        try { if ((localStorage.getItem('hermes-skin') || '') === key) applySkin('default'); } catch (_) {}
+        renderEditor();
+        renderSaved();
+      });
+    });
+  }
+
+  function install(attempt) {
+    attempt = attempt || 0;
+    if (document.querySelector('.rail')) {
+      ensureRailButton();
+      registerAll();   // make saved themes available in the picker on load
+      window.HermesThemeCreatorExtension = {
+        version: '0.1.0',
+        themes: loadThemes,
+        open: openPanel,
+        registerAll,
+      };
+      return true;
+    }
+    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
+    console.warn('[' + EXT + '] rail not found; not installed');
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/theme-creator/assets/theme-creator.js
+++ b/extensions/theme-creator/assets/theme-creator.js
@@ -130,6 +130,44 @@
     };
   }
 
+  // ── code / chat surface token coverage ───────────────────────────────────
+  // The core registerHermesSkin allowlist excludes several code/chat-surface
+  // tokens (--strong, --code-inline-bg, --pre-text, --input-bg) and emits no
+  // dark-mode variant, so on a mismatched base theme a custom theme's inline
+  // code / code blocks inherit the base-theme values and can render unreadable
+  // (the same composition gap @franksong2702 flagged on the fixed skin packs).
+  // We can't push these through registerHermesSkin, so we emit our own managed
+  // <style> for every saved theme + the live-preview key, derived from each
+  // theme's own palette, under both :root[data-skin] and :root.dark[data-skin]
+  // so it composes cleanly in Light, Dark, and System Default base modes.
+  const _CODE_STYLE_ID = 'hwxThemeCreatorCodeStyles';
+
+  function codeTokensFor(base) {
+    const dark = luminance(base.bg) < 0.5;
+    return {
+      '--strong': mix(base.text, dark ? '#ffffff' : '#000000', 0.15),
+      '--code-bg': mix(base.bg, dark ? '#ffffff' : '#000000', 0.04),
+      '--code-text': base.text,
+      '--code-inline-bg': 'rgba(' + rgbStr(dark ? '#ffffff' : '#000000') + ', ' + (dark ? '0.08' : '0.06') + ')',
+      '--pre-text': base.text,
+      '--input-bg': mix(base.surface, dark ? '#ffffff' : '#000000', 0.03),
+    };
+  }
+
+  function renderCodeStyles(extra) {
+    let el = document.getElementById(_CODE_STYLE_ID);
+    if (!el) { el = document.createElement('style'); el.id = _CODE_STYLE_ID; document.head.appendChild(el); }
+    const entries = loadThemes().map((t) => ({ key: t.key, base: t.base }));
+    if (extra && extra.key && extra.base) entries.push(extra);
+    const blocks = [];
+    for (const e of entries) {
+      const toks = codeTokensFor(e.base);
+      const decls = Object.keys(toks).map((k) => k + ':' + toks[k] + ' !important').join(';');
+      if (decls) blocks.push(':root[data-skin="' + e.key + '"],\n:root.dark[data-skin="' + e.key + '"]{' + decls + '}');
+    }
+    el.textContent = blocks.join('\n');
+  }
+
   // Register all saved themes into the native picker.
   function registerAll() {
     if (!hasCapability()) return 0;
@@ -137,6 +175,7 @@
     for (const t of loadThemes()) {
       try { if (window.registerHermesSkin(descriptorFor(t))) n++; } catch (_) {}
     }
+    renderCodeStyles();
     return n;
   }
 
@@ -273,6 +312,7 @@
     }
     try {
       window.registerHermesSkin({ name: 'Preview', value: previewKey, colors: [base.accent, base.bg, base.surface], tokens: deriveTokens(base) });
+      renderCodeStyles({ key: previewKey, base });
       applySkin(previewKey);
     } catch (_) {}
     togglePreviewButtons(true);
@@ -280,7 +320,7 @@
   function updatePreview() {
     if (!previewKey || !hasCapability()) return;
     const base = currentBaseFromInputs();
-    try { window.registerHermesSkin({ name: 'Preview', value: previewKey, colors: [base.accent, base.bg, base.surface], tokens: deriveTokens(base) }); applySkin(previewKey); } catch (_) {}
+    try { window.registerHermesSkin({ name: 'Preview', value: previewKey, colors: [base.accent, base.bg, base.surface], tokens: deriveTokens(base) }); renderCodeStyles({ key: previewKey, base }); applySkin(previewKey); } catch (_) {}
   }
   function cancelPreview() {
     if (previewKey && prevSkinBeforePreview !== null) {
@@ -327,6 +367,7 @@
     // register + apply it
     if (hasCapability()) {
       try { window.registerHermesSkin(descriptorFor(rec)); } catch (_) {}
+      renderCodeStyles();
       cancelPreview();
       applySkin(key);
     }
@@ -369,6 +410,7 @@
         if (editing && editing.key === key) editing = null;
         // if the deleted theme was active, revert to default
         try { if ((localStorage.getItem('hermes-skin') || '') === key) applySkin('default'); } catch (_) {}
+        renderCodeStyles();
         renderEditor();
         renderSaved();
       });
@@ -381,7 +423,7 @@
       ensureRailButton();
       registerAll();   // make saved themes available in the picker on load
       window.HermesThemeCreatorExtension = {
-        version: '0.1.0',
+        version: '0.1.1',
         themes: loadThemes,
         open: openPanel,
         registerAll,

--- a/extensions/theme-creator/assets/theme-creator.js
+++ b/extensions/theme-creator/assets/theme-creator.js
@@ -11,7 +11,7 @@
   // locally; nothing is uploaded.
   //
   // DEPENDENCY: requires the core registerHermesSkin capability
-  // (nesquena/hermes-webui PR #5083). Without it the extension shows a notice and
+  // (nesquena/hermes-webui PR #5100). Without it the extension shows a notice and
   // does nothing destructive.
   //
   // Design note: rather than expose ~30 raw tokens, the editor offers a curated
@@ -186,7 +186,7 @@
           '<button type="button" class="hwx-tc-x" aria-label="Close">✕</button></div>' +
         (hasCapability() ? '' :
           '<div class="hwx-tc-warn">The theme-registration capability isn\u2019t available in this WebUI build ' +
-          '(needs core PR #5083). You can still design a theme, but it can\u2019t be applied yet.</div>') +
+          '(needs core PR #5100). You can still design a theme, but it can\u2019t be applied yet.</div>') +
         '<div class="hwx-tc-body">' +
           '<div class="hwx-tc-editor"></div>' +
           '<div class="hwx-tc-saved"></div>' +

--- a/extensions/theme-creator/extension.json
+++ b/extensions/theme-creator/extension.json
@@ -25,7 +25,9 @@
   "permissions": {
     "webui_api": {
       "read": [],
-      "write": []
+      "write": [
+        "settings"
+      ]
     },
     "webui_navigation": false,
     "dom": {

--- a/extensions/theme-creator/extension.json
+++ b/extensions/theme-creator/extension.json
@@ -1,8 +1,8 @@
 {
   "id": "theme-creator",
   "name": "Theme Creator",
-  "description": "Build your own theme: pick colors for the key design tokens, see a live preview, name it, and save. Custom themes register into the native Settings \u2192 Appearance picker. Create, edit, and delete multiple themes; everything is stored locally.",
-  "version": "0.1.0",
+  "description": "Build your own theme: pick colors for the key design tokens, see a live preview, name it, and save. Custom themes register into the native Settings → Appearance picker. Create, edit, and delete multiple themes; everything is stored locally.",
+  "version": "0.1.1",
   "author": "nesquena-hermes",
   "assets": {
     "scripts": [

--- a/extensions/theme-creator/extension.json
+++ b/extensions/theme-creator/extension.json
@@ -1,0 +1,52 @@
+{
+  "id": "theme-creator",
+  "name": "Theme Creator",
+  "description": "Build your own theme: pick colors for the key design tokens, see a live preview, name it, and save. Custom themes register into the native Settings \u2192 Appearance picker. Create, edit, and delete multiple themes; everything is stored locally.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/theme-creator.js"
+    ],
+    "stylesheets": [
+      "assets/theme-creator.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-custom-themes"
+      ],
+      "shared_webui_keys": [
+        "hermes-skin"
+      ]
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false,
+    "registers_skin": true
+  }
+}

--- a/extensions/theme-creator/manifest.json
+++ b/extensions/theme-creator/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "theme-creator",
+      "name": "Theme Creator",
+      "description": "Build your own theme with a live color editor; saves into the native Appearance picker.",
+      "scripts": [
+        "assets/theme-creator.js"
+      ],
+      "stylesheets": [
+        "assets/theme-creator.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **`theme-creator`** extension — a **build-your-own-theme** editor. Pick colors for the key design tokens, watch a live preview, name it, and save; your custom theme registers into the **native** Settings → Appearance skin picker, selectable and persisted like a built-in skin. Create, edit, and delete as many themes as you like.

This is the extension form of closed core PR **nesquena/hermes-webui#1589** ("user-defined custom themes" by **@Michaelyklam**), which was declined for core on curation grounds — custom user themes are exactly the opt-in, local personalization the extension system is for.

## How it works

- A rail button opens the editor: curated color inputs (background, surfaces, text, muted, accent, borders, your-message bubble), each with a color picker + hex field.
- **Live preview** applies the in-progress theme app-wide; **Stop preview** reverts to your previous skin.
- **Save** registers the theme via `window.registerHermesSkin(...)` and applies it; **Saved themes** list supports apply / edit / delete.
- To stay usable, the editor exposes a handful of primary colors and **derives** the full token set (accent family, secondary surfaces, borders, code bg, etc.) with color math — every derived value still passes through the **core sanitizer**, so an invalid color can never be applied.

## Dependency

Requires the core theme-registration capability (`window.registerHermesSkin`), **nesquena/hermes-webui#5083**. Without it the panel still opens to design a theme but shows a notice that it can't be applied yet (nothing destructive).

## End-to-end verification (live browser, against #5083)

- ✅ editor opens — 7 color rows (pickers + hex stay in sync), name field, save
- ✅ **Save registers into `_SKINS` + `_VALID_SKINS` and applies** (active skin = the new `custom-…` key)
- ✅ **derived tokens correct**: e.g. accent `#3fa7d6` → `--accent-rgb 63, 167, 214`, `--accent-hover #62b7dd` (lightened), `--surface2 #1e2f42` (mixed)
- ✅ **edit updates in place** (no duplicate), new accent applied live
- ✅ **live preview** applies app-wide (green "Forest" theme visible across rail/chips/composer) and reverts on stop
- ✅ **persists across reload** and re-registers on load (edited value retained)
- ✅ **delete** reverts to default when the deleted theme was active
- ✅ repo gates green: validate / safety-scan / registry / validator self-test

## Permissions disclosure

- `registers_skin: true`; `network_external: false`; no API/cookies/sidecar/native host/filesystem
- `dom.owned: true` / `mutates_core_views: true` (rail button + editor panel)
- `storage.owned: ["hermes-ext-custom-themes"]`; **`shared_webui_keys: ["hermes-skin"]`** — it writes the core skin-selection key to apply a theme (same key the built-in picker uses), declared honestly
- theme names escaped; all colors validated hex + re-sanitized by the core API

## Notes

- Curated inputs with derived tokens (not every raw token individually editable) — a deliberate usability trade-off.
- Brand logo glyph keeps its gold gradient (hardcoded in core; no skin recolors it).
- 🤖 Agent-authored; flagging for review, not self-merging.
