### PR TITLE
Add session-export-pdf extension (export conversation to PDF / Markdown)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -28,3 +28,5 @@ need it and maintainers agree on the shared contract.
   transcript (downscaled + stored locally; assistant-only).
 - `theme-creator`: build your own theme with a live color editor; custom themes
   register into the native Appearance picker (needs core theme-registration).
+- `session-export-pdf`: export the current conversation to PDF (print) or copy
+  it as Markdown, via a titlebar button.

--- a/extensions/session-export-pdf/README.md
+++ b/extensions/session-export-pdf/README.md
@@ -1,0 +1,121 @@
+# Session Export to PDF
+
+Session Export to PDF is a trusted local Hermes WebUI extension that lets you
+export the current conversation to a clean **PDF** (via the browser's print
+dialog, with a print-styled layout) or **copy it as Markdown**. It adds an export
+button to the app titlebar.
+
+## What It Does
+
+- Adds an export button to the app titlebar (next to Reload); it shows only when
+  a conversation is open.
+- Clicking it opens a small menu:
+  - **Export to PDF** — clones the rendered transcript into a print-styled,
+    off-screen container and calls `window.print()` with a scoped `@media print`
+    stylesheet, so the printed/saved PDF is just the conversation (titled, with
+    roles, code blocks, links preserved) rather than a raw `Ctrl+P` of the whole
+    app chrome. Use your browser's "Save as PDF" destination.
+  - **Copy as Markdown** — copies the conversation as `# title` + `## You` /
+    `## Assistant` sections to the clipboard.
+- No backend, **no bundled PDF library**, no network. Everything is done in the
+  browser from the already-rendered transcript.
+
+## Credit
+
+Design reference: closed core PR
+[#3425](https://github.com/nesquena/hermes-webui/pull/3425) (@vanshaj-pahwa),
+which added a print-markup/formatting export to core. This is the extension form
+of that idea (routed to extensions to keep core lean).
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/session-export-pdf.js + .css
+  -> titlebar button -> menu -> clone #messages rows into #hwxPrintRoot
+     + @media print { show only #hwxPrintRoot } -> window.print()
+  -> (or) copy transcript as Markdown to the clipboard
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, access external networks, read/write files, or use
+native host APIs.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/session-export-pdf HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+Open a conversation, click the export button in the titlebar, and choose Export
+to PDF (then pick "Save as PDF" in the print dialog) or Copy as Markdown.
+
+## Controls
+
+Also on `window.HermesSessionExportExtension`:
+
+- `.exportPdf()` — open the print dialog for the current conversation
+- `.exportMarkdown()` — copy the conversation as Markdown
+- `.refresh()` — re-evaluate button visibility
+
+## Disable And Uninstall
+
+Restart Hermes WebUI without `HERMES_WEBUI_EXTENSION_DIR` /
+`HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the `extensions/session-export-pdf/`
+directory. The extension stores nothing.
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- creates extension-owned DOM (a titlebar button, a small menu, and a temporary
+  off-screen print container that is removed after printing)
+- reads the rendered transcript from `#messages` (`.msg-body` of each real
+  message row; hidden anchor/worklog segments are skipped)
+- calls `window.print()` (`uses_print`) and writes to the clipboard
+  (`uses_clipboard`) for the Markdown copy
+- does NOT call WebUI HTTP APIs, read/write localStorage, access cookies, contact
+  any network, or use the filesystem / native hosts
+- the print body reuses the already-sanitized rendered HTML from core's renderer
+  (it is cloned, not re-parsed from raw input)
+
+## Compatibility
+
+- manifest-bundled extension assets + same-origin serving under `/extensions/`
+- the app titlebar (`.app-titlebar`, `#btnReload`) to host the button
+- the transcript DOM (`#messages`, `[data-msg-idx]`, `.msg-body`) — the
+  integration contract; a core rename would need an update
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/session-export-pdf/assets/session-export-pdf.js
+python3 -m json.tool extensions/session-export-pdf/extension.json
+python3 -m json.tool extensions/session-export-pdf/manifest.json
+```
+
+Manual verification:
+
+- with a conversation open, the titlebar export button appears; with no
+  conversation it is hidden
+- Export to PDF opens the print dialog showing only the titled transcript (not
+  the app chrome), with roles, code blocks, and links preserved
+- Copy as Markdown puts the conversation on the clipboard
+- the off-screen print container is removed after printing (no leftover DOM)
+
+## Known Limitations
+
+- PDF generation uses the browser print dialog (choose "Save as PDF") — there is
+  no silent server-side PDF render (deliberate: no bundled library, no backend).
+- Exports the currently-open conversation (not a bulk/all-sessions export).
+- Reads the rendered transcript, so only what's rendered in the DOM is exported;
+  very long virtualized transcripts export what is present in `#messages`.

--- a/extensions/session-export-pdf/README.md
+++ b/extensions/session-export-pdf/README.md
@@ -117,5 +117,13 @@ Manual verification:
 - PDF generation uses the browser print dialog (choose "Save as PDF") — there is
   no silent server-side PDF render (deliberate: no bundled library, no backend).
 - Exports the currently-open conversation (not a bulk/all-sessions export).
-- Reads the rendered transcript, so only what's rendered in the DOM is exported;
-  very long virtualized transcripts export what is present in `#messages`.
+- **Scope = the loaded/rendered transcript, not guaranteed to be the full
+  session.** It reads `#messages` from the DOM and adds no WebUI API dependency.
+  For long conversations the transcript can be windowed/virtualized (the core
+  "virtualize transcript" setting, or large sessions), so earlier messages may
+  not be in the DOM at export time. The extension **detects this** (a virtual
+  spacer / the virtualize flag) and, when it applies, shows a toast and prints a
+  visible "this covers the loaded transcript, scroll up for earlier messages"
+  note in the export — so a windowed export is never silently presented as
+  complete. For a guaranteed-complete copy, scroll to the top first (or disable
+  transcript virtualization) before exporting.

--- a/extensions/session-export-pdf/assets/session-export-pdf.css
+++ b/extensions/session-export-pdf/assets/session-export-pdf.css
@@ -1,0 +1,112 @@
+/* Session Export to PDF extension for Hermes WebUI.
+   Scoped to hwx-export-* / hwx-print-* classes. Uses core CSS variables. */
+
+/* ── titlebar button (flex child next to Reload — no absolute positioning,
+   so it can't collide with other titlebar controls) ── */
+.hwx-export-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted, #888);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color .12s ease, background .12s ease;
+}
+.hwx-export-btn:hover {
+  color: var(--text, #111);
+  background: var(--hover-bg, rgba(127, 127, 127, .14));
+}
+
+/* ── dropdown menu ── */
+.hwx-export-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 180px;
+  background: var(--surface, #fff);
+  color: var(--text, #111);
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, .28);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.hwx-export-item {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text, #111);
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: 7px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.hwx-export-item:hover { background: var(--hover-bg, rgba(127, 127, 127, .14)); }
+
+/* ── toast ── */
+.hwx-export-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 84px;
+  transform: translateX(-50%) translateY(8px);
+  background: var(--surface, #222);
+  color: var(--text, #fff);
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, .3);
+  opacity: 0;
+  transition: opacity .2s ease, transform .2s ease;
+  z-index: 1001;
+  pointer-events: none;
+}
+.hwx-export-toast--in { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+/* ── the print root: hidden on screen, the ONLY thing shown when printing ── */
+#hwxPrintRoot { display: none; }
+
+@media print {
+  /* When we're printing the conversation, hide the entire live app and show
+     only our print root. body.hwx-printing is added just before window.print(). */
+  body.hwx-printing > *:not(#hwxPrintRoot) { display: none !important; }
+  body.hwx-printing #hwxPrintRoot {
+    display: block !important;
+    position: static !important;
+    margin: 0;
+    padding: 0;
+    background: #fff !important;
+    color: #111 !important;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  #hwxPrintRoot .hwx-print-head { margin: 0 0 18px; padding-bottom: 10px; border-bottom: 2px solid #111; }
+  #hwxPrintRoot .hwx-print-head h1 { font-size: 20px; margin: 0 0 4px; }
+  #hwxPrintRoot .hwx-print-meta { font-size: 11px; color: #555; }
+  #hwxPrintRoot .hwx-print-msg { margin: 0 0 16px; page-break-inside: avoid; }
+  #hwxPrintRoot .hwx-print-role {
+    font-size: 11px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .04em; color: #555; margin-bottom: 4px;
+  }
+  #hwxPrintRoot .hwx-print-user .hwx-print-role { color: #1a56db; }
+  #hwxPrintRoot .hwx-print-body { font-size: 13px; line-height: 1.5; color: #111; }
+  #hwxPrintRoot .hwx-print-body pre {
+    background: #f4f4f4; border: 1px solid #ddd; border-radius: 6px;
+    padding: 8px 10px; overflow-x: auto; white-space: pre-wrap; word-break: break-word;
+    font-size: 12px; page-break-inside: avoid;
+  }
+  #hwxPrintRoot .hwx-print-body code { background: #f4f4f4; padding: 1px 4px; border-radius: 4px; font-size: 12px; }
+  #hwxPrintRoot .hwx-print-body img { max-width: 100%; }
+  #hwxPrintRoot .hwx-print-body a { color: #1a56db; text-decoration: underline; }
+  @page { margin: 1.5cm; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hwx-export-btn, .hwx-export-toast { transition: none; }
+}

--- a/extensions/session-export-pdf/assets/session-export-pdf.css
+++ b/extensions/session-export-pdf/assets/session-export-pdf.css
@@ -89,6 +89,7 @@
   #hwxPrintRoot .hwx-print-head { margin: 0 0 18px; padding-bottom: 10px; border-bottom: 2px solid #111; }
   #hwxPrintRoot .hwx-print-head h1 { font-size: 20px; margin: 0 0 4px; }
   #hwxPrintRoot .hwx-print-meta { font-size: 11px; color: #555; }
+  #hwxPrintRoot .hwx-print-note { font-size: 11px; color: #8a5a00; background: #fff7e6; border: 1px solid #f0d8a8; border-radius: 6px; padding: 6px 8px; margin-top: 8px; }
   #hwxPrintRoot .hwx-print-msg { margin: 0 0 16px; page-break-inside: avoid; }
   #hwxPrintRoot .hwx-print-role {
     font-size: 11px; font-weight: 700; text-transform: uppercase;

--- a/extensions/session-export-pdf/assets/session-export-pdf.js
+++ b/extensions/session-export-pdf/assets/session-export-pdf.js
@@ -1,0 +1,244 @@
+(() => {
+  'use strict';
+
+  // ── Session Export to PDF extension for Hermes WebUI ─────────────────────
+  // Adds an "Export conversation" button to the app titlebar (next to Reload).
+  // Clicking it opens a small menu: Export to PDF (print) or Copy as Markdown.
+  // The PDF path clones the rendered transcript into a print-styled, off-screen
+  // container and calls window.print() with a scoped @media print stylesheet, so
+  // you control the output formatting instead of relying on raw Ctrl+P of the
+  // whole app chrome. No backend, no bundled PDF library, no network.
+  //
+  // Credit: design reference is closed core PR #3425 (@vanshaj-pahwa) — the
+  // print-markup / formatting approach; this is the extension form of that idea.
+
+  const EXT = 'session-export-pdf';
+  if (window.__hermesSessionExportLoaded) return;
+  window.__hermesSessionExportLoaded = true;
+
+  const BTN_ID = 'hwxExportBtn';
+  const MENU_ID = 'hwxExportMenu';
+  const PRINT_ROOT_ID = 'hwxPrintRoot';
+
+  function $(id) { return document.getElementById(id); }
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function currentTitle() {
+    const el = $('appTitlebarTitle');
+    const t = el ? el.textContent.trim() : '';
+    return (t && t !== 'Hermes') ? t : 'Conversation';
+  }
+
+  function hasOpenConversation() {
+    const c = $('messages');
+    return !!(c && c.querySelector('[data-msg-idx]'));
+  }
+
+  // ── extract the transcript as ordered {role, html/text} rows ─────────────
+  // We read the REAL rendered rows so formatting (code blocks, lists, etc.) is
+  // preserved for the PDF, and plain text for the Markdown copy. Hidden
+  // anchor/worklog segments are skipped (same lesson as message-pins).
+  function collectRows() {
+    const container = $('messages');
+    if (!container) return [];
+    const rows = [];
+    const seen = new Set();
+    container.querySelectorAll('[data-msg-idx]').forEach((node) => {
+      if (node.classList &&
+          (node.classList.contains('assistant-segment-anchor') ||
+           node.classList.contains('assistant-segment-worklog-source'))) return;
+      const idx = node.getAttribute('data-msg-idx');
+      if (idx == null || seen.has(idx)) return;
+      const body = node.querySelector('.msg-body');
+      if (!body) return;
+      if (node.getBoundingClientRect().height <= 1) return;
+      seen.add(idx);
+      const isUser = !!node.closest('.msg-row') &&
+        !node.classList.contains('assistant-turn') &&
+        !node.querySelector('.role-icon.assistant');
+      // role detection: assistant turns carry .role-icon.assistant / .assistant-turn
+      const assistant = node.classList.contains('assistant-turn') ||
+        node.querySelector('.role-icon.assistant') ||
+        node.closest('.assistant-turn');
+      rows.push({
+        role: assistant ? 'assistant' : 'user',
+        html: body.innerHTML,
+        text: (body.innerText || body.textContent || '').trim(),
+      });
+    });
+    return rows;
+  }
+
+  // ── PDF via print ─────────────────────────────────────────────────────────
+  function exportPdf() {
+    const rows = collectRows();
+    if (!rows.length) { toast('No conversation to export.'); return; }
+    const title = currentTitle();
+    // Build an off-screen print root that ONLY shows during print.
+    let root = $(PRINT_ROOT_ID);
+    if (root) root.remove();
+    root = document.createElement('div');
+    root.id = PRINT_ROOT_ID;
+    root.setAttribute('aria-hidden', 'true');
+    let html = '<div class="hwx-print-head"><h1>' + escapeHtml(title) + '</h1>' +
+      '<div class="hwx-print-meta">' + escapeHtml(new Date().toLocaleString()) +
+      ' · ' + rows.length + ' messages</div></div>';
+    for (const r of rows) {
+      html += '<div class="hwx-print-msg hwx-print-' + r.role + '">' +
+        '<div class="hwx-print-role">' + (r.role === 'user' ? 'You' : 'Assistant') + '</div>' +
+        '<div class="hwx-print-body">' + r.html + '</div></div>';
+    }
+    root.innerHTML = html;
+    document.body.appendChild(root);
+    document.body.classList.add('hwx-printing');
+    const cleanup = () => {
+      document.body.classList.remove('hwx-printing');
+      const r = $(PRINT_ROOT_ID);
+      if (r) r.remove();
+      window.removeEventListener('afterprint', cleanup);
+    };
+    window.addEventListener('afterprint', cleanup);
+    // Give layout a tick, then print.
+    setTimeout(() => { try { window.print(); } catch (_) { cleanup(); } }, 60);
+    closeMenu();
+  }
+
+  // ── Markdown copy ─────────────────────────────────────────────────────────
+  function exportMarkdown() {
+    const rows = collectRows();
+    if (!rows.length) { toast('No conversation to export.'); return; }
+    let md = '# ' + currentTitle() + '\n\n';
+    for (const r of rows) {
+      md += '## ' + (r.role === 'user' ? 'You' : 'Assistant') + '\n\n' + r.text + '\n\n';
+    }
+    const done = () => toast('Conversation copied as Markdown');
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(md).then(done).catch(() => fallbackCopy(md, done));
+    } else {
+      fallbackCopy(md, done);
+    }
+    closeMenu();
+  }
+  function fallbackCopy(text, done) {
+    const ta = document.createElement('textarea');
+    ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+    document.body.appendChild(ta); ta.select();
+    try { document.execCommand('copy'); done(); } catch (_) {}
+    ta.remove();
+  }
+
+  // ── menu ──────────────────────────────────────────────────────────────────
+  function toggleMenu(anchor) {
+    if ($(MENU_ID)) { closeMenu(); return; }
+    const menu = document.createElement('div');
+    menu.id = MENU_ID;
+    menu.className = 'hwx-export-menu';
+    menu.setAttribute('role', 'menu');
+    const mkItem = (label, fn) => {
+      const b = document.createElement('button');
+      b.type = 'button'; b.className = 'hwx-export-item'; b.textContent = label;
+      b.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); fn(); });
+      return b;
+    };
+    menu.appendChild(mkItem('Export to PDF', exportPdf));
+    menu.appendChild(mkItem('Copy as Markdown', exportMarkdown));
+    document.body.appendChild(menu);
+    const r = anchor.getBoundingClientRect();
+    const w = menu.offsetWidth || 180;
+    let left = r.right - w;
+    if (left < 8) left = 8;
+    menu.style.left = left + 'px';
+    menu.style.top = (r.bottom + 6) + 'px';
+    setTimeout(() => {
+      document.addEventListener('pointerdown', outside, true);
+      document.addEventListener('keydown', esc, true);
+    }, 0);
+  }
+  function outside(e) { const m = $(MENU_ID); if (m && !m.contains(e.target) && e.target.id !== BTN_ID && !(e.target.closest && e.target.closest('#' + BTN_ID))) closeMenu(); }
+  function esc(e) { if (e.key === 'Escape') closeMenu(); }
+  function closeMenu() {
+    const m = $(MENU_ID); if (m) m.remove();
+    document.removeEventListener('pointerdown', outside, true);
+    document.removeEventListener('keydown', esc, true);
+  }
+
+  // ── toast ─────────────────────────────────────────────────────────────────
+  function toast(msg) {
+    const t = document.createElement('div');
+    t.className = 'hwx-export-toast'; t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(() => { t.classList.add('hwx-export-toast--in'); }, 10);
+    setTimeout(() => { t.classList.remove('hwx-export-toast--in'); setTimeout(() => t.remove(), 250); }, 2200);
+  }
+
+  // ── titlebar button ───────────────────────────────────────────────────────
+  function icon() {
+    return '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+      'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/>' +
+      '<line x1="12" y1="15" x2="12" y2="3"/></svg>';
+  }
+  function ensureButton() {
+    if ($(BTN_ID)) return $(BTN_ID);
+    const reload = $('btnReload');
+    const titlebar = document.querySelector('.app-titlebar');
+    if (!titlebar) return null;
+    const btn = document.createElement('button');
+    btn.id = BTN_ID;
+    btn.type = 'button';
+    btn.className = 'hwx-export-btn has-tooltip has-tooltip--bottom';
+    btn.dataset.tooltip = 'Export conversation';
+    btn.setAttribute('aria-label', 'Export conversation');
+    btn.innerHTML = icon();
+    btn.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); toggleMenu(btn); });
+    // Place just before Reload so it sits in the titlebar's right cluster.
+    if (reload && reload.parentNode) reload.parentNode.insertBefore(btn, reload);
+    else titlebar.appendChild(btn);
+    return btn;
+  }
+
+  function refresh() {
+    const btn = ensureButton();
+    if (!btn) return;
+    btn.style.display = hasOpenConversation() ? '' : 'none';
+  }
+
+  // ── observe so the button shows/hides with the open conversation ──────────
+  let raf = false;
+  function schedule() {
+    if (raf) return; raf = true;
+    requestAnimationFrame(() => { raf = false; try { refresh(); } catch (_) {} });
+  }
+
+  function install(attempt) {
+    attempt = attempt || 0;
+    if (document.querySelector('.app-titlebar')) {
+      ensureButton();
+      refresh();
+      const c = $('messages');
+      if (c) {
+        const obs = new MutationObserver(schedule);
+        obs.observe(c, { childList: true, subtree: true });
+      }
+      window.HermesSessionExportExtension = {
+        version: '0.1.0',
+        exportPdf, exportMarkdown, refresh,
+      };
+      return true;
+    }
+    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
+    console.warn('[' + EXT + '] app titlebar not found; not installed');
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/session-export-pdf/assets/session-export-pdf.js
+++ b/extensions/session-export-pdf/assets/session-export-pdf.js
@@ -28,6 +28,49 @@
       .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
+  // Produce a SANITIZED clone of a rendered .msg-body for the print document.
+  // Although core already sanitizes rendered markdown, we never re-inject raw
+  // innerHTML (gate rule: clone, don't reparse attacker-influenceable HTML).
+  // We also strip OFF-ORIGIN media so exporting cannot fire cross-origin
+  // requests (image/audio/video beacons) — the extension declares
+  // network_external:false, and this keeps that honest. Same-origin and
+  // data:-URI media are preserved.
+  function sameOriginOrData(url) {
+    if (!url) return false;
+    const u = String(url).trim();
+    if (/^data:/i.test(u)) return true;
+    try {
+      const resolved = new URL(u, document.baseURI);
+      return resolved.origin === window.location.origin;
+    } catch (_) { return false; }
+  }
+  function sanitizeClone(body) {
+    const clone = body.cloneNode(true);
+    // Drop any event-handler attributes + script/style/iframe/object/embed nodes.
+    clone.querySelectorAll('script,style,iframe,object,embed,link,meta').forEach((n) => n.remove());
+    const walk = (el) => {
+      if (el.attributes) {
+        for (const attr of Array.from(el.attributes)) {
+          if (/^on/i.test(attr.name)) el.removeAttribute(attr.name);
+        }
+      }
+      // Strip off-origin media sources so export triggers no cross-origin fetch.
+      ['src', 'href', 'poster'].forEach((a) => {
+        if (el.hasAttribute && el.hasAttribute(a) && !sameOriginOrData(el.getAttribute(a))) {
+          if (a === 'src' || a === 'poster') el.removeAttribute(a);
+          // keep off-origin <a href> as plain text link target is harmless on print,
+          // but neutralize javascript: URLs entirely
+          if (a === 'href' && /^\s*javascript:/i.test(el.getAttribute(a) || '')) el.removeAttribute(a);
+        }
+      });
+      if (el.hasAttribute && el.hasAttribute('srcset')) el.removeAttribute('srcset');
+      let child = el.firstElementChild;
+      while (child) { walk(child); child = child.nextElementSibling; }
+    };
+    walk(clone);
+    return clone;
+  }
+
   function currentTitle() {
     const el = $('appTitlebarTitle');
     const t = el ? el.textContent.trim() : '';
@@ -67,7 +110,7 @@
         node.closest('.assistant-turn');
       rows.push({
         role: assistant ? 'assistant' : 'user',
-        html: body.innerHTML,
+        body: body,
         text: (body.innerText || body.textContent || '').trim(),
       });
     });
@@ -86,6 +129,11 @@
       if (!c) return false;
       if (c.querySelector('[data-virtual-spacer]')) return true;
       if (window._virtualizeTranscript === true) return true;
+      // Server-paginated "load earlier" state: core renders #loadOlderIndicator /
+      // .message-window-load-earlier when older messages are not yet loaded, so the
+      // DOM holds only a partial window (Frank/Codex, PR #27).
+      if (c.querySelector('#loadOlderIndicator, .message-window-load-earlier')) return true;
+      if (document.querySelector('#loadOlderIndicator, .message-window-load-earlier')) return true;
       return false;
     } catch (_) { return false; }
   }
@@ -101,7 +149,9 @@
     root = document.createElement('div');
     root.id = PRINT_ROOT_ID;
     root.setAttribute('aria-hidden', 'true');
-    let html = '<div class="hwx-print-head"><h1>' + escapeHtml(title) + '</h1>' +
+    // Head (extension-authored text only) is built as escaped HTML; the message
+    // BODIES are appended as SANITIZED CLONES (never raw innerHTML reparse).
+    const headHtml = '<div class="hwx-print-head"><h1>' + escapeHtml(title) + '</h1>' +
       '<div class="hwx-print-meta">' + escapeHtml(new Date().toLocaleString()) +
       ' · ' + rows.length + ' messages rendered</div>' +
       (windowed
@@ -111,12 +161,22 @@
           'the top to load earlier messages before exporting for a complete copy.</div>'
         : '') +
       '</div>';
+    const head = document.createElement('div');
+    head.innerHTML = headHtml;   // extension-authored, fully escaped above
+    root.appendChild(head);
     for (const r of rows) {
-      html += '<div class="hwx-print-msg hwx-print-' + r.role + '">' +
-        '<div class="hwx-print-role">' + (r.role === 'user' ? 'You' : 'Assistant') + '</div>' +
-        '<div class="hwx-print-body">' + r.html + '</div></div>';
+      const msg = document.createElement('div');
+      msg.className = 'hwx-print-msg hwx-print-' + r.role;
+      const role = document.createElement('div');
+      role.className = 'hwx-print-role';
+      role.textContent = (r.role === 'user' ? 'You' : 'Assistant');
+      const bodyWrap = document.createElement('div');
+      bodyWrap.className = 'hwx-print-body';
+      bodyWrap.appendChild(sanitizeClone(r.body));   // sanitized clone, not raw HTML
+      msg.appendChild(role);
+      msg.appendChild(bodyWrap);
+      root.appendChild(msg);
     }
-    root.innerHTML = html;
     document.body.appendChild(root);
     document.body.classList.add('hwx-printing');
     const cleanup = () => {

--- a/extensions/session-export-pdf/assets/session-export-pdf.js
+++ b/extensions/session-export-pdf/assets/session-export-pdf.js
@@ -75,10 +75,26 @@
   }
 
   // ── PDF via print ─────────────────────────────────────────────────────────
+  // Detect whether the transcript DOM is windowed/virtualized — in that case the
+  // rendered #messages only holds part of the conversation, so an export from the
+  // DOM is the "loaded/visible transcript", not necessarily the full session
+  // (Frank, PR #27). Signals: a virtual spacer node, or the virtualize flag on
+  // with a partial window.
+  function transcriptMaybeWindowed() {
+    try {
+      const c = $('messages');
+      if (!c) return false;
+      if (c.querySelector('[data-virtual-spacer]')) return true;
+      if (window._virtualizeTranscript === true) return true;
+      return false;
+    } catch (_) { return false; }
+  }
+
   function exportPdf() {
     const rows = collectRows();
     if (!rows.length) { toast('No conversation to export.'); return; }
     const title = currentTitle();
+    const windowed = transcriptMaybeWindowed();
     // Build an off-screen print root that ONLY shows during print.
     let root = $(PRINT_ROOT_ID);
     if (root) root.remove();
@@ -87,7 +103,14 @@
     root.setAttribute('aria-hidden', 'true');
     let html = '<div class="hwx-print-head"><h1>' + escapeHtml(title) + '</h1>' +
       '<div class="hwx-print-meta">' + escapeHtml(new Date().toLocaleString()) +
-      ' · ' + rows.length + ' messages</div></div>';
+      ' · ' + rows.length + ' messages rendered</div>' +
+      (windowed
+        ? '<div class="hwx-print-note">Note: this conversation is long enough to be ' +
+          'windowed/virtualized, so this export covers the currently-loaded ' +
+          'transcript, which may not include the entire conversation. Scroll to ' +
+          'the top to load earlier messages before exporting for a complete copy.</div>'
+        : '') +
+      '</div>';
     for (const r of rows) {
       html += '<div class="hwx-print-msg hwx-print-' + r.role + '">' +
         '<div class="hwx-print-role">' + (r.role === 'user' ? 'You' : 'Assistant') + '</div>' +
@@ -103,6 +126,7 @@
       window.removeEventListener('afterprint', cleanup);
     };
     window.addEventListener('afterprint', cleanup);
+    if (windowed) toast('Exporting the loaded transcript — scroll up to include earlier messages.');
     // Give layout a tick, then print.
     setTimeout(() => { try { window.print(); } catch (_) { cleanup(); } }, 60);
     closeMenu();
@@ -112,11 +136,19 @@
   function exportMarkdown() {
     const rows = collectRows();
     if (!rows.length) { toast('No conversation to export.'); return; }
+    const windowed = transcriptMaybeWindowed();
     let md = '# ' + currentTitle() + '\n\n';
+    if (windowed) {
+      md += '> _Note: this export covers the currently-loaded transcript and may ' +
+        'not include the entire conversation (long transcripts are windowed). ' +
+        'Scroll to the top to load earlier messages before exporting._\n\n';
+    }
     for (const r of rows) {
       md += '## ' + (r.role === 'user' ? 'You' : 'Assistant') + '\n\n' + r.text + '\n\n';
     }
-    const done = () => toast('Conversation copied as Markdown');
+    const done = () => toast(windowed
+      ? 'Loaded transcript copied as Markdown (scroll up for earlier messages)'
+      : 'Conversation copied as Markdown');
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(md).then(done).catch(() => fallbackCopy(md, done));
     } else {

--- a/extensions/session-export-pdf/extension.json
+++ b/extensions/session-export-pdf/extension.json
@@ -1,0 +1,49 @@
+{
+  "id": "session-export-pdf",
+  "name": "Session Export to PDF",
+  "description": "Export the current conversation to a clean PDF (via the browser print dialog, with a print-styled layout) or copy it as Markdown. Adds an export button to the app titlebar. No backend, no bundled PDF library.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/session-export-pdf.js"
+    ],
+    "stylesheets": [
+      "assets/session-export-pdf.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false,
+    "uses_clipboard": true,
+    "uses_print": true
+  }
+}

--- a/extensions/session-export-pdf/manifest.json
+++ b/extensions/session-export-pdf/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "session-export-pdf",
+      "name": "Session Export to PDF",
+      "description": "Export the current conversation to PDF (print) or copy it as Markdown.",
+      "scripts": [
+        "assets/session-export-pdf.js"
+      ],
+      "stylesheets": [
+        "assets/session-export-pdf.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **`session-export-pdf`** extension — export the current conversation to a clean **PDF** (via the browser print dialog with a print-styled layout) or **copy it as Markdown**. Adds a download button to the app titlebar.

- Titlebar button (next to Reload), shown only when a conversation is open → menu with **Export to PDF** + **Copy as Markdown**.
- PDF path clones the rendered transcript into an off-screen print container and `window.print()`s with a scoped `@media print` stylesheet so the output is just the titled transcript (roles, code blocks, links preserved), not the app chrome.
- **No backend, no bundled PDF library, no network.**

## Credit
Design reference: closed core PR **nesquena/hermes-webui#3425** (@vanshaj-pahwa) — the print-markup/formatting approach. Routed to extensions to keep core lean.

## Full pre-push QA (fresh-port sim server, 12-message conversation)
Per the new `webui-extension-qa` process (the one that came out of @franksong2702's #19 review):
- ✅ titlebar button placed cleanly between New-Chat and Reload — **no overlap, vision-verified**
- ✅ menu opens with both items; button hides when no conversation is open
- ✅ **PDF print root builds with all 12 messages**, title, and **preserved code blocks**; `window.print()` fires and the `afterprint` handler cleans up the print root + body class
- ✅ **`@media print` isolation rule verified served** (hide app chrome / show only the print root / `@page` margins)
- ✅ **Copy as Markdown** produces a full titled doc (You/Assistant sections, code content)
- ✅ gates green (validate / safety-scan / registry / validator self-test)

## Permissions
- `network_external:false`; no API calls; no storage; `uses_print` + `uses_clipboard`; `dom.owned:true` (titlebar button + temporary print container, removed after print). Print body reuses core's already-sanitized rendered HTML (cloned, not re-parsed).

🤖 Agent-authored; flagging for review, not self-merging.
