### PR TITLE
Refine mobile conversations drawer close affordance

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -19,5 +19,5 @@ need it and maintainers agree on the shared contract.
 
 - `desktop-companion`: trusted local Desktop Companion entry and first
   sidecar-class extension candidate.
-- `mobile-conversations`: phone-only floating Conversations button and
-  long-press shortcuts for the existing Hermes WebUI mobile drawer.
+- `mobile-conversations`: phone-only floating Conversations button, same-location
+  drawer close X, and long-press shortcuts for the existing Hermes WebUI mobile drawer.

--- a/extensions/mobile-conversations/README.md
+++ b/extensions/mobile-conversations/README.md
@@ -2,20 +2,21 @@
 
 Mobile Conversations Button is a trusted local Hermes WebUI extension that adds
 a phone-only floating **Conversations** button near the chat composer. It opens
-the existing mobile conversations drawer and provides a long-press shortcuts
-menu for common conversation navigation actions.
+the existing mobile conversations drawer, then stays in the same floating
+position as an **X** above the open drawer so it can be closed again. It also
+provides a long-press shortcuts menu for common conversation navigation actions.
 
 ## What It Does
 
 - Adds a phone-width-only floating Conversations button inside the chat messages
   shell.
-- Short tap opens or closes the existing mobile conversations/sidebar drawer.
+- Short tap opens the existing mobile conversations/sidebar drawer.
 - Long press opens a menu with shortcuts for:
   - New conversation
   - Open sidebar
   - Go to top
   - Go to last message
-- Hides the floating button while the mobile drawer is already open.
+- Keeps the same button in its normal floating position above the open mobile drawer as an **X** close affordance.
 - Leaves desktop-width layouts unchanged.
 
 ## Current Shape
@@ -88,13 +89,14 @@ browser origin and can use the logged-in browser session.
 Current disclosed behavior:
 
 - creates extension-owned DOM for the floating button and long-press menu
-- inserts the floating button into the existing `.messages-shell`
+- inserts the floating button into the existing `.messages-shell` and temporarily reparents it to `document.body` while the mobile drawer is open so it can sit above the drawer at the same visual position
 - reads existing mobile layout state through WebUI DOM/classes
 - calls existing WebUI browser functions when available, including
   `switchPanel`, `closeMobileSidebar`, `newSession`, `renderSessionList`,
   `jumpToSessionStart`, and `scrollToBottom`
 - toggles existing mobile sidebar classes as a fallback when the public browser
   helper is unavailable
+- swaps its icon between the conversations glyph and a close X based on the mobile sidebar state
 - uses pointer, context-menu, keyboard, resize, scroll, and mutation-observer
   handlers for mobile interaction and accessibility behavior
 - does not call WebUI HTTP APIs

--- a/extensions/mobile-conversations/assets/mobile-conversations.css
+++ b/extensions/mobile-conversations/assets/mobile-conversations.css
@@ -8,7 +8,12 @@
   .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.active,
   .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--pressing{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--text);}
   .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab svg{display:block;}
-  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--drawer-open{display:none!important;}
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--drawer-open,
+  body > .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--drawer-open{position:fixed;right:20px;bottom:60px;top:auto;z-index:240;width:44px;height:44px;min-width:44px;min-height:44px;border-radius:999px;border:1px solid var(--border);display:inline-flex!important;align-items:center;justify-content:center;background:var(--surface,var(--code-bg));color:var(--text);box-shadow:0 8px 24px rgba(0,0,0,.35);cursor:pointer;-webkit-tap-highlight-color:transparent;touch-action:manipulation;}
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--drawer-open:hover,
+  .messages-shell .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--drawer-open:focus-visible,
+  body > .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--drawer-open:hover,
+  body > .mobile-conversations-fab.hwx-mobile-conversations-fab.mobile-conversations-fab--drawer-open:focus-visible{background:var(--hover-bg);border-color:var(--border2);color:var(--text);outline:none;}
   .mobile-conversations-menu.hwx-mobile-conversations-menu .ws-opt-action{min-height:44px;}
   .mobile-conversations-menu.hwx-mobile-conversations-menu .ws-opt-name{white-space:nowrap;}
 }

--- a/extensions/mobile-conversations/assets/mobile-conversations.js
+++ b/extensions/mobile-conversations/assets/mobile-conversations.js
@@ -3,6 +3,7 @@
 
   const EXT = 'mobile-conversations';
   const BUTTON_ID = 'mobileConversationsBtn';
+  const SVG_NS = 'http://www.w3.org/2000/svg';
   const LONG_PRESS_DELAY_MS = 400;
   const CLICK_IGNORE_MS = 700;
   const INIT_RETRIES = 80;
@@ -45,22 +46,58 @@
     return !!(sidebar && sidebar.classList.contains('mobile-open'));
   }
 
-  function chatPanelActive() {
-    const panel = $('panelChat');
-    if (panel && panel.classList.contains('active')) return true;
-    const main = document.querySelector('main.main');
-    if (!main) return true;
-    return !Array.from(main.classList).some((name) => name.indexOf('showing-') === 0);
+  function buttonHomeShell() {
+    return document.querySelector('.messages-shell');
+  }
+
+  function buttonHomeBefore(shell) {
+    if (!shell) return null;
+    return $('jumpToSessionStartBtn') || $('scrollToBottomBtn') || shell.firstElementChild;
+  }
+
+  function placeButtonForSidebarState(btn, open) {
+    if (!btn) return;
+    if (open) {
+      if (btn.parentNode !== document.body) document.body.appendChild(btn);
+      return;
+    }
+    const shell = buttonHomeShell();
+    if (!shell || btn.parentNode === shell) return;
+    const before = buttonHomeBefore(shell);
+    shell.insertBefore(btn, before || null);
+  }
+
+  function appendSvgNode(svg, name, attrs) {
+    const node = document.createElementNS(SVG_NS, name);
+    Object.entries(attrs).forEach(([key, value]) => node.setAttribute(key, value));
+    svg.appendChild(node);
+    return node;
+  }
+
+  function setButtonIcon(btn, open) {
+    const svg = btn.querySelector('svg[data-hwx-mobile-conversations-icon="1"]');
+    if (!svg) return;
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+    if (open) {
+      appendSvgNode(svg, 'line', { x1: '18', y1: '6', x2: '6', y2: '18' });
+      appendSvgNode(svg, 'line', { x1: '6', y1: '6', x2: '18', y2: '18' });
+      return;
+    }
+    appendSvgNode(svg, 'path', { d: 'M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z' });
   }
 
   function syncButton() {
     const btn = $(BUTTON_ID);
     if (!btn || btn.dataset.hwxMobileConversations !== '1') return;
     const open = sidebarOpen();
+    placeButtonForSidebarState(btn, open);
+    setButtonIcon(btn, open);
     btn.classList.toggle('mobile-conversations-fab--drawer-open', open);
     btn.setAttribute('aria-expanded', open ? 'true' : 'false');
     btn.setAttribute('aria-label', open ? 'Close conversations' : 'Open conversations');
     btn.title = open ? 'Close conversations' : 'Conversations';
+    if (open) btn.removeAttribute('aria-haspopup');
+    else btn.setAttribute('aria-haspopup', 'menu');
   }
 
   function closeDrawer() {
@@ -117,7 +154,7 @@
   async function toggleMobileConversationsSidebar() {
     if (isDesktopWidth()) return false;
     closeMenu();
-    if (sidebarOpen() && chatPanelActive()) {
+    if (sidebarOpen()) {
       closeDrawer();
       return false;
     }
@@ -337,8 +374,7 @@
   }
 
   function buttonSvg() {
-    const svgNamespace = 'http://www.w3.org/2000/svg';
-    const svg = document.createElementNS(svgNamespace, 'svg');
+    const svg = document.createElementNS(SVG_NS, 'svg');
     svg.setAttribute('width', '20');
     svg.setAttribute('height', '20');
     svg.setAttribute('viewBox', '0 0 24 24');
@@ -348,9 +384,8 @@
     svg.setAttribute('stroke-linecap', 'round');
     svg.setAttribute('stroke-linejoin', 'round');
     svg.setAttribute('aria-hidden', 'true');
-    const path = document.createElementNS(svgNamespace, 'path');
-    path.setAttribute('d', 'M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z');
-    svg.appendChild(path);
+    svg.setAttribute('data-hwx-mobile-conversations-icon', '1');
+    appendSvgNode(svg, 'path', { d: 'M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z' });
     return svg;
   }
 
@@ -374,7 +409,7 @@
       btn.setAttribute('aria-expanded', 'false');
       btn.title = 'Conversations';
       btn.appendChild(buttonSvg());
-      const before = $('jumpToSessionStartBtn') || $('scrollToBottomBtn') || shell.firstElementChild;
+      const before = buttonHomeBefore(shell);
       shell.insertBefore(btn, before || null);
     }
     return btn;
@@ -392,6 +427,11 @@
     btn.addEventListener('pointerdown', (event) => {
       if (isDesktopWidth()) return;
       if (event.pointerType === 'mouse' || (event.button && event.button !== 0)) return;
+      if (sidebarOpen()) {
+        clearPressTimer();
+        clearClickIgnore();
+        return;
+      }
       clearPressTimer();
       clearClickIgnore();
       pressX = event.clientX;
@@ -412,6 +452,7 @@
     btn.addEventListener('contextmenu', (event) => {
       if (isDesktopWidth()) return;
       event.preventDefault();
+      if (sidebarOpen()) return;
       clearPressTimer();
       ignoreNextClick();
       openMenu(btn);
@@ -433,7 +474,7 @@
       observeSidebar();
       syncButton();
       window.HermesMobileConversationsExtension = {
-        version: '0.1.0',
+        version: '0.1.1',
         sync: syncButton,
         openMenu,
         toggle: toggleMobileConversationsSidebar,

--- a/extensions/mobile-conversations/extension.json
+++ b/extensions/mobile-conversations/extension.json
@@ -1,8 +1,8 @@
 {
   "id": "mobile-conversations",
   "name": "Mobile Conversations Button",
-  "description": "Phone-only floating Conversations button for Hermes WebUI that opens the existing mobile conversations drawer and exposes long-press shortcuts.",
-  "version": "0.1.0",
+  "description": "Phone-only floating Conversations button for Hermes WebUI that opens the existing mobile conversations drawer, becomes a same-location close X while the drawer is open, and exposes long-press shortcuts.",
+  "version": "0.1.1",
   "author": "santastabber",
   "assets": {
     "scripts": [

--- a/extensions/mobile-conversations/manifest.json
+++ b/extensions/mobile-conversations/manifest.json
@@ -3,7 +3,7 @@
     {
       "id": "mobile-conversations",
       "name": "Mobile Conversations Button",
-      "description": "Phone-only floating Conversations button and shortcut menu for Hermes WebUI.",
+      "description": "Phone-only floating Conversations button with same-location drawer close X and shortcut menu for Hermes WebUI.",
       "scripts": [
         "assets/mobile-conversations.js"
       ],


### PR DESCRIPTION
## Summary
- keep the mobile Conversations extension button visible above the open drawer as a close X
- preserve the same lower-right floating position used by the normal button
- update extension metadata/docs to describe the close affordance and DOM reparenting behavior

## Verification
- `node --check extensions/mobile-conversations/assets/mobile-conversations.js`
- `python3 -m json.tool extensions/mobile-conversations/extension.json >/dev/null`
- `python3 -m json.tool extensions/mobile-conversations/manifest.json >/dev/null`
- `node scripts/validate-extensions.mjs`
- `node scripts/scan-extension-safety.mjs`
- `node scripts/test-extension-validator.mjs`
- `git diff --check`
