### PR TITLE
voicevox-tts: add iOS Safari audio unlock on first user gesture

### DIFF
--- a/extensions/voicevox-tts/assets/voicevox-tts.js
+++ b/extensions/voicevox-tts/assets/voicevox-tts.js
@@ -22,6 +22,30 @@
   if (window.__hermesVoicevoxLoaded) return;
   window.__hermesVoicevoxLoaded = true;
 
+  // ── iOS Safari audio unlock ────────────────────────────────────────
+  // iOS Safari suspends AudioContext until the first user gesture (touch/
+  // click).  Without this the extension returns valid WAV bytes but the
+  // core's <audio> / AudioContext playback produces silence.  A one-shot
+  // silent buffer on the first interaction unlocks the audio subsystem.
+  (function installIOSAudioUnlock() {
+    var AC = window.AudioContext || window.webkitAudioContext;
+    if (!AC) return;   // no Web Audio API → nothing to unlock
+    function unlock() {
+      try {
+        var ctx = new AC();
+        var buf = ctx.createBuffer(1, 1, 22050);   // 1 sample of silence
+        var src = ctx.createBufferSource();
+        src.buffer = buf;
+        src.connect(ctx.destination);
+        src.start(0);
+        if (ctx.state === 'suspended') ctx.resume();
+        setTimeout(function () { ctx.close(); }, 1000);
+      } catch (_) { /* best-effort unlock */ }
+    }
+    document.addEventListener('touchstart', unlock, { once: true });
+    document.addEventListener('click',     unlock, { once: true });
+  })();
+
   // VOICEVOX engine base. Configurable via localStorage (hermes-ext-voicevox-base).
   // The speaker id is also configurable; default 1 (a standard VOICEVOX voice).
   const BASE_KEY = 'hermes-ext-voicevox-base';

--- a/extensions/voicevox-tts/assets/voicevox-tts.js
+++ b/extensions/voicevox-tts/assets/voicevox-tts.js
@@ -48,8 +48,12 @@
 
   // VOICEVOX engine base. Configurable via localStorage (hermes-ext-voicevox-base).
   // The speaker id is also configurable; default 1 (a standard VOICEVOX voice).
+  // Default: use the same-origin proxy path /voicevox (proxied by Tailscale Serve
+  // or nginx to the VOICEVOX engine).  This works from any device — desktop,
+  // iPhone, etc.  For direct loopback access (localhost browser), override to
+  // http://127.0.0.1:50021 in Settings.
   const BASE_KEY = 'hermes-ext-voicevox-base';
-  const DEF_BASE = 'http://127.0.0.1:50021';
+  const DEF_BASE = '/voicevox';
   const SPEAKER_KEY = 'hermes-ext-voicevox-speaker';
 
   // Accept ONLY a loopback http(s) host, OR a safe root-relative same-origin proxy
@@ -184,12 +188,12 @@
     div.className = 'settings-field'; div.id = 'settingsVoicevoxUrlField';
     div.style.display = 'none';
     div.innerHTML = '<label for="settingsVoicevoxUrl">VOICEVOX Server URL</label>'
-      + '<input type="text" id="settingsVoicevoxUrl" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px" placeholder="http://127.0.0.1:50021">'
+      + '<input type="text" id="settingsVoicevoxUrl" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px" placeholder="/voicevox">'
       + '<div style="font-size:11px;color:var(--muted);margin-top:4px">Override the VOICEVOX server address. Defaults to the standard loopback. Use a relative path for same-origin proxies.</div>';
     vf.parentNode.insertBefore(div, vf.nextSibling);
     var inp = document.getElementById('settingsVoicevoxUrl');
     if (inp) {
-      inp.value = localStorage.getItem(BASE_KEY) || DEF_BASE;
+      inp.value = localStorage.getItem(BASE_KEY) || '/voicevox';
       inp.oninput = function () {
         var v = this.value.trim();
         if (v) localStorage.setItem(BASE_KEY, v); else localStorage.removeItem(BASE_KEY);


### PR DESCRIPTION
## Problem
VOICEVOX TTS works on desktop but produces **no sound on iPhone Safari**, while Edge TTS plays fine on both.

## Root Cause
The extension's default VOICEVOX URL was changed from `/voicevox` (same-origin proxy path) to `http://127.0.0.1:50021` (direct loopback). 

- **Desktop**: `127.0.0.1` = the server machine → reaches VOICEVOX ✅
- **iPhone**: `127.0.0.1` = **the iPhone itself** → no VOICEVOX there ❌
- **Edge TTS**: unaffected because it uses browser built-ins / cloud APIs, bypassing the proxy entirely

The `/voicevox` path is proxied by Tailscale Serve (`tailscale serve --set-path /voicevox http://127.0.0.1:50023`) and works from **any device** on the Tailscale network — desktop, iPhone, tablet, etc.

## Fix
Restore `/voicevox` (same-origin proxy path) as the default:

```
-const DEF_BASE = 'http://127.0.0.1:50021';
+const DEF_BASE = '/voicevox';
```

Also includes an iOS Safari audio unlock (one-shot silent buffer on first touch/click) as a defense-in-depth measure, in case the AudioContext is suspended on first load.

## Changes
| File | Change |
|---|---|
| `voicevox-tts.js` | `DEF_BASE` → `/voicevox` |
| `voicevox-tts.js` | iOS audio unlock on first user gesture |
| `voicevox-tts.js` | Placeholder + default input value → `/voicevox` |