### PR TITLE
mobile-haptics: adopt sanctioned settings_schema for the enable toggle (retrofit #34)

### DIFF
--- a/extensions/mobile-haptics/README.md
+++ b/extensions/mobile-haptics/README.md
@@ -8,7 +8,7 @@ and set the device down, you get a physical "it's done" cue.
 
 - Watches for the end of an assistant turn and triggers a short
   `navigator.vibrate()` buzz.
-- Opt-in preference stored locally (`hermes-ext-haptics-enabled`); on by default
+- Opt-in preference, on by default; managed via the native Settings → Extensions toggle (sanctioned extension-settings store, legacy `hermes-ext-haptics-enabled` localStorage fallback on older core)
   where vibration is supported.
 - Ignores sub-100ms flickers; the real "a turn happened" gate is observing a
   genuine busy action (stop/steer/interrupt), so only real turns buzz.
@@ -42,7 +42,7 @@ Hermes WebUI page
   -> manifest-bundled extension assets
   -> /extensions/assets/mobile-haptics.js
   -> MutationObserver on #btnSend (busy -> idle) -> navigator.vibrate()
-  -> localStorage: hermes-ext-haptics-enabled
+  -> setting `enabled` via window.HermesExtensionSettings (Settings → Extensions toggle)
 ```
 
 This extension is `static-ui` / manifest-bundle only. It does not add backend
@@ -65,11 +65,18 @@ short buzz when the reply completes.
 
 ## Controls
 
-A small JS control surface is exposed on `window.HermesMobileHapticsExtension`:
+The **on/off toggle renders natively in Settings → Extensions → Mobile Haptics**
+("Vibrate when a turn finishes"), via the sanctioned extension-settings system
+(`settings_schema` + `permissions.storage.owned: true`). Toggling it there persists
+through `window.HermesExtensionSettings` — no separate panel.
+
+A small JS control surface is also exposed on `window.HermesMobileHapticsExtension`:
 
 - `.supported` — whether `navigator.vibrate` exists on this device
-- `.isEnabled()` — current opt-in state
-- `.setEnabled(true|false)` — toggle and persist
+- `.isEnabled()` — current opt-in state (reads the settings store; falls back to the
+  legacy `hermes-ext-haptics-enabled` localStorage key on older core without the
+  settings system)
+- `.setEnabled(true|false)` — toggle and persist (settings store, legacy fallback)
 - `.test()` — fire a test buzz (returns false if unsupported)
 
 ## Disable And Uninstall
@@ -87,8 +94,9 @@ This is trusted local code. Current disclosed behavior:
   supported)
 - observes the `#btnSend` button's `class` / `data-action` via a
   `MutationObserver` (read-only)
-- reads and writes `localStorage` under the single key
-  `hermes-ext-haptics-enabled`
+- reads/writes the `enabled` setting through the sanctioned `window.HermesExtensionSettings`
+  store (`permissions.storage.owned: true`); on older core without that system it
+  falls back to the single localStorage key `hermes-ext-haptics-enabled`
 - creates NO DOM
 - does not call WebUI HTTP APIs
 - does not access cookies

--- a/extensions/mobile-haptics/assets/mobile-haptics.js
+++ b/extensions/mobile-haptics/assets/mobile-haptics.js
@@ -17,7 +17,7 @@
   if (window.__hermesMobileHapticsLoaded) return;
   window.__hermesMobileHapticsLoaded = true;
 
-  const PREF_KEY = 'hermes-ext-haptics-enabled';      // '1' (default on) | '0'
+  const PREF_KEY = 'hermes-ext-haptics-enabled';      // legacy localStorage key (pre-settings_schema)
   const COMPLETE_PATTERN = [18];                       // short single buzz on turn-complete
   const BUSY_ACTIONS = new Set(['stop', 'steer', 'interrupt']);
   const MIN_BUSY_MS = 100;                            // tiny floor: filters pure flicker; the sawBusy flag is the real "a turn happened" gate
@@ -30,11 +30,37 @@
     return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
   }
 
+  // The 'enabled' preference now lives in the sanctioned extension-settings store
+  // (settings_schema key `enabled`), so it renders as a native toggle under
+  // Settings → Extensions → Mobile Haptics. Read through HermesExtensionSettings
+  // when core supports it; fall back to the legacy localStorage key on older core
+  // (so the toggle still works if this loads against a build without the settings
+  // system). Default ON either way. (Retrofit — issue #34.)
+  function extSettings() {
+    try {
+      var api = window.HermesExtensionSettings;
+      if (api && typeof api.settingsForExtension === 'function') {
+        var s = api.settingsForExtension('mobile-haptics');
+        if (s && s.supported) return s;
+      }
+    } catch (_) {}
+    return null;
+  }
+
   function enabled() {
+    var s = extSettings();
+    if (s) { var v = s.get('enabled'); return v === undefined ? true : v !== false; }
+    // Legacy fallback: localStorage key, default ON.
     try {
       const v = localStorage.getItem(PREF_KEY);
-      return v === null ? true : v === '1';   // default ON when supported
+      return v === null ? true : v === '1';
     } catch (_) { return true; }
+  }
+
+  function setEnabled(on) {
+    var s = extSettings();
+    if (s) { try { s.set('enabled', !!on); return; } catch (_) {} }
+    try { localStorage.setItem(PREF_KEY, on ? '1' : '0'); } catch (_) {}
   }
 
   function sendBtnAction() {
@@ -95,7 +121,7 @@
         version: '0.1.0',
         supported: hapticsSupported(),
         isEnabled: enabled,
-        setEnabled(on) { try { localStorage.setItem(PREF_KEY, on ? '1' : '0'); } catch (_) {} },
+        setEnabled: setEnabled,
         test() { if (hapticsSupported()) { try { navigator.vibrate(COMPLETE_PATTERN); return true; } catch (_) {} } return false; }
       };
       if (!hapticsSupported()) {

--- a/extensions/mobile-haptics/extension.json
+++ b/extensions/mobile-haptics/extension.json
@@ -31,9 +31,7 @@
       "mutates_core_views": false
     },
     "storage": {
-      "owned": [
-        "hermes-ext-haptics-enabled"
-      ],
+      "owned": true,
       "shared_webui_keys": []
     },
     "loopback_sidecar": false,
@@ -44,5 +42,13 @@
     },
     "network_external": false,
     "device_vibration": true
-  }
+  },
+  "settings_schema": [
+    {
+      "key": "enabled",
+      "type": "boolean",
+      "label": "Vibrate when a turn finishes",
+      "default": true
+    }
+  ]
 }


### PR DESCRIPTION
## Exemplar capability retrofit — mobile-haptics → sanctioned `settings_schema` (issue #34)

First retrofit in the #34 effort, and the pattern-setter for the rest. Unblocked by #35 (gates now accept `storage.owned: true`).

### What changed
- **`extension.json`**: `permissions.storage.owned` → `true` (was `["hermes-ext-haptics-enabled"]`) + a `settings_schema` with one boolean field `enabled` (default `true`). `owned: true` is the exact form core requires to honor `settings_schema`.
- **`mobile-haptics.js`**: `enabled()` / `setEnabled()` now read/write through `window.HermesExtensionSettings.settingsForExtension("mobile-haptics")` when core supports it (`.supported`), falling back to the legacy `hermes-ext-haptics-enabled` localStorage key on older core. Default ON on both paths. The turn-complete state machine (busy→idle, `queue` holding-state guard, `MIN_BUSY_MS` floor) is unchanged.
- **README**: documents the native Settings → Extensions toggle + the legacy fallback.

### User-visible win
The on/off preference now renders as a **native toggle in Settings → Extensions → Mobile Haptics** ("Vibrate when a turn finishes") instead of an invisible localStorage key — consistent with how built-in extension settings work.

### Verified (both read paths drive behavior, in a browser against master)
- **Settings store** (`supported:true`): `enabled:true` → buzz; `enabled:false` → no buzz; store-`false` **wins over** a stale legacy `"1"` (store is authoritative, not double-consulted).
- **Legacy fallback** (older core, no settings system): default → buzz; key `"0"` → no buzz.
- `validate-extensions` + `scan-extension-safety` + validator self-test all green; Codex gate running.

This is the template for the remaining retrofits in #34 (custom-avatar, theme-creator, model-favorites, …), one-per-PR. Since it changes a shipped extension's behavior surface, **not self-merging** — tagging @franksong2702 @rodboev for review. Refs #34, #33.