### PR TITLE
voicevox-tts: add configurable base URL, voice list, and settings URL field

### DIFF
--- a/extensions/voicevox-tts/assets/voicevox-tts.js
+++ b/extensions/voicevox-tts/assets/voicevox-tts.js
@@ -22,10 +22,18 @@
   if (window.__hermesVoicevoxLoaded) return;
   window.__hermesVoicevoxLoaded = true;
 
-  // VOICEVOX engine base. Loopback only (no external network). The speaker id
-  // is configurable via localStorage; default 1 (a standard VOICEVOX voice).
-  const BASE = 'http://127.0.0.1:50021';
+  // VOICEVOX engine base. Configurable via localStorage (hermes-ext-voicevox-base).
+  // The speaker id is also configurable; default 1 (a standard VOICEVOX voice).
+  const BASE_KEY = 'hermes-ext-voicevox-base';
+  const DEF_BASE = 'http://127.0.0.1:50021';
   const SPEAKER_KEY = 'hermes-ext-voicevox-speaker';
+
+  function baseUrl() {
+    var v = (localStorage.getItem(BASE_KEY) || '').trim();
+    if (!v) return DEF_BASE;
+    if (v.charAt(0) === '/') return v;
+    try { new URL(v); return v; } catch (_) { return DEF_BASE; }
+  }
 
   function speakerId() {
     const v = parseInt(localStorage.getItem(SPEAKER_KEY) || '', 10);
@@ -36,8 +44,9 @@
   //   1) POST /audio_query?text=...&speaker=N  -> a query JSON
   //   2) POST /synthesis?speaker=N  (body: the query JSON)  -> WAV audio bytes
   function synthesize(text, opts) {
+    const base = baseUrl();
     const speaker = speakerId();
-    const q = BASE + '/audio_query?text=' + encodeURIComponent(text) +
+    const q = base + '/audio_query?text=' + encodeURIComponent(text) +
       '&speaker=' + encodeURIComponent(speaker);
     return fetch(q, { method: 'POST' })
       .then(function (r) {
@@ -50,7 +59,7 @@
         if (opts && typeof opts.rate === 'number' && !isNaN(opts.rate)) {
           query.speedScale = Math.min(2, Math.max(0.5, opts.rate));
         }
-        return fetch(BASE + '/synthesis?speaker=' + encodeURIComponent(speaker), {
+        return fetch(base + '/synthesis?speaker=' + encodeURIComponent(speaker), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(query),
@@ -61,6 +70,96 @@
         return r.arrayBuffer();   // WAV bytes -> core plays via <audio>
       });
   }
+
+  // ── Voice list ───────────────────────────────────────────────────
+  var _voiceCache = null, _voiceCacheTs = 0, _voiceCacheBase = null;
+
+  function fetchVoices() {
+    var cb = baseUrl();
+    if (_voiceCache && _voiceCacheBase === cb && Date.now() - _voiceCacheTs < 30000)
+      return Promise.resolve(_voiceCache);
+    return fetch(cb + '/speakers')
+      .then(function (r) { if (!r.ok) throw new Error('speakers ' + r.status); return r.json(); })
+      .then(function (speakers) {
+        var voices = [];
+        speakers.forEach(function (sp) {
+          (sp.styles || []).forEach(function (st) {
+            voices.push({ value: String(st.id), label: sp.name + ' (' + st.name + ')' });
+          });
+        });
+        _voiceCache = voices; _voiceCacheTs = Date.now(); _voiceCacheBase = cb;
+        return voices;
+      });
+  }
+
+  function populateVoiceDropdown(sel) {
+    if (!sel) return;
+    sel.innerHTML = '<option value="">Loading voices...</option>';
+    fetchVoices().then(function (voices) {
+      if (!voices || !voices.length) { sel.innerHTML = '<option value="">No voices available</option>'; return; }
+      var cur = localStorage.getItem('hermes-tts-voice') || '';
+      sel.innerHTML = '<option value="">Default speaker</option>';
+      voices.forEach(function (v) {
+        var opt = document.createElement('option');
+        opt.value = v.value; opt.textContent = v.label;
+        if (v.value === cur) opt.selected = true;
+        sel.appendChild(opt);
+      });
+    }).catch(function () { sel.innerHTML = '<option value="">Failed to load voices</option>'; });
+  }
+
+  // ── URL field + MutationObserver ──────────────────────────────────-
+  var _urlInjected = false;
+  function injectUrlField() {
+    if (_urlInjected) return;
+    var vs = document.getElementById('settingsTtsVoice');
+    if (!vs) return;
+    var vf = vs.closest('.settings-field');
+    if (!vf) return;
+    var div = document.createElement('div');
+    div.className = 'settings-field'; div.id = 'settingsVoicevoxUrlField';
+    div.style.display = 'none';
+    div.innerHTML = '<label for="settingsVoicevoxUrl">VOICEVOX Server URL</label>'
+      + '<input type="text" id="settingsVoicevoxUrl" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px" placeholder="http://127.0.0.1:50021">'
+      + '<div style="font-size:11px;color:var(--muted);margin-top:4px">Override the VOICEVOX server address. Defaults to the standard loopback. Use a relative path for same-origin proxies.</div>';
+    vf.parentNode.insertBefore(div, vf.nextSibling);
+    var inp = document.getElementById('settingsVoicevoxUrl');
+    if (inp) {
+      inp.value = localStorage.getItem(BASE_KEY) || DEF_BASE;
+      inp.oninput = function () {
+        var v = this.value.trim();
+        if (v) localStorage.setItem(BASE_KEY, v); else localStorage.removeItem(BASE_KEY);
+        if (window.__vvUrlTimer) clearTimeout(window.__vvUrlTimer);
+        window.__vvUrlTimer = setTimeout(function () {
+          _voiceCache = null;
+          var s = document.getElementById('settingsTtsVoice');
+          if (s) populateVoiceDropdown(s);
+        }, 400);
+      };
+    }
+    _urlInjected = true;
+  }
+
+  function onEngineChange() {
+    var f = document.getElementById('settingsVoicevoxUrlField');
+    var es = document.getElementById('settingsTtsEngine');
+    var eng = es ? es.value : 'browser';
+    if (f) f.style.display = (eng === 'voicevox') ? '' : 'none';
+    if (eng === 'voicevox') {
+      var s = document.getElementById('settingsTtsVoice');
+      if (s) populateVoiceDropdown(s);
+    }
+  }
+
+  new MutationObserver(function () {
+    injectUrlField();
+    var es = document.getElementById('settingsTtsEngine');
+    if (es && !es.__vvHooked) {
+      es.__vvHooked = true;
+      es.addEventListener('change', onEngineChange);
+      onEngineChange();
+    }
+  }).observe(document.body, { childList: true, subtree: true });
 
   function register(attempt) {
     attempt = attempt || 0;
@@ -75,7 +174,7 @@
         version: '0.1.0',
         getSpeaker: speakerId,
         setSpeaker: function (n) { try { localStorage.setItem(SPEAKER_KEY, String(parseInt(n, 10))); } catch (_) {} },
-        base: BASE,
+        base: baseUrl(),
       };
       return true;
     }


### PR DESCRIPTION
Adds three features, all self-contained (no core changes):

- **Configurable base URL** — `localStorage` key `hermes-ext-voicevox-base`, defaults to `http://127.0.0.1:50021`. Supports absolute URLs and relative paths.
- **Voice list** — fetches speakers/styles from `GET /speakers`, populates the Settings voice dropdown. Cached 30s.
- **VOICEVOX Server URL field** — injected via MutationObserver, visible only when engine is selected. Debounced 400ms refresh on URL change.

+105/-6, preserves original `register()` retry loop and `synthesize()` structure.