### PR TITLE
docs: Capabilities & Best Practices section for the entry contract (#34)

### DIFF
--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -48,6 +48,73 @@ Extension entries should keep paths local to the extension directory.
 
 Use stable, lowercase extension IDs. Prefer letters, numbers, and hyphens.
 
+## Capabilities And Best Practices
+
+Extensions run as **trusted local code in the WebUI origin against the authenticated
+session**, so they can lean on core-provided capabilities instead of re-implementing
+them, and they must follow the patterns that keep that trust safe. The current
+capability spectrum:
+
+### User settings — `settings_schema` (preferred over ad-hoc localStorage panels)
+
+If an extension has user-configurable options, declare them so they render natively
+in **Settings → Extensions → [extension]** rather than building a bespoke panel:
+
+```json
+"permissions": { "storage": { "owned": true } },
+"settings_schema": [
+  { "key": "enabled", "type": "boolean", "label": "Enable", "default": true },
+  { "key": "mode", "type": "enum", "label": "Mode",
+    "options": [ {"value":"compact","label":"Compact"}, {"value":"full","label":"Full"} ],
+    "default": "compact" }
+]
+```
+
+- Supported field types: `boolean`, `string`, `number`, `integer`, `enum`. `sensitive`
+  fields, unknown types, malformed enum options, duplicate keys, and type-mismatched
+  defaults are dropped by the core sanitizer.
+- **`settings_schema` is honored only when `permissions.storage.owned` is exactly `true`**
+  (the boolean "owns its whole storage namespace" form). This repo's validator and
+  safety scan accept both `owned: true` and the array-of-keys form; use `true` when you
+  want `settings_schema`.
+- Read/write at runtime through the sanctioned accessors, not raw localStorage:
+  `window.HermesExtensionSettings.settingsForExtension("<id>")` (`.get(key)` / `.set(key,v)` /
+  `.supported`) and `.storageForExtension("<id>")` for free-form owned storage.
+- **Degrade gracefully**: guard on `.supported` and fall back to your prior localStorage
+  key when running against older core without the settings system (see `mobile-haptics`
+  for the reference pattern).
+
+### Skins — `registerHermesSkin` with a base `scheme`
+
+Skin extensions call `window.registerHermesSkin({ name, value, tokens, ... })`. A skin
+tuned for one base mode must declare **`scheme: 'light' | 'dark'`** so core forces the
+matching base theme while the skin is active — this keeps code/chat tokens
+(`--strong`, `--code-inline-bg`, `--pre-text`, `--input-bg`, which are NOT on the
+`registerHermesSkin` allowlist) readable. Do **not** ship per-token CSS workarounds for
+this; use `scheme`. See `e-ink-skin` (`scheme:'light'`) and `skin-pack` (`scheme:'dark'`).
+
+### TTS engines — `registerHermesTtsEngine`
+
+An extension can register a speech engine via `window.registerHermesTtsEngine({ id,
+label, synthesize })` that appears in Settings → TTS Engine and drives both the Listen
+button and voice mode. See `voicevox-tts`. Normalize/chunk long input before synthesis
+where the backend has length limits.
+
+### Best practices (enforced in review + by the safety scan)
+
+- **Absolute same-origin fetch**, never route-relative: `fetch('/api/x', {credentials:'same-origin'})`.
+  `window.api('/api/x')` and `new URL('api/x', document.baseURI)` resolve wrong on a
+  `/session/<id>` route.
+- **No unbounded/backtracking regex on message or session text** (it's attacker-influenceable
+  in the authed tab) — use linear, bounded scans; avoid `[^x]*` spanning long inputs.
+- **Scope MutationObservers** to the specific node/attributes you need; disconnect during
+  your own DOM writes to avoid self-loops.
+- **Sanitize any cloned/exported HTML** — strip off-origin `src`/`href`, `on*` handlers,
+  script/style/iframe — so `network_external:false` stays honest.
+- **Declare every permission you actually use** (`webui_api.write`, `shared_webui_keys`,
+  `network_external`, `device_vibration`, sandbox attrs) — the README and `extension.json`
+  must match the code; the safety scan checks this.
+
 ## Sidecar Metadata
 
 Extensions that depend on a local helper process should declare it in manifest


### PR DESCRIPTION
## Docs pass for the capability retrofit (#34)

Adds a **Capabilities And Best Practices** section to `docs/extension-entry.md` so new contributors author against the current capability spectrum instead of the ad-hoc patterns the earliest entries used. Docs-only, no code.

Covers:
- **`settings_schema` + `storage.owned: true`** — the native Settings → Extensions toggle system: supported field types (`boolean`/`string`/`number`/`integer`/`enum`), the exact `owned: true` requirement (and that this repo's gates now accept it — #35), the `window.HermesExtensionSettings` accessors, and graceful degradation on older core (the `mobile-haptics` pattern from #36).
- **`registerHermesSkin` with `scheme: 'light'|'dark'`** — the correct way to keep code/chat tokens readable, no per-token CSS workarounds (`e-ink-skin` / `skin-pack`).
- **`registerHermesTtsEngine`** — speech engines (`voicevox-tts`), normalize/chunk long input.
- **Best practices the safety scan + review enforce** — absolute same-origin fetch (not route-relative), no unbounded/backtracking regex on attacker-influenceable text, scoped MutationObservers, HTML-clone sanitization, honest permission disclosure.

This is the extensions-repo half of the #34 docs pass. The core-side half (clarifying the `storage.owned: true` contract in `nesquena/hermes-webui/docs/EXTENSIONS.md`) is a separate core PR I'll raise. cc @franksong2702 @rodboev