### PR TITLE
Add mcp-tool-shortcuts extension (pin MCP tools, draft-not-execute)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -30,3 +30,5 @@ need it and maintainers agree on the shared contract.
   register into the native Appearance picker (needs core theme-registration).
 - `session-export-pdf`: export the current conversation to PDF (print) or copy
   it as Markdown, via a titlebar button.
+- `mcp-tool-shortcuts`: pin MCP tools and draft a ready-to-send request into
+  the composer (never auto-executes); lives in Settings → MCP Tools.

--- a/extensions/mcp-tool-shortcuts/README.md
+++ b/extensions/mcp-tool-shortcuts/README.md
@@ -1,0 +1,132 @@
+# MCP Tool Shortcuts
+
+MCP Tool Shortcuts is a trusted local Hermes WebUI extension that lets you **pin
+frequently-used MCP tools** and get a one-click strip that **drafts a
+ready-to-send natural-language tool request into the composer**. It **never
+auto-executes** a tool — it only inserts a prompt you review and send.
+
+## What It Does
+
+- In **Settings → MCP Tools**, each tool row gets a **pin star**.
+- Pinned tools appear as **clickable chips** in a "★ Pinned tools" strip at the
+  top of the MCP Tools section.
+- Clicking a chip drafts `Use the <name> tool (on the <server> server) to: `
+  into the composer, focuses it, and switches to chat so you can finish the
+  request and send it.
+- Pins persist in `localStorage` and are **filtered against the live tool list**
+  (from the authenticated `/api/mcp/tools`), so stale or cross-profile pins
+  simply don't render.
+
+## Safety (important)
+
+- It **never calls `/api/mcp/call`** and never executes a tool. It only **drafts
+  a prompt** into the composer for you to review and send — the same
+  draft-not-execute model as the source PR.
+- All tool names / servers are HTML-escaped wherever rendered.
+- Pins are filtered against the live, profile-scoped tool inventory, so a pin
+  from another profile or a removed tool never produces a chip.
+
+## Credit
+
+Design reference: closed core PR
+[#3222](https://github.com/nesquena/hermes-webui/pull/3222) (@AJV20) — the
+draft-not-execute model, `esc()`-everything, stale-pin filtering, and the
+`server::name` shortcut key. This is the extension form of that idea (routed to
+extensions to keep the core MCP panel lean).
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/mcp-tool-shortcuts.js + .css
+  -> GET /api/mcp/tools (live, authed) for the tool inventory
+  -> Settings -> MCP Tools: pin stars on rows + a "Pinned tools" chip strip
+  -> click a chip -> draft a prompt into #msg (composer) -> switch to chat
+  -> localStorage: hermes-ext-mcp-pinned-tools (["server::name", ...])
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, access external networks, read/write files, or use
+native host APIs. It reads the existing authenticated `/api/mcp/tools` endpoint.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/mcp-tool-shortcuts HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+Open **Settings → MCP Tools**, pin a tool with its star, then click its chip in
+the "Pinned tools" strip — a drafted request appears in the composer.
+
+## Controls
+
+Also on `window.HermesMcpShortcutsExtension`:
+
+- `.pins()` — current pinned keys (`server::name`)
+- `.refresh()` — re-fetch the live tool list and re-render
+
+## Disable And Uninstall
+
+Restart Hermes WebUI without `HERMES_WEBUI_EXTENSION_DIR` /
+`HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the
+`extensions/mcp-tool-shortcuts/` directory. Pins live under
+`hermes-ext-mcp-pinned-tools`.
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- creates extension-owned DOM (pin stars on tool rows + a pinned-tools chip
+  strip in the MCP Tools settings section)
+- reads the existing authenticated `GET /api/mcp/tools` (declared
+  `webui_api.read: ["mcp/tools"]`) for the live tool inventory
+- inserts a drafted natural-language prompt into the composer (`#msg`) and uses
+  `switchPanel('chat')` to show it (`webui_navigation: true`)
+- reads/writes `localStorage` under the single key
+  `hermes-ext-mcp-pinned-tools`
+- **does NOT call `/api/mcp/call` or execute any tool**, does NOT access cookies,
+  contact external networks, use the filesystem, or use native hosts
+
+## Compatibility
+
+- manifest-bundled extension assets + same-origin serving under `/extensions/`
+- the authenticated `/api/mcp/tools` endpoint
+- the MCP Tools settings DOM (`#mcpToolList`, `.mcp-tool-row`,
+  `.mcp-tool-name`, `.mcp-tool-server`) and the composer (`#msg`) — the
+  integration contract; a core rename would need an update
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.js
+python3 -m json.tool extensions/mcp-tool-shortcuts/extension.json
+python3 -m json.tool extensions/mcp-tool-shortcuts/manifest.json
+```
+
+Manual verification:
+
+- open Settings → MCP Tools; each tool row shows a pin star
+- pinning a tool adds a chip to the "Pinned tools" strip; unpinning removes it
+- clicking a chip drafts a request into the composer and switches to chat, and
+  does NOT execute anything
+- pins persist across a reload and a removed/cross-profile tool produces no chip
+- the strip + stars re-apply after the tool list re-renders (search/pagination)
+
+## Known Limitations
+
+- Pinning happens in Settings → MCP Tools (where the tool list lives); the chips
+  also render there. (A future version could surface the chips near the composer
+  too.)
+- Drafts a generic "use this tool to: …" prompt — it does not pre-fill tool
+  arguments (deliberate: no execution, no schema-form).
+- Relies on the MCP Tools DOM + `/api/mcp/tools`; a core rename would need an
+  update.

--- a/extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.css
+++ b/extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.css
@@ -1,0 +1,95 @@
+/* MCP Tool Shortcuts extension for Hermes WebUI.
+   Scoped to hwx-mcp-* classes; uses core CSS variables. */
+
+/* pin star on each tool row */
+.hwx-mcp-star {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-left: 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted, #888);
+  cursor: pointer;
+  flex: 0 0 auto;
+  vertical-align: middle;
+  transition: color .12s ease, background .12s ease;
+}
+.hwx-mcp-star:hover { color: var(--text, #111); background: var(--hover-bg, rgba(127,127,127,.14)); }
+.hwx-mcp-star--on { color: var(--accent, #f5c542); }
+
+/* pinned-tools strip */
+.hwx-mcp-strip {
+  margin: 0 0 12px;
+  padding: 10px;
+  border: 1px solid var(--border2, rgba(127,127,127,.25));
+  border-radius: 10px;
+  background: var(--code-bg, rgba(127,127,127,.08));
+}
+.hwx-mcp-strip-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--accent-text, var(--accent, #f5c542));
+  margin-bottom: 8px;
+}
+.hwx-mcp-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.hwx-mcp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 6px 5px 10px;
+  border: 1px solid var(--border2, rgba(127,127,127,.3));
+  border-radius: 999px;
+  background: var(--surface, #fff);
+  color: var(--text, #111);
+  font-size: 12px;
+  cursor: pointer;
+  max-width: 100%;
+  transition: border-color .12s ease, background .12s ease;
+}
+.hwx-mcp-chip:hover { border-color: var(--accent, #6366f1); background: var(--hover-bg, rgba(127,127,127,.12)); }
+.hwx-mcp-chip-name { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 160px; }
+.hwx-mcp-chip-server { color: var(--muted, #888); font-size: 11px; white-space: nowrap; }
+.hwx-mcp-chip-x {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--muted, #888);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 50%;
+}
+.hwx-mcp-chip-x:hover { color: var(--danger, #e5534b); background: var(--hover-bg, rgba(127,127,127,.18)); }
+
+/* toast */
+.hwx-mcp-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 84px;
+  transform: translateX(-50%) translateY(8px);
+  background: var(--surface, #222);
+  color: var(--text, #fff);
+  border: 1px solid var(--border, rgba(127,127,127,.3));
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  box-shadow: 0 6px 20px rgba(0,0,0,.3);
+  opacity: 0;
+  transition: opacity .2s ease, transform .2s ease;
+  z-index: 1001;
+  pointer-events: none;
+  max-width: 80vw;
+  text-align: center;
+}
+.hwx-mcp-toast--in { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+@media (prefers-reduced-motion: reduce) {
+  .hwx-mcp-star, .hwx-mcp-chip, .hwx-mcp-toast { transition: none; }
+}

--- a/extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.js
+++ b/extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.js
@@ -52,7 +52,7 @@
     const apiFn = window.api;
     const p = (typeof apiFn === 'function')
       ? apiFn('/api/mcp/tools')
-      : fetch(new URL('api/mcp/tools', document.baseURI || location.href).href, { credentials: 'same-origin' })
+      : fetch('/api/mcp/tools', { credentials: 'same-origin' })
           .then((r) => r.ok ? r.json() : { tools: [] });
     return Promise.resolve(p).then((r) => {
       liveTools = (r && Array.isArray(r.tools)) ? r.tools : [];

--- a/extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.js
+++ b/extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.js
@@ -49,11 +49,12 @@
   // ── live tool list (authed endpoint; do NOT rely on the in-page cache) ────
   let liveTools = [];
   function fetchTools() {
-    const apiFn = window.api;
-    const p = (typeof apiFn === 'function')
-      ? apiFn('/api/mcp/tools')
-      : fetch('/api/mcp/tools', { credentials: 'same-origin' })
-          .then((r) => r.ok ? r.json() : { tools: [] });
+    // Always use an ABSOLUTE same-origin fetch. (Do NOT route through window.api:
+    // core's api() strips the leading slash and resolves against document.baseURI,
+    // so on a /session/<id> route '/api/mcp/tools' becomes '/session/api/mcp/tools'
+    // → 404 → silent empty tool list. Codex gate, PR #28.)
+    const p = fetch('/api/mcp/tools', { credentials: 'same-origin' })
+      .then((r) => r.ok ? r.json() : { tools: [] });
     return Promise.resolve(p).then((r) => {
       liveTools = (r && Array.isArray(r.tools)) ? r.tools : [];
       return liveTools;
@@ -214,7 +215,10 @@
     const list = $('mcpToolList');
     if (!list) return false;
     const obs = new MutationObserver(schedule);
-    obs.observe(list, { childList: true, subtree: true });
+    // childList only (NOT subtree): decorateRows() rewrites star.innerHTML, and a
+    // subtree observer would re-trigger on our own mutation → rAF/decorate loop.
+    // Core renders MCP rows as direct children of #mcpToolList. (Codex gate, PR #28.)
+    obs.observe(list, { childList: true });
     return true;
   }
 

--- a/extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.js
+++ b/extensions/mcp-tool-shortcuts/assets/mcp-tool-shortcuts.js
@@ -1,0 +1,259 @@
+(() => {
+  'use strict';
+
+  // ── MCP Tool Shortcuts extension for Hermes WebUI ────────────────────────
+  // Pin frequently-used MCP tools and get a one-click strip that DRAFTS a
+  // ready-to-send natural-language tool request into the composer. It NEVER
+  // auto-executes a tool (it does not call /api/mcp/call) — it only inserts a
+  // prompt you can review and send.
+  //
+  // - a "pin" star is added to each tool row in Settings -> MCP Tools
+  // - pinned tools appear as clickable chips at the top of the MCP Tools section
+  // - clicking a chip drafts "Use the <name> tool (on <server>) to: " into the
+  //   composer, focuses it, and switches to chat
+  // - pins persist in localStorage and are filtered against the LIVE tool list
+  //   (stale / cross-profile pins simply don't render)
+  //
+  // Credit: design reference is closed core PR #3222 (@AJV20) — the
+  // draft-not-execute model, esc()-everything, stale-pin filtering, and the
+  // server::name shortcut key. This is the extension form of that idea.
+
+  const EXT = 'mcp-tool-shortcuts';
+  if (window.__hermesMcpShortcutsLoaded) return;
+  window.__hermesMcpShortcutsLoaded = true;
+
+  const STORE_KEY = 'hermes-ext-mcp-pinned-tools';   // [ "server::name", ... ]
+  const STRIP_ID = 'hwxMcpPinStrip';
+
+  function $(id) { return document.getElementById(id); }
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function toolKey(server, name) { return (server || 'unknown') + '::' + (name || ''); }
+
+  function loadPins() {
+    try {
+      const raw = localStorage.getItem(STORE_KEY);
+      if (!raw) return [];
+      const a = JSON.parse(raw);
+      return Array.isArray(a) ? a.filter((x) => typeof x === 'string') : [];
+    } catch (_) { return []; }
+  }
+  function savePins(pins) {
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(pins)); } catch (_) {}
+  }
+
+  // ── live tool list (authed endpoint; do NOT rely on the in-page cache) ────
+  let liveTools = [];
+  function fetchTools() {
+    const apiFn = window.api;
+    const p = (typeof apiFn === 'function')
+      ? apiFn('/api/mcp/tools')
+      : fetch(new URL('api/mcp/tools', document.baseURI || location.href).href, { credentials: 'same-origin' })
+          .then((r) => r.ok ? r.json() : { tools: [] });
+    return Promise.resolve(p).then((r) => {
+      liveTools = (r && Array.isArray(r.tools)) ? r.tools : [];
+      return liveTools;
+    }).catch(() => { liveTools = []; return liveTools; });
+  }
+
+  function pinnedLiveTools() {
+    const pins = new Set(loadPins());
+    return liveTools.filter((t) => pins.has(toolKey(t.server, t.name)));
+  }
+
+  function isPinned(server, name) {
+    return loadPins().indexOf(toolKey(server, name)) >= 0;
+  }
+  function togglePin(server, name) {
+    const key = toolKey(server, name);
+    let pins = loadPins();
+    if (pins.indexOf(key) >= 0) pins = pins.filter((k) => k !== key);
+    else pins.push(key);
+    savePins(pins);
+    renderStrip();
+    decorateRows();
+  }
+
+  // ── draft a prompt into the composer (NEVER execute) ─────────────────────
+  function draftPrompt(tool) {
+    const input = $('msg');
+    if (!input) return;
+    const server = tool.server ? ' (on the ' + tool.server + ' server)' : '';
+    const draft = 'Use the ' + (tool.name || 'tool') + ' tool' + server + ' to: ';
+    // switch to chat so the composer is visible
+    if (typeof window.switchPanel === 'function') {
+      try { window.switchPanel('chat'); } catch (_) {}
+    }
+    // close settings overlay if open (best-effort; harmless if not)
+    input.value = draft;
+    input.focus();
+    // place caret at end
+    try { input.selectionStart = input.selectionEnd = input.value.length; } catch (_) {}
+    // let the composer enable its send button / autosize
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    toast('Drafted a request for "' + (tool.name || 'tool') + '" — review and send');
+  }
+
+  // ── the pinned-tools strip (top of the MCP Tools section) ────────────────
+  function mcpToolsSection() {
+    const list = $('mcpToolList');
+    return list ? list.parentElement : null;   // the settings-field wrapping the tools
+  }
+
+  function renderStrip() {
+    const section = mcpToolsSection();
+    if (!section) return;
+    let strip = $(STRIP_ID);
+    const pinned = pinnedLiveTools();
+    if (!pinned.length) {
+      if (strip) strip.remove();
+      return;
+    }
+    if (!strip) {
+      strip = document.createElement('div');
+      strip.id = STRIP_ID;
+      strip.className = 'hwx-mcp-strip';
+      // insert just before the tool list (above search results)
+      const list = $('mcpToolList');
+      section.insertBefore(strip, list);
+    }
+    let html = '<div class="hwx-mcp-strip-title">\u2605 Pinned tools</div><div class="hwx-mcp-chips">';
+    pinned.forEach((t, i) => {
+      html += '<span class="hwx-mcp-chip" data-i="' + i + '" role="button" tabindex="0" ' +
+        'title="Draft a request using ' + escapeHtml(t.name) + '">' +
+        '<span class="hwx-mcp-chip-name">' + escapeHtml(t.name) + '</span>' +
+        '<span class="hwx-mcp-chip-server">' + escapeHtml(t.server || '') + '</span>' +
+        '<button type="button" class="hwx-mcp-chip-x" data-i="' + i + '" aria-label="Unpin" title="Unpin">\u00d7</button>' +
+        '</span>';
+    });
+    html += '</div>';
+    strip.innerHTML = html;
+    // wire chips
+    strip.querySelectorAll('.hwx-mcp-chip').forEach((chip) => {
+      const t = pinned[parseInt(chip.dataset.i, 10)];
+      chip.addEventListener('click', (e) => {
+        if (e.target.closest('.hwx-mcp-chip-x')) return;
+        draftPrompt(t);
+      });
+      chip.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); draftPrompt(t); }
+      });
+    });
+    strip.querySelectorAll('.hwx-mcp-chip-x').forEach((x) => {
+      const t = pinned[parseInt(x.dataset.i, 10)];
+      x.addEventListener('click', (e) => {
+        e.preventDefault(); e.stopPropagation();
+        togglePin(t.server, t.name);
+      });
+    });
+  }
+
+  // ── pin stars on each tool row ───────────────────────────────────────────
+  function decorateRows() {
+    const list = $('mcpToolList');
+    if (!list) return;
+    list.querySelectorAll('.mcp-tool-row').forEach((row) => {
+      const nameEl = row.querySelector('.mcp-tool-name');
+      const serverEl = row.querySelector('.mcp-tool-server');
+      if (!nameEl) return;
+      const name = nameEl.textContent.trim();
+      const server = serverEl ? serverEl.textContent.trim() : '';
+      const pinned = isPinned(server, name);
+      let star = row.querySelector(':scope .hwx-mcp-star');
+      if (!star) {
+        star = document.createElement('button');
+        star.type = 'button';
+        star.className = 'hwx-mcp-star';
+        const head = row.querySelector('.mcp-server-row-head') || row;
+        head.appendChild(star);
+      }
+      star.classList.toggle('hwx-mcp-star--on', pinned);
+      star.title = pinned ? 'Unpin tool' : 'Pin tool';
+      star.setAttribute('aria-label', star.title);
+      star.setAttribute('aria-pressed', pinned ? 'true' : 'false');
+      star.innerHTML = starSvg(pinned);
+      if (!star.dataset.wired) {
+        star.dataset.wired = '1';
+        star.addEventListener('click', (e) => {
+          e.preventDefault(); e.stopPropagation();
+          const n = nameEl.textContent.trim();
+          const s = serverEl ? serverEl.textContent.trim() : '';
+          togglePin(s, n);
+        });
+      }
+    });
+  }
+
+  function starSvg(filled) {
+    return '<svg width="13" height="13" viewBox="0 0 24 24" fill="' + (filled ? 'currentColor' : 'none') +
+      '" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>';
+  }
+
+  // ── toast ─────────────────────────────────────────────────────────────────
+  function toast(msg) {
+    const t = document.createElement('div');
+    t.className = 'hwx-mcp-toast'; t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(() => t.classList.add('hwx-mcp-toast--in'), 10);
+    setTimeout(() => { t.classList.remove('hwx-mcp-toast--in'); setTimeout(() => t.remove(), 250); }, 2400);
+  }
+
+  // ── observe the MCP tool list re-rendering (pagination/search/panel open) ──
+  let raf = false;
+  function schedule() {
+    if (raf) return; raf = true;
+    requestAnimationFrame(() => { raf = false; try { renderStrip(); decorateRows(); } catch (_) {} });
+  }
+
+  function startObserver() {
+    const list = $('mcpToolList');
+    if (!list) return false;
+    const obs = new MutationObserver(schedule);
+    obs.observe(list, { childList: true, subtree: true });
+    return true;
+  }
+
+  function refreshAll() {
+    return fetchTools().then(() => { renderStrip(); decorateRows(); });
+  }
+
+  function install(attempt) {
+    attempt = attempt || 0;
+    if ($('mcpToolList')) {
+      startObserver();
+      refreshAll();
+      window.HermesMcpShortcutsExtension = {
+        version: '0.1.0',
+        pins: loadPins,
+        refresh: refreshAll,
+        _draft: draftPrompt,
+      };
+      return true;
+    }
+    // The MCP Tools list only exists once Settings → MCP Tools has rendered.
+    // Watch the document for it appearing, then install once.
+    if (!window.__hermesMcpShortcutsWatching) {
+      window.__hermesMcpShortcutsWatching = true;
+      const bodyObs = new MutationObserver(() => {
+        if ($('mcpToolList')) {
+          bodyObs.disconnect();
+          window.__hermesMcpShortcutsWatching = false;
+          install();
+        }
+      });
+      bodyObs.observe(document.body, { childList: true, subtree: true });
+    }
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/mcp-tool-shortcuts/extension.json
+++ b/extensions/mcp-tool-shortcuts/extension.json
@@ -1,0 +1,53 @@
+{
+  "id": "mcp-tool-shortcuts",
+  "name": "MCP Tool Shortcuts",
+  "description": "Pin frequently-used MCP tools and get a one-click strip that DRAFTS a ready-to-send natural-language tool request into the composer. Never auto-executes a tool \u2014 it only inserts a prompt you review and send. Lives in Settings \u2192 MCP Tools.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/mcp-tool-shortcuts.js"
+    ],
+    "stylesheets": [
+      "assets/mcp-tool-shortcuts.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [
+        "mcp/tools"
+      ],
+      "write": []
+    },
+    "webui_navigation": true,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-mcp-pinned-tools"
+      ],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false,
+    "drafts_composer_prompt": true,
+    "never_executes_tools": true
+  }
+}

--- a/extensions/mcp-tool-shortcuts/manifest.json
+++ b/extensions/mcp-tool-shortcuts/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "mcp-tool-shortcuts",
+      "name": "MCP Tool Shortcuts",
+      "description": "Pin MCP tools and draft a ready-to-send request into the composer (never auto-executes).",
+      "scripts": [
+        "assets/mcp-tool-shortcuts.js"
+      ],
+      "stylesheets": [
+        "assets/mcp-tool-shortcuts.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **`mcp-tool-shortcuts`** extension — pin frequently-used MCP tools and get a one-click strip that **drafts a ready-to-send natural-language request into the composer**. It **never auto-executes** a tool.

- In **Settings → MCP Tools**, each tool row gets a **pin star**; pinned tools appear as **chips** at the top of the section.
- Clicking a chip drafts `Use the <name> tool (on the <server> server) to: ` into the composer (`#msg`), focuses it, and switches to chat.
- Reads the live authed `/api/mcp/tools`; pins persist in `localStorage` and are **filtered against the live list** (stale / cross-profile pins never render). All names HTML-escaped.

## Safety
- **Never calls `/api/mcp/call`** / never executes — draft-only, you review and send. Verified in QA with a call-trap (`mcpCallInvoked: false`).

## Credit
Design reference: closed core PR **nesquena/hermes-webui#3222** (@AJV20) — the draft-not-execute model, `esc()`-everything, stale-pin filtering, and the `server::name` key. Routed to extensions to keep the core MCP panel lean.

## Full pre-push QA (fresh-port sim server)
- ✅ installs and **handles an empty tool list gracefully** (no empty strip / clutter)
- ✅ with tools present: each row gets a star; pinning shows the chip strip with **provider-aware keys** (`filesystem::search_files`)
- ✅ clicking a chip **drafts into the composer + switches to chat** and **does NOT invoke `/api/mcp/call`** (trap-verified) — composer draft vision-verified in the real UI
- ✅ **stale-pin filtering**: a ghost pin not in the live list renders no chip
- ✅ unpin via the chip × works; strip/stars re-apply after the tool list re-renders
- ✅ gates green (validate / safety-scan / registry / validator self-test)

## Permissions
- `webui_api.read:["mcp/tools"]`, `webui_navigation:true` (switchPanel + composer draft), `storage.owned:["hermes-ext-mcp-pinned-tools"]`, `dom.owned:true`; no `/api/mcp/call`, no cookies, no network, no filesystem/native host.

🤖 Agent-authored; flagging for review, not self-merging.
