### PR TITLE
gates: accept permissions.storage.owned === true (enables settings_schema)

### DIFF
--- a/scripts/extension-registry-lib.mjs
+++ b/scripts/extension-registry-lib.mjs
@@ -355,10 +355,20 @@ function validatePermissions(entry, scriptText, errors) {
   if (!isPlainObject(permissions.storage)) {
     errors.push('permissions.storage must be an object');
   } else {
-    const owned = new Set(assertArray(permissions.storage.owned || [], 'permissions.storage.owned', errors));
+    // storage.owned is EITHER an array of specific key names OR the boolean `true`.
+    // `true` means "owns its entire storage namespace" and is the exact form core
+    // (api/extensions.py) requires to enable the sanctioned settings_schema system.
+    // When true, the per-key "owned must include <key>" drift check is satisfied by
+    // definition; only the array form is checked key-by-key.
+    const ownsNamespace = permissions.storage.owned === true;
+    const owned = ownsNamespace
+      ? null
+      : new Set(assertArray(permissions.storage.owned || [], 'permissions.storage.owned', errors));
     const shared = new Set(assertArray(permissions.storage.shared_webui_keys || [], 'permissions.storage.shared_webui_keys', errors));
-    for (const key of OWNED_STORAGE_KEYS) {
-      if (scriptText.includes(key) && !owned.has(key)) errors.push(`permissions.storage.owned must include ${key}`);
+    if (!ownsNamespace) {
+      for (const key of OWNED_STORAGE_KEYS) {
+        if (scriptText.includes(key) && !owned.has(key)) errors.push(`permissions.storage.owned must include ${key}`);
+      }
     }
     for (const key of SHARED_STORAGE_KEYS) {
       if (scriptText.includes(key) && !shared.has(key)) errors.push(`permissions.storage.shared_webui_keys must include ${key}`);

--- a/scripts/scan-extension-safety.mjs
+++ b/scripts/scan-extension-safety.mjs
@@ -100,8 +100,15 @@ function scanJavaScriptFile(entry, file, text, errors) {
   }
 
   if (/localStorage\.setItem\s*\(/.test(text)) {
-    const owned = new Set(permissions.storage?.owned || []);
-    if (owned.size === 0) errors.push(`${repoRelative(file.path)} writes localStorage without declaring owned storage keys`);
+    // storage.owned is EITHER an array of specific key names OR the boolean `true`,
+    // which core (api/extensions.py) treats as "owns its whole storage namespace"
+    // and is the exact form REQUIRED to enable the sanctioned settings_schema system.
+    // Accept both: `true` (namespace-owning) satisfies the declaration; an array must
+    // be non-empty. Anything else (missing / false / empty array) fails closed.
+    const ownedDecl = permissions.storage?.owned;
+    const declared = ownedDecl === true
+      || (Array.isArray(ownedDecl) && ownedDecl.length > 0);
+    if (!declared) errors.push(`${repoRelative(file.path)} writes localStorage without declaring owned storage keys`);
   }
 }
 

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -161,6 +161,45 @@ try {
   assert.equal(safetyScanFromScripts.status, 0, safetyScanFromScripts.stderr || safetyScanFromScripts.stdout);
   assert.match(safetyScanFromScripts.stdout, /safety scan passed for \d+ extension entr(?:y|ies)/);
 
+  // Regression: an entry that writes localStorage and declares storage.owned === true
+  // (the boolean form core REQUIRES to enable settings_schema) must PASS the safety scan.
+  // Before the fix the scan crashed with "boolean true is not iterable"; the key-array
+  // form must still be accepted, and an undeclared write must still fail closed.
+  const repoRoot = path.resolve(scriptsDir, '..');
+  const extDir = path.join(repoRoot, 'extensions', 'scan-owned-true-case');
+  try {
+    mkdirSync(path.join(extDir, 'assets'), { recursive: true });
+    writeJson(path.join(extDir, 'extension.json'), {
+      id: 'scan-owned-true-case', name: 'Scan Case', description: 'temp test entry',
+      version: '0.0.1', author: 'test',
+      assets: { scripts: ['assets/x.js'], stylesheets: [] },
+      capabilities: ['manifest-bundle'],
+      lifecycle: { webui_restart_required: false, sidecar_start_required: false, native_host_start_required: false, native_host_autostart: 'none' },
+      screenshots: [],
+      permissions: {
+        webui_api: { read: [], write: [] }, webui_navigation: false,
+        dom: { owned: true, mutates_core_views: false },
+        storage: { owned: true, shared_webui_keys: [] },   // boolean form — enables settings_schema
+        loopback_sidecar: false, native_host: false,
+        filesystem: { arbitrary: false, serves_bundled_assets: true },
+        network_external: false
+      },
+      settings_schema: [{ key: 'enabled', type: 'boolean', label: 'Enabled', default: true }]
+    });
+    writeJson(path.join(extDir, 'manifest.json'), {
+      extensions: [{ id: 'scan-owned-true-case', name: 'Scan Case', description: 'temp test entry', scripts: ['assets/x.js'], stylesheets: [] }]
+    });
+    writeFileSync(path.join(extDir, 'README.md'), '# Scan Case\n', 'utf8');
+    writeFileSync(path.join(extDir, 'assets', 'x.js'), "localStorage.setItem('k','v');\n", 'utf8');
+    const scanOwnedTrue = spawnSync(process.execPath, ['scan-extension-safety.mjs'], {
+      cwd: scriptsDir, encoding: 'utf8', timeout: 30000
+    });
+    assert.equal(scanOwnedTrue.status, 0,
+      `storage.owned:true + localStorage write should pass the safety scan, got: ${scanOwnedTrue.stderr || scanOwnedTrue.stdout}`);
+  } finally {
+    rmSync(extDir, { recursive: true, force: true });
+  }
+
   console.log('extension validator self-tests passed');
 } finally {
   rmSync(tmpRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Enabling fix for the capability retrofit (#34)

Core honors an extension's `settings_schema` **only when `permissions.storage.owned === true`** (the boolean "owns its whole storage namespace" form — `api/extensions.py:_manifest_entry_storage_owned`). But both library gates assumed `owned` is always an array of key names, so an extension couldn't adopt `settings_schema` without failing CI:

- **`scan-extension-safety.mjs`** crashed with `TypeError: boolean true is not iterable` when an entry that writes `localStorage` declared `owned: true`.
- **`extension-registry-lib.mjs`** (used by `validate-extensions.mjs`) rejected it with `permissions.storage.owned must be an array`.

### Change
Both gates now accept `owned === true` **in addition to** a non-empty key array:
- `true` = namespace-owning → satisfies the "declared owned storage" requirement, and the per-key drift check (`owned must include <key>`) is skipped as moot.
- array form → unchanged (still checked key-by-key, still must be non-empty when localStorage is written).
- `false` / missing / empty array → still **fails closed**.

### Verification (all green)
- `node scripts/validate-extensions.mjs` → 11 entries ok
- `node scripts/scan-extension-safety.mjs` → passed for 11 entries
- `node scripts/test-extension-validator.mjs` → passed, **including a new regression case**: a temp entry with `storage.owned: true` + a `localStorage.setItem` write now passes the safety scan (before: crash).
- Predicate unit-checked: `true`→declared, non-empty array→declared, empty/`false`/missing→not declared.

No entry changes here — this only unblocks the gates. The first extension to use it (mobile-haptics → `settings_schema`) follows in a separate PR per #34. cc @franksong2702 @rodboev