### PR TITLE
docs(readme): reconcile README with the shipped install loop + live entry sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ Hermes WebUI core code.
 
 ## Status
 
-This repository is intentionally early. The WebUI extension APIs and backend
-support are still evolving, so the conventions here should be treated as a
-foundation for review rather than a locked marketplace contract.
+This repository is young but the core loop is live: the registry, CI safety
+gates, and the one-click install/uninstall UI in WebUI (Settings → Extensions)
+have all shipped. The WebUI extension APIs are still growing, so the conventions
+here are a maintained foundation rather than a locked marketplace contract.
 
-For the current WebUI-side loading contract, see `docs/EXTENSIONS.md` in the
-main Hermes WebUI repository.
+For the current WebUI-side loading contract, see
+[`docs/EXTENSIONS.md`](https://github.com/nesquena/hermes-webui/blob/main/docs/EXTENSIONS.md)
+in the main Hermes WebUI repository. For authoring an entry in this repo, see
+[`docs/extension-entry.md`](docs/extension-entry.md).
 
 ## What Belongs Here
 
@@ -99,16 +102,23 @@ node scripts/generate-registry.mjs --out dist/registry.json
 Pull requests run the same validator and safety scan in CI. Pushes to `main`
 generate the registry and per-extension zip artifacts for GitHub Pages. The
 registry entry includes a `download` URL and artifact-level `sha256` for each
-extension so the future WebUI install client can fetch and verify reviewed
-bytes before extracting them. The core-side install client, safe extraction,
-rollback, and uninstall flow are tracked in the main Hermes WebUI repo.
+extension so the WebUI install client fetches and verifies reviewed bytes before
+extracting them. The core-side install client — safe extraction, sha256
+verification, and uninstall — has shipped in the main Hermes WebUI repo
+(Settings → Extensions).
 
 ## Current Entries
 
-- `extensions/desktop-companion/`: trusted local Desktop Companion entry and
-  first sidecar-class extension candidate.
+The live entry list is maintained in
+[`extensions/README.md`](extensions/README.md), and the published, installable set
+is the generated registry
+([`registry.json`](https://hermes-webui.github.io/hermes-webui-extensions/registry.json)).
+See those rather than a hardcoded list here, which drifts on every merge.
 
-This repository does not yet add an extension registry UI, install flow, or
-backend proxy. Entries should continue to document their current manual install
-and lifecycle behavior explicitly until the core WebUI gallery/install client
-ships.
+The one-click **install flow and registry UI shipped in core** (Settings →
+Extensions: browse the registry, review permissions, install/uninstall with
+sha256 verification). Merged entries here are validated + safety-scanned in CI,
+published to the registry, and become one-click-installable from inside WebUI.
+The Tier-A loopback sidecar proxy remains future/demand-driven; sidecar-class
+entries currently reach their local backend directly under the loopback CSP
+allowance and should document their manual install + lifecycle explicitly.

--- a/VISION.md
+++ b/VISION.md
@@ -37,9 +37,8 @@ so every entry is reviewed like application code. Entries must disclose the APIs
 and DOM surfaces they touch, any local sidecar process, any network/filesystem/
 native-host/OS access, and how to install/disable/remove them.
 
-Because the library is **curated**, *being merged is the vetting*. The future
-one-click install trusts the registry precisely because every entry in it passed
-review.
+Because the library is **curated**, *being merged is the vetting*. The one-click
+install trusts the registry precisely because every entry in it passed review.
 
 ## Capability ladder
 
@@ -48,8 +47,9 @@ Extensions grow in capability in stages. Each rung is independently shippable.
 1. **Asset bundling** ✅ *done* — a manifest bundles an extension's scripts/styles
    so multi-extension installs don't require hand-maintained env-var lists.
    Same-origin only (`/extensions/` or `/static/`).
-2. **Settings UI** *in progress* — a Settings → Extensions surface: read-only
-   listing first, then enable/disable, then install-from-GUI.
+2. **Settings UI** ✅ *shipped* — a Settings → Extensions surface: listing,
+   enable/disable, and one-click install/uninstall from the gallery (with sha256
+   verification against the registry), plus a diagnostics tab.
 3. **Sidecar metadata + direct loopback** *foundation merged (descriptive metadata); direct loopback shipped* — an extension can
    *declare* a local helper process (`sidecar: { type, origin, health_path }`) so
    WebUI can show the dependency and, later, report coarse health. **Today**, an


### PR DESCRIPTION
## Reconcile the top-level README with the shipped system (docs-only)

The README's **Status**, **Current Entries**, and **Compatibility And Testing** sections predated the now-shipped extension system and had gone stale:

- **Status** said "intentionally early … APIs and backend still evolving" and implied no install flow yet. The registry, CI safety gates, and the one-click install/uninstall UI have all shipped (core v0.51.644). Reframed to "core loop is live, APIs still growing."
- **Current Entries** hardcoded only `desktop-companion` (11 entries are merged now) and claimed the repo "does not yet add an extension registry UI, install flow, or backend proxy." Replaced the drift-prone hardcoded list with pointers to the **live sources** — [`extensions/README.md`](extensions/README.md) + the generated [`registry.json`](https://hermes-webui.github.io/hermes-webui-extensions/registry.json) — and corrected the shipped-status text (Tier-A sidecar proxy remains the only future/demand-driven piece).
- **Compatibility** called the install client "future"; it has shipped.
- Linked the core `docs/EXTENSIONS.md` by URL and added a pointer to `docs/extension-entry.md`.

Docs-only — no entry or script changes; `validate-extensions` still green. Pairs with the core-side link PR (nesquena/hermes-webui#5326) and the `docs/extension-entry.md` capabilities section (#37).

cc @franksong2702 @rodboev