### PR TITLE
feat: add hermes-desktop — Linux XFCE desktop in Hermes WebUI

### DIFF
--- a/extensions/hermes-desktop/README.md
+++ b/extensions/hermes-desktop/README.md
@@ -1,0 +1,268 @@
+# Hermes Desktop
+
+A full Linux desktop inside Hermes WebUI. Drive GUI applications (Blender,
+LibreOffice, Chromium, terminals) from your browser. The Hermes agent and
+you share the same desktop — the agent opens apps via `docker exec`, you
+watch and interact through a VNC panel.
+
+## What It Does
+
+- Ships a Docker container running **XFCE4** with **TigerVNC**
+- Includes pre-installed desktop apps: Chromium, LibreOffice, Blender,
+  ImageMagick, xdotool, xclip
+- The agent drives the desktop through `docker exec` — no new agent tools
+  needed (just `terminal` + `vision_analyze`)
+- The WebUI extension adds a **🐧 sidebar button** that opens a desktop panel
+  with a live VNC viewport (noVNC via iframe)
+- A **Python sidecar** manages container lifecycle (start/stop/health) and
+  provides a stable localhost API
+
+## Who It Is For
+
+- Users who want to run desktop Linux apps from within their Hermes workflow
+- Developers who want the agent to visually iterate on GUI tasks (open
+  Blender, model an object, screenshot for feedback)
+- Anyone evaluating whether Hermes can match "Agent Zero"-style desktop
+  integration without a separate full-stack framework
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Browser (Hermes WebUI)                 │
+│  ┌─────────────────────┐  ┌───────────────────────────┐ │
+│  │      Chat Panel     │  │    Desktop Panel (ext)    │ │
+│  │                     │  │  ┌─────────────────────┐  │ │
+│  │  Agent runs         │  │  │  iframe → noVNC     │  │ │
+│  │  docker exec ...    │  │  │  (localhost:6080)   │  │ │
+│  └─────────────────────┘  │  └─────────────────────┘  │ │
+│                           └───────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+                    │                     │
+                    │ docker exec         │ HTTP (iframe)
+                    ▼                     ▼
+┌─────────────────────────────────────────────────────────┐
+│  Host                                                    │
+│  ┌──────────────────┐  ┌──────────────────────────────┐ │
+│  │ Sidecar (Python) │  │ Docker container              │ │
+│  │ :17887           │  │ ┌──────────────────────────┐ │ │
+│  │ • lifecycle API  │  │ │ XFCE4 + TigerVNC         │ │ │
+│  │ • health check   │  │ │ noVNC on :6080           │ │ │
+│  └──────────────────┘  │ │ VNC on :5900             │ │ │
+│                         │ │ Chromium, Blender, etc   │ │ │
+│                         │ └──────────────────────────┘ │ │
+│                         └──────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Installation
+
+### 1. Install the Extension
+
+In Hermes WebUI, open **Settings → Extensions → Gallery** and install
+**Hermes Desktop**. (Once the entry is merged into the curated library.)
+
+For local testing before gallery install:
+
+```bash
+cd hermes-desktop/extensions/hermes-desktop
+HERMES_WEBUI_EXTENSION_DIR=. \
+HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json \
+./start.sh
+```
+
+### 2. Clone the Companion Repo
+
+The Docker image and sidecar live in a companion repository:
+
+```bash
+git clone https://github.com/ChonSong/hermes-desktop
+cd hermes-desktop
+```
+
+### 3. Build the Docker Container
+
+```bash
+docker compose -f docker/docker-compose.yml build
+```
+
+First build pulls `ubuntu:24.04`, installs XFCE4, TigerVNC, noVNC, and
+desktop tools. Expect 1-2 minutes (image size ~2.5 GB).
+
+### 4. Start the Sidecar
+
+```bash
+python3 sidecar/sidecar.py
+```
+
+The sidecar binds to `127.0.0.1:17887`. It manages the container lifecycle
+via `docker compose` and provides:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/health` | GET | Sidecar + container status |
+| `/container/start` | POST | Start the desktop container |
+| `/container/stop` | POST | Stop the desktop container |
+| `/container/status` | GET | Container state detail |
+
+### 5. Open the Desktop
+
+Click the **🐧** button in the WebUI sidebar. If the sidecar is running and
+the container is started, the panel shows a live VNC viewport of the XFCE
+desktop.
+
+## Agent-Driven Desktop Control
+
+Once the container is running, the agent can control the desktop through
+Hermes' existing `terminal` tool:
+
+```bash
+# Launch an app
+docker exec hermes-desktop xfce4-terminal &
+# Click at coordinates
+docker exec hermes-desktop xdotool mousemove 400 300 click 1
+# Type text
+docker exec hermes-desktop xdotool type "Hello from Hermes"
+# Take a screenshot
+docker exec hermes-desktop import -window root /tmp/screenshot.png
+# Copy screenshot back for vision analysis
+docker cp hermes-desktop:/tmp/screenshot.png /tmp/screenshot.png
+# The agent then runs vision_analyze(image_url="/tmp/screenshot.png")
+```
+
+No new Hermes tools are needed. The `terminal` + `vision_analyze` loop is
+the same pattern the agent already uses for browser automation.
+
+## Remote Access
+
+The VNC iframe loads from `localhost:6080`, which works when the browser
+runs on the same machine as Hermes. For remote access:
+
+1. **Cloudflare Tunnel** — tunnel port 6080 alongside the WebUI tunnel
+2. **SSH port forward** — `ssh -L 6080:localhost:6080 your-host`
+3. **RustDesk** — connect to the host desktop directly (bypasses the
+   WebUI panel but gives full desktop access)
+4. **Future** — a `sidecar-proxy` capability (planned for WebUI core)
+   would route VNC through the WebUI domain, making remote access
+   work automatically
+
+## Disable and Uninstall
+
+**Disable** (keep installed, stop injecting):
+1. Add `"hermes-desktop"` to `disabled_extensions` in
+   `~/.hermes/webui/extension-overrides.json`
+2. Restart WebUI: `systemctl --user restart hermes-webui.service`
+
+**Stop the desktop container:**
+```bash
+docker compose -f hermes-desktop/docker/docker-compose.yml down
+```
+
+**Uninstall** (fully remove):
+1. Stop the container as above
+2. Remove the extension from `extension-install-manifest.json`
+3. Delete the extension directory:
+   `rm -rf ~/.hermes/webui/extensions/hermes-desktop/`
+4. Remove the Docker image: `docker rmi hermes-desktop`
+5. Restart WebUI
+
+## Trust Model and Permissions
+
+Hermes Desktop is **trusted local code**. The injected adapter runs in the
+Hermes WebUI browser origin and can use the logged-in browser session.
+
+**Current behavior:**
+- Creates an owned DOM panel (does NOT mutate core WebUI views)
+- Opens an iframe to `http://127.0.0.1:6080` (the container's noVNC page)
+- Fetches sidecar health/status via `http://127.0.0.1:17887`
+- Does NOT read authenticated WebUI APIs
+- Does NOT write to WebUI session/approval/clarify endpoints
+- Does NOT navigate WebUI sessions
+- Stores extension-owned preferences in localStorage under its own prefix
+- Does NOT access external networks
+- Does NOT write to arbitrary filesystem paths
+
+**The sidecar** (separate process, user-launched):
+- Starts/stops a Docker container via `docker compose`
+- Provides HTTP health + status responses on `127.0.0.1:17887`
+- Does NOT proxy authenticated WebUI calls
+- Does NOT serve WebSocket/VNC — noVNC runs inside the container
+
+**The Docker container:**
+- Binds VNC port 5900 to `127.0.0.1:5900` (host-only)
+- Binds noVNC port 6080 to `127.0.0.1:6080` (host-only)
+- Not reachable from the network — loopback only
+
+## Known Limitations
+
+- **Remote access requires manual port tunneling** — the VNC iframe
+  connects to localhost, which only works for local browsers. This is
+  the same constraint as Agent Zero's noVNC integration. Future
+  `sidecar-proxy` support in WebUI core would solve this.
+
+- **First container build is slow** — pulling Ubuntu 24.04 + installing
+  XFCE4 + Tools takes ~2 minutes on first build. Subsequent starts
+  are near-instant.
+
+- **Image size** — the built image is approximately 2.5 GB.
+
+- **Audio forwarding** — not included in v0.1. The desktop has no
+  audio output path to the browser. PulseAudio bridge can be added
+  in a future version.
+
+- **Clipboard sync** — noVNC provides basic clipboard but bidirectional
+  sync with Hermes' clipboard is not implemented.
+
+- **No multi-user / multi-session** — one container, one desktop.
+  Multiple concurrent users would need separate container instances.
+
+## Compatibility
+
+- **Hermes WebUI:** tested against WebUI with `manifest-bundle` and
+  `loopback-sidecar` capabilities
+- **Browser:** any browser that renders iframes and allows loopback
+  CSP (`http://127.0.0.1:*`)
+- **Host OS:** Linux with Docker 24+ and Python 3.10+
+- **Agent model:** any model that can use `terminal` + `vision_analyze`
+  tools (all Hermes models)
+
+## Verification
+
+After installation, verify each layer:
+
+```bash
+# 1. Sidecar health
+curl http://127.0.0.1:17887/health
+# → {"ok":true,"container":"stopped","message":"sidecar running"}
+
+# 2. Start container
+curl -X POST http://127.0.0.1:17887/container/start
+# → {"status":"started"}
+
+# 3. Container health
+curl http://127.0.0.1:17887/health
+# → {"ok":true,"container":"running","message":"sidecar running"}
+
+# 4. noVNC accessible
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:6080/health
+# → 200
+
+# 5. Desktop running
+docker exec hermes-desktop xdotool getdisplaygeometry
+# → 1280 720
+```
+
+In the WebUI:
+- The 🐧 button appears in the sidebar (or as a floating button if no sidebar nav found)
+- Clicking it opens the panel
+- Status shows "Desktop running" with a live VNC viewport
+- Clicking "Stop Desktop" shuts down the container cleanly
+
+## Related
+
+- **Companion repo** (Docker + sidecar):
+  [ChonSong/hermes-desktop](https://github.com/ChonSong/hermes-desktop)
+- **Agent Zero** (inspiration):
+  [agent0ai/agent-zero](https://github.com/agent0ai/agent-zero)
+- **Desktop Companion** (sidecar extension pattern):
+  [hermes-webui-extensions/desktop-companion](https://github.com/hermes-webui/hermes-webui-extensions/tree/main/extensions/desktop-companion)

--- a/extensions/hermes-desktop/README.md
+++ b/extensions/hermes-desktop/README.md
@@ -1,79 +1,101 @@
-# Hermes Desktop
+# Hermes Desktop v0.2.0 — Computer Use Integration
 
-A full Linux desktop inside Hermes WebUI. Drive GUI applications (Blender,
-LibreOffice, Chromium, terminals) from your browser. The Hermes agent and
-you share the same desktop — the agent opens apps via `docker exec`, you
-watch and interact through a VNC panel.
+A full Linux desktop inside Hermes WebUI with **Computer Use** target selection.
+Choose which display the agent drives — the **host Xvfb framebuffer** or a
+**containerized XFCE desktop** — and watch it happen live via noVNC.
 
-## What It Does
-
-- Ships a Docker container running **XFCE4** with **TigerVNC**
-- Includes pre-installed desktop apps: Chromium, LibreOffice, Blender,
-  ImageMagick, xdotool, xclip
-- The agent drives the desktop through `docker exec` — no new agent tools
-  needed (just `terminal` + `vision_analyze`)
-- The WebUI extension adds a **🐧 sidebar button** that opens a desktop panel
-  with a live VNC viewport (noVNC via iframe)
-- A **Python sidecar** manages container lifecycle (start/stop/health) and
-  provides a stable localhost API
-
-## Who It Is For
-
-- Users who want to run desktop Linux apps from within their Hermes workflow
-- Developers who want the agent to visually iterate on GUI tasks (open
-  Blender, model an object, screenshot for feedback)
-- Anyone evaluating whether Hermes can match "Agent Zero"-style desktop
-  integration without a separate full-stack framework
+---
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                   Browser (Hermes WebUI)                 │
-│  ┌─────────────────────┐  ┌───────────────────────────┐ │
-│  │      Chat Panel     │  │    Desktop Panel (ext)    │ │
-│  │                     │  │  ┌─────────────────────┐  │ │
-│  │  Agent runs         │  │  │  iframe → noVNC     │  │ │
-│  │  docker exec ...    │  │  │  (localhost:6080)   │  │ │
-│  └─────────────────────┘  │  └─────────────────────┘  │ │
-│                           └───────────────────────────┘ │
-└─────────────────────────────────────────────────────────┘
-                    │                     │
-                    │ docker exec         │ HTTP (iframe)
-                    ▼                     ▼
-┌─────────────────────────────────────────────────────────┐
-│  Host                                                    │
-│  ┌──────────────────┐  ┌──────────────────────────────┐ │
-│  │ Sidecar (Python) │  │ Docker container              │ │
-│  │ :17887           │  │ ┌──────────────────────────┐ │ │
-│  │ • lifecycle API  │  │ │ XFCE4 + TigerVNC         │ │ │
-│  │ • health check   │  │ │ noVNC on :6080           │ │ │
-│  └──────────────────┘  │ │ VNC on :5900             │ │ │
-│                         │ │ Chromium, Blender, etc   │ │ │
-│                         │ └──────────────────────────┘ │ │
-│                         └──────────────────────────────┘ │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│                        Browser (Hermes WebUI)                     │
+│  ┌─────────────────────┐  ┌──────────────────────────────────┐   │
+│  │      Chat Panel     │  │     Desktop Panel (Extension)     │   │
+│  │                     │  │  ┌────────────────────────────┐   │   │
+│  │  User <-> Agent     │  │  │  noVNC iframe              │   │   │
+│  │                     │  │  │  (live desktop viewport)   │   │   │
+│  │                     │  │  ├────────────────────────────┤   │   │
+│  │                     │  │  │  Mini Transcript            │   │   │
+│  │                     │  │  │  (renderTranscript hook)    │   │   │
+│  │                     │  │  ├────────────────────────────┤   │   │
+│  │                     │  │  │  Settings → Target Selector │   │   │
+│  │                     │  │  │  ● Host (Xvfb :0)          │   │   │
+│  │                     │  │  │  ○ Container (Xfce :1)     │   │   │
+│  └─────────────────────┘  │  └────────────────────────────┘   │   │
+│                           └──────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────┘
+         │                          │
+         │Terminal / computer_use    │ HTTP iframe
+         ▼                          ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                        Host Machine                               │
+│                                                                   │
+│  ┌──────────────────────┐  ┌────────────────────────────────┐    │
+│  │  cua-driver (Host)   │  │  Sidecar (Python) :17887        │    │
+│  │  DISPLAY=:0          │  │  ┌──────────────────────────┐  │    │
+│  │  Xvfb                │  │  │  /health                  │  │    │
+│  │  640×480             │  │  │  /container/start         │  │    │
+│  │  x11vnc :5901 → noVNC│  │  │  /container/stop         │  │    │
+│  │  :6081                │  │  │  /cua/status             │  │    │
+│  └──────────────────────┘  │  │  /cua/target              │  │    │
+│                            │  └──────────────────────────┘  │    │
+│  ┌──────────────────────┐  └────────────────────────────────┘    │
+│  │  Docker Container    │                                         │
+│  │  (hermes-desktop)    │                                         │
+│  │  Xfce4 on DISPLAY=:1 │                                         │
+│  │  TigerVNC :5900 →    │                                         │
+│  │  noVNC :6901          │                                         │
+│  │  Chromium, Blender,  │                                         │
+│  │  LibreOffice, xdotool│                                         │
+│  └──────────────────────┘                                         │
+│                                                                   │
+│  ┌──────────────────────┐                                         │
+│  │  cua-driver (Cont.)  │                                         │
+│  │  (inside container)  │                                         │
+│  │  DISPLAY=:1          │                                         │
+│  └──────────────────────┘                                         │
+│                                                                   │
+└──────────────────────────────────────────────────────────────────┘
 ```
+
+### How the agent interacts
+
+1. **You chat** in the main WebUI panel
+2. **Agent uses `computer_use` tool** — dispatches to the selected target's
+   cua-driver instance (host `:0` or container `:1`)
+3. **Desktop updates appear live** in the noVNC iframe in the extension panel
+4. **Agent transcript** renders alongside the desktop via `renderTranscript`
+   hook (requires PR #5508 in WebUI core)
+5. **You watch and steer** — the panel shows exactly what the agent sees
+
+### Two targets
+
+| Target | DISPLAY | Desktop | VNC | Use Case |
+|--------|---------|---------|-----|----------|
+| **Host (Xvfb :0)** | `:0` | Headless framebuffer | x11vnc → noVNC :6081 | Lightweight, no container overhead, fast screenshots |
+| **Container (Xfce :1)** | `:1` | Full XFCE4 | TigerVNC → noVNC :6901 | Real desktop apps (browser, office, 3D), RustDesk client |
+
+---
 
 ## Installation
 
 ### 1. Install the Extension
 
 In Hermes WebUI, open **Settings → Extensions → Gallery** and install
-**Hermes Desktop**. (Once the entry is merged into the curated library.)
+**Hermes Desktop**.
 
-For local testing before gallery install:
+For local development:
 
 ```bash
-cd hermes-desktop/extensions/hermes-desktop
-HERMES_WEBUI_EXTENSION_DIR=. \
+cd hermes-webui-extensions
+HERMES_WEBUI_EXTENSION_DIR=extensions/hermes-desktop \
 HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json \
 ./start.sh
 ```
 
 ### 2. Clone the Companion Repo
-
-The Docker image and sidecar live in a companion repository:
 
 ```bash
 git clone https://github.com/ChonSong/hermes-desktop
@@ -87,7 +109,7 @@ docker compose -f docker/docker-compose.yml build
 ```
 
 First build pulls `ubuntu:24.04`, installs XFCE4, TigerVNC, noVNC, and
-desktop tools. Expect 1-2 minutes (image size ~2.5 GB).
+desktop tools. Expect 1-2 minutes (~2.5 GB image).
 
 ### 4. Start the Sidecar
 
@@ -95,174 +117,212 @@ desktop tools. Expect 1-2 minutes (image size ~2.5 GB).
 python3 sidecar/sidecar.py
 ```
 
-The sidecar binds to `127.0.0.1:17887`. It manages the container lifecycle
-via `docker compose` and provides:
+The sidecar binds to `127.0.0.1:17887` and provides the management API
+used by the extension.
 
-| Endpoint | Method | Purpose |
-|---|---|---|
+### 5. Install cua-driver (for Computer Use)
+
+```bash
+hermes computer-use install
+```
+
+This installs the `cua-driver` binary and enables the `computer_use` tool
+for the Hermes agent.
+
+For **container target** support, also install inside the container:
+
+```bash
+docker exec hermes-desktop hermes computer-use install
+```
+
+### 6. Open the Desktop
+
+Click the **🐧** button in the WebUI sidebar. The panel shows:
+- Container status (start/stop)
+- Target selector (Host vs Container)
+- Live noVNC viewport of the active target
+- Agent transcript (when open)
+- Computer Use status per target
+
+---
+
+## Usage Flow
+
+### Selecting a target
+
+Open the panel → click **⚙** → choose **Host (Xvfb :0)** or **Container (Xfce :1)**.
+The choice persists in localStorage.
+
+When you switch targets:
+- The noVNC iframe reloads to point at the new target's VNC port
+- The agent's subsequent `computer_use` calls route to the corresponding
+  cua-driver instance
+- The status badge updates to show the active target
+
+### Agent-driven desktop workflow
+
+1. Open the desktop panel and ensure the target is running
+2. Tell the agent: *"Open Chromium in the desktop and navigate to example.com"*
+3. The agent calls `computer_use` to click the app menu, type the URL, etc.
+4. Watch the desktop update live in the panel
+5. The mini transcript shows the agent's reasoning in parallel
+
+### Manual control via terminal
+
+```bash
+# Launch an app in the container
+docker exec hermes-desktop xfce4-terminal &
+
+# Type text
+docker exec hermes-desktop xdotool type "Hello from Hermes"
+
+# Click at coordinates
+docker exec hermes-desktop xdotool mousemove 400 300 click 1
+
+# Take a screenshot
+docker exec hermes-desktop import -window root /tmp/screenshot.png
+
+# Copy screenshot for vision analysis
+docker cp hermes-desktop:/tmp/screenshot.png /tmp/screenshot.png
+```
+
+---
+
+## Configuration Reference
+
+### Extension Settings
+
+| Setting | Key (localStorage) | Values | Default | Description |
+|---------|-------------------|--------|---------|-------------|
+| Target | `hermes-desktop:target` | `"host"` / `"container"` | `"container"` | Which display the agent drives |
+| Transcript | `hermes-desktop:transcript` | `true` / `false` | `false` | Show agent transcript in panel |
+
+### Sidecar API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
 | `/health` | GET | Sidecar + container status |
 | `/container/start` | POST | Start the desktop container |
 | `/container/stop` | POST | Stop the desktop container |
 | `/container/status` | GET | Container state detail |
+| `/cua/status` | GET | cua-driver health for each target (`{"host": "...", "container": "..."}`) |
+| `/cua/target` | GET | Current active target |
+| `/cua/target` | POST | Set active target (body: `{"target": "host"}`) |
 
-### 5. Open the Desktop
+### WebUI Core APIs (PR #5508)
 
-Click the **🐧** button in the WebUI sidebar. If the sidecar is running and
-the container is started, the panel shows a live VNC viewport of the XFCE
-desktop.
+| API | Purpose |
+|-----|---------|
+| `window.registerHermesSessionOpenHandler(fn)` | Hook into session navigation (used for transcript refresh) |
+| `window.renderTranscript(container, messages, opts)` | Render chat messages into any DOM container |
 
-## Agent-Driven Desktop Control
-
-Once the container is running, the agent can control the desktop through
-Hermes' existing `terminal` tool:
-
-```bash
-# Launch an app
-docker exec hermes-desktop xfce4-terminal &
-# Click at coordinates
-docker exec hermes-desktop xdotool mousemove 400 300 click 1
-# Type text
-docker exec hermes-desktop xdotool type "Hello from Hermes"
-# Take a screenshot
-docker exec hermes-desktop import -window root /tmp/screenshot.png
-# Copy screenshot back for vision analysis
-docker cp hermes-desktop:/tmp/screenshot.png /tmp/screenshot.png
-# The agent then runs vision_analyze(image_url="/tmp/screenshot.png")
-```
-
-No new Hermes tools are needed. The `terminal` + `vision_analyze` loop is
-the same pattern the agent already uses for browser automation.
+---
 
 ## Remote Access
 
-The VNC iframe loads from `localhost:6080`, which works when the browser
+The VNC iframe connects to `localhost` ports, which works when the browser
 runs on the same machine as Hermes. For remote access:
 
-1. **Cloudflare Tunnel** — tunnel port 6080 alongside the WebUI tunnel
-2. **SSH port forward** — `ssh -L 6080:localhost:6080 your-host`
-3. **RustDesk** — connect to the host desktop directly (bypasses the
-   WebUI panel but gives full desktop access)
-4. **Future** — a `sidecar-proxy` capability (planned for WebUI core)
-   would route VNC through the WebUI domain, making remote access
-   work automatically
+| Method | How |
+|--------|-----|
+| **Cloudflare Tunnel** | Tunnel ports 6081 (host) and 6901 (container) alongside WebUI |
+| **SSH forward** | `ssh -L 6081:localhost:6081 -L 6901:localhost:6901 your-host` |
+| **RustDesk** | Connect to the host desktop directly (bypasses WebUI) |
+| **Future** | `sidecar-proxy` capability routes VNC through the WebUI domain |
+
+---
+
+## Trust Model and Permissions
+
+Hermes Desktop is **trusted local code**. Summary:
+
+- Creates an **owned DOM panel** — does NOT mutate core WebUI views
+- Opens an **iframe to `http://127.0.0.1:6080`** or `:6901` (VNC viewport)
+- Fetches sidecar health/status via **`http://127.0.0.1:17887`**
+- Does NOT read authenticated WebUI APIs
+- Does NOT write to WebUI session/approval/clarify endpoints
+- Stores extension-owned preferences in **localStorage** under `hermes-desktop:` prefix
+- Does NOT access external networks
+- Does NOT write to arbitrary filesystem paths
+
+**The sidecar** manages Docker lifecycle and exposes cua-driver status.
+
+**The `computer_use` tool** runs via `hermes computer-use install` — it drives
+the desktop via accessibility (AT-SPI on Linux), not pixel scraping. See the
+[computer-use skill](https://github.com/nousresearch/hermes-agent) for details.
+
+---
+
+## Dependencies
+
+| Component | Required | Version |
+|-----------|----------|---------|
+| Docker | Yes | 24+ |
+| Python | Yes | 3.10+ |
+| cua-driver | For agent-driven control | Latest (`hermes computer-use install`) |
+| x11vnc | For host target visualization | Any |
+| noVNC | For host target (optional on container) | Included in container |
+| Hermes WebUI | Yes | v0.10+ with manifest-bundle support |
+
+---
+
+## Known Limitations
+
+- **Host target requires x11vnc + noVNC** — the extension expects noVNC on
+  port 6081 for the host framebuffer. Set up manually:
+  ```bash
+  x11vnc -display :0 -forever -nopw -shared -rfbport 5901 &
+  /usr/share/novnc/utils/novnc_proxy --vnc localhost:5901 --listen 6081 &
+  ```
+- **cua-driver in container** — installing cua-driver inside the Docker
+  container requires the container to have `hermes` CLI available or the
+  binary installed manually.
+- **No clipboard sync** — bidirectional clipboard between browser and
+  desktop is not implemented.
+- **Audio not bridged** — PulseAudio bridge can be added as a follow-up.
+- **Multi-session not supported** — one container, one desktop.
+
+---
 
 ## Disable and Uninstall
 
 **Disable** (keep installed, stop injecting):
-1. Add `"hermes-desktop"` to `disabled_extensions` in
-   `~/.hermes/webui/extension-overrides.json`
-2. Restart WebUI: `systemctl --user restart hermes-webui.service`
+1. Add `"hermes-desktop"` to `disabled_extensions` in `extension-overrides.json`
+2. Restart WebUI
 
 **Stop the desktop container:**
 ```bash
 docker compose -f hermes-desktop/docker/docker-compose.yml down
 ```
 
-**Uninstall** (fully remove):
+**Uninstall:**
 1. Stop the container as above
 2. Remove the extension from `extension-install-manifest.json`
-3. Delete the extension directory:
-   `rm -rf ~/.hermes/webui/extensions/hermes-desktop/`
-4. Remove the Docker image: `docker rmi hermes-desktop`
+3. `rm -rf ~/.hermes/webui/extensions/hermes-desktop/`
+4. `docker rmi hermes-desktop`
 5. Restart WebUI
 
-## Trust Model and Permissions
-
-Hermes Desktop is **trusted local code**. The injected adapter runs in the
-Hermes WebUI browser origin and can use the logged-in browser session.
-
-**Current behavior:**
-- Creates an owned DOM panel (does NOT mutate core WebUI views)
-- Opens an iframe to `http://127.0.0.1:6080` (the container's noVNC page)
-- Fetches sidecar health/status via `http://127.0.0.1:17887`
-- Does NOT read authenticated WebUI APIs
-- Does NOT write to WebUI session/approval/clarify endpoints
-- Does NOT navigate WebUI sessions
-- Stores extension-owned preferences in localStorage under its own prefix
-- Does NOT access external networks
-- Does NOT write to arbitrary filesystem paths
-
-**The sidecar** (separate process, user-launched):
-- Starts/stops a Docker container via `docker compose`
-- Provides HTTP health + status responses on `127.0.0.1:17887`
-- Does NOT proxy authenticated WebUI calls
-- Does NOT serve WebSocket/VNC — noVNC runs inside the container
-
-**The Docker container:**
-- Binds VNC port 5900 to `127.0.0.1:5900` (host-only)
-- Binds noVNC port 6080 to `127.0.0.1:6080` (host-only)
-- Not reachable from the network — loopback only
-
-## Known Limitations
-
-- **Remote access requires manual port tunneling** — the VNC iframe
-  connects to localhost, which only works for local browsers. This is
-  the same constraint as Agent Zero's noVNC integration. Future
-  `sidecar-proxy` support in WebUI core would solve this.
-
-- **First container build is slow** — pulling Ubuntu 24.04 + installing
-  XFCE4 + Tools takes ~2 minutes on first build. Subsequent starts
-  are near-instant.
-
-- **Image size** — the built image is approximately 2.5 GB.
-
-- **Audio forwarding** — not included in v0.1. The desktop has no
-  audio output path to the browser. PulseAudio bridge can be added
-  in a future version.
-
-- **Clipboard sync** — noVNC provides basic clipboard but bidirectional
-  sync with Hermes' clipboard is not implemented.
-
-- **No multi-user / multi-session** — one container, one desktop.
-  Multiple concurrent users would need separate container instances.
-
-## Compatibility
-
-- **Hermes WebUI:** tested against WebUI with `manifest-bundle` and
-  `loopback-sidecar` capabilities
-- **Browser:** any browser that renders iframes and allows loopback
-  CSP (`http://127.0.0.1:*`)
-- **Host OS:** Linux with Docker 24+ and Python 3.10+
-- **Agent model:** any model that can use `terminal` + `vision_analyze`
-  tools (all Hermes models)
-
-## Verification
-
-After installation, verify each layer:
-
-```bash
-# 1. Sidecar health
-curl http://127.0.0.1:17887/health
-# → {"ok":true,"container":"stopped","message":"sidecar running"}
-
-# 2. Start container
-curl -X POST http://127.0.0.1:17887/container/start
-# → {"status":"started"}
-
-# 3. Container health
-curl http://127.0.0.1:17887/health
-# → {"ok":true,"container":"running","message":"sidecar running"}
-
-# 4. noVNC accessible
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:6080/health
-# → 200
-
-# 5. Desktop running
-docker exec hermes-desktop xdotool getdisplaygeometry
-# → 1280 720
-```
-
-In the WebUI:
-- The 🐧 button appears in the sidebar (or as a floating button if no sidebar nav found)
-- Clicking it opens the panel
-- Status shows "Desktop running" with a live VNC viewport
-- Clicking "Stop Desktop" shuts down the container cleanly
+---
 
 ## Related
 
-- **Companion repo** (Docker + sidecar):
-  [ChonSong/hermes-desktop](https://github.com/ChonSong/hermes-desktop)
-- **Agent Zero** (inspiration):
-  [agent0ai/agent-zero](https://github.com/agent0ai/agent-zero)
-- **Desktop Companion** (sidecar extension pattern):
-  [hermes-webui-extensions/desktop-companion](https://github.com/hermes-webui/hermes-webui-extensions/tree/main/extensions/desktop-companion)
+- **Companion repo** (Docker + sidecar): [ChonSong/hermes-desktop](https://github.com/ChonSong/hermes-desktop)
+- **Computer Use skill**: [computer-use](https://github.com/nousresearch/hermes-agent/skills/computer-use)
+- **WebUI core hooks** (PR #5508): `registerHermesSessionOpenHandler` + `renderTranscript`
+- **Desktop Companion** (original sidecar pattern): `hermes-webui-extensions/desktop-companion`
+- **Agent Zero** (inspiration): [agent0ai/agent-zero](https://github.com/agent0ai/agent-zero)
+
+---
+
+## Changelog
+
+### v0.2.0 (2026-07-06)
+- **Target selector**: Choose Host (Xvfb :0) or Container (Xfce :1)
+- **Computer Use integration**: cua-driver status indicators per target
+- **Mini transcript**: Agent messages rendered via `renderTranscript` hook
+- **Settings panel**: Persistent configuration via local storage
+- **Sidecar API**: `/cua/status` and `/cua/target` endpoints
+- **Documentation**: Architecture diagram, usage flow, configuration reference
+
+### v0.1.0 (2026-07-01)
+- Initial release: containerized XFCE desktop with noVNC panel

--- a/extensions/hermes-desktop/assets/desktop-extension.css
+++ b/extensions/hermes-desktop/assets/desktop-extension.css
@@ -1,0 +1,151 @@
+/* Hermes Desktop — WebUI extension styles */
+
+.hd-panel {
+  display: none;
+  position: fixed;
+  top: 50px;
+  right: 16px;
+  bottom: 16px;
+  width: 65%;
+  min-width: 520px;
+  max-width: 1100px;
+  background: var(--bg-primary, #1a1a2e);
+  border: 1px solid var(--border, #2a2a4a);
+  border-radius: 10px;
+  box-shadow: 0 4px 32px rgba(0,0,0,.45);
+  z-index: 9000;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  resize: both;
+}
+
+.hd-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 14px;
+  height: 38px;
+  background: var(--bg-secondary, #16213e);
+  border-bottom: 1px solid var(--border, #2a2a4a);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text, #e0e0e0);
+  cursor: move;
+  user-select: none;
+  -webkit-app-region: no-drag;
+}
+
+.hd-close-btn {
+  background: none;
+  border: none;
+  color: var(--muted, #888);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0 6px;
+  line-height: 1;
+  -webkit-app-region: no-drag;
+}
+.hd-close-btn:hover { color: var(--danger, #ff6b6b); }
+
+.hd-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  color: var(--text, #ccc);
+}
+
+.hd-status {
+  font-size: 15px;
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  background: var(--bg-tertiary, #111122);
+}
+.hd-status-on  { color: #4ade80; }
+.hd-status-warn { color: #fbbf24; }
+.hd-status-off  { color: #ef4444; }
+
+.hd-controls {
+  margin-bottom: 14px;
+}
+.hd-controls pre {
+  background: var(--bg-tertiary, #0d0d1a);
+  padding: 10px;
+  border-radius: 5px;
+  font-size: 13px;
+  overflow-x: auto;
+}
+
+.hd-btn {
+  padding: 8px 20px;
+  border: 1px solid var(--border, #333);
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  margin-right: 8px;
+  transition: background .15s;
+}
+.hd-btn-start {
+  background: #166534;
+  color: #4ade80;
+  border-color: #4ade80;
+}
+.hd-btn-start:hover { background: #1a7a3e; }
+.hd-btn-stop {
+  background: #7f1d1d;
+  color: #fca5a5;
+  border-color: #f87171;
+}
+.hd-btn-stop:hover { background: #991b1b; }
+
+.hd-hint {
+  font-size: 12px;
+  color: var(--muted, #777);
+  margin-top: 6px;
+}
+
+.hd-desktop-wrap {
+  flex: 1;
+  min-height: 400px;
+  border: 1px solid var(--border, #2a2a4a);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #000;
+}
+
+/* Sidebar button */
+.hd-sidebar-btn {
+  background: var(--bg-tertiary, #1a1a2e);
+  border: 1px solid var(--border, #2a2a4a);
+  border-radius: 8px;
+  color: var(--text, #ccc);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 6px 10px;
+  margin: 4px;
+  transition: background .15s, border-color .15s;
+  -webkit-app-region: no-drag;
+}
+.hd-sidebar-btn:hover { background: var(--accent, #6366f1); color: #fff; }
+.hd-sidebar-btn.hd-active { background: var(--accent, #6366f1); color: #fff; border-color: var(--accent, #6366f1); }
+
+/* Floating fallback */
+.hd-sidebar-btn--float {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 8000;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hd-panel {
+    width: 95%;
+    right: 2.5%;
+    min-width: unset;
+  }
+}

--- a/extensions/hermes-desktop/assets/desktop-extension.css
+++ b/extensions/hermes-desktop/assets/desktop-extension.css
@@ -1,4 +1,6 @@
-/* Hermes Desktop — WebUI extension styles */
+/* Hermes Desktop — WebUI extension styles v0.2.0 */
+
+/* ---- Panel ---- */
 
 .hd-panel {
   display: none;
@@ -31,10 +33,28 @@
   font-size: 14px;
   font-weight: 600;
   color: var(--text, #e0e0e0);
-  cursor: move;
   user-select: none;
-  -webkit-app-region: no-drag;
+  flex-shrink: 0;
 }
+
+.hd-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.hd-header-btn {
+  background: none;
+  border: none;
+  color: var(--muted, #888);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 2px 6px;
+  line-height: 1;
+  border-radius: 4px;
+  transition: color .15s, background .15s;
+}
+.hd-header-btn:hover { color: var(--text, #e0e0e0); background: rgba(255,255,255,.08); }
 
 .hd-close-btn {
   background: none;
@@ -44,7 +64,6 @@
   cursor: pointer;
   padding: 0 6px;
   line-height: 1;
-  -webkit-app-region: no-drag;
 }
 .hd-close-btn:hover { color: var(--danger, #ff6b6b); }
 
@@ -55,16 +74,35 @@
   color: var(--text, #ccc);
 }
 
+/* ---- Status ---- */
+
 .hd-status {
   font-size: 15px;
   margin-bottom: 12px;
   padding: 10px 14px;
   border-radius: 6px;
   background: var(--bg-tertiary, #111122);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 .hd-status-on  { color: #4ade80; }
 .hd-status-warn { color: #fbbf24; }
 .hd-status-off  { color: #ef4444; }
+
+.hd-target-badge {
+  display: inline-block;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: rgba(99, 102, 241, .2);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, .3);
+  font-weight: 500;
+}
+
+/* ---- Controls ---- */
 
 .hd-controls {
   margin-bottom: 14px;
@@ -84,6 +122,7 @@
   font-size: 14px;
   cursor: pointer;
   margin-right: 8px;
+  margin-bottom: 4px;
   transition: background .15s;
 }
 .hd-btn-start {
@@ -98,6 +137,12 @@
   border-color: #f87171;
 }
 .hd-btn-stop:hover { background: #991b1b; }
+.hd-btn-transcript {
+  background: #1e3a5f;
+  color: #93c5fd;
+  border-color: #60a5fa;
+}
+.hd-btn-transcript:hover { background: #1e40af; }
 
 .hd-hint {
   font-size: 12px;
@@ -105,16 +150,242 @@
   margin-top: 6px;
 }
 
+/* ---- Desktop VNC iframe ---- */
+
 .hd-desktop-wrap {
   flex: 1;
-  min-height: 400px;
+  min-height: 380px;
   border: 1px solid var(--border, #2a2a4a);
   border-radius: 8px;
   overflow: hidden;
   background: #000;
 }
 
-/* Sidebar button */
+/* ---- Transcript ---- */
+
+.hd-transcript {
+  border-top: 1px solid var(--border, #2a2a4a);
+  margin-top: 8px;
+  background: var(--bg-tertiary, #111122);
+  border-radius: 6px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.hd-transcript-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted, #888);
+  background: var(--bg-secondary, #16213e);
+  border-bottom: 1px solid var(--border, #2a2a4a);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.hd-transcript-body {
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
+.hd-transcript-body .msg-row {
+  margin-bottom: 6px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: rgba(255,255,255,.03);
+}
+.hd-transcript-body .msg-row[data-role="assistant"] {
+  border-left: 2px solid #6366f1;
+}
+.hd-transcript-body .msg-row[data-role="user"] {
+  border-left: 2px solid #4ade80;
+}
+
+/* ---- Settings Overlay ---- */
+
+.hd-settings-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,.6);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hd-settings-panel {
+  background: var(--bg-primary, #1a1a2e);
+  border: 1px solid var(--border, #2a2a4a);
+  border-radius: 10px;
+  width: 90%;
+  max-width: 480px;
+  max-height: 80%;
+  overflow-y: auto;
+  box-shadow: 0 8px 40px rgba(0,0,0,.5);
+}
+
+.hd-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text, #e0e0e0);
+  background: var(--bg-secondary, #16213e);
+  border-bottom: 1px solid var(--border, #2a2a4a);
+}
+
+.hd-settings-body {
+  padding: 14px;
+}
+
+.hd-setting-group {
+  margin-bottom: 18px;
+}
+.hd-setting-group h4 {
+  margin: 0 0 6px;
+  font-size: 14px;
+  color: var(--text, #e0e0e0);
+}
+.hd-setting-desc {
+  font-size: 12px;
+  color: var(--muted, #777);
+  margin: 0 0 10px;
+}
+.hd-setting-desc code {
+  font-size: 11px;
+  background: rgba(255,255,255,.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+/* ---- Target Selector ---- */
+
+.hd-target-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hd-target-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border, #2a2a4a);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color .15s, background .15s;
+}
+.hd-target-option:hover {
+  border-color: #6366f1;
+  background: rgba(99, 102, 241, .08);
+}
+.hd-target-option.hd-target-active {
+  border-color: #6366f1;
+  background: rgba(99, 102, 241, .12);
+}
+
+.hd-target-radio {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border, #555);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color .15s;
+}
+.hd-target-active .hd-target-radio {
+  border-color: #6366f1;
+}
+.hd-target-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: transparent;
+  transition: background .15s;
+}
+.hd-target-active .hd-target-dot {
+  background: #6366f1;
+}
+
+.hd-target-info {
+  flex: 1;
+}
+.hd-target-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text, #e0e0e0);
+}
+.hd-target-desc {
+  font-size: 11px;
+  color: var(--muted, #777);
+  margin-top: 2px;
+}
+
+/* ---- Computer Use Status ---- */
+
+.hd-cua-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+  font-size: 13px;
+  color: var(--text, #ccc);
+  border-bottom: 1px solid var(--border, #1a1a2e);
+}
+.hd-cua-row:last-child { border-bottom: none; }
+
+.hd-cua-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  padding: 2px 10px;
+  border-radius: 10px;
+}
+.hd-cua-dot::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.hd-cua-installed::before { background: #4ade80; }
+.hd-cua-running::before { background: #4ade80; }
+.hd-cua-installed { background: rgba(74, 222, 128, .12); color: #4ade80; }
+.hd-cua-running { background: rgba(74, 222, 128, .12); color: #4ade80; }
+.hd-cua-not-installed::before { background: #f87171; }
+.hd-cua-not-installed { background: rgba(248, 113, 113, .12); color: #f87171; }
+.hd-cua-unknown::before { background: #9ca3af; }
+.hd-cua-unknown { background: rgba(156, 163, 175, .12); color: #9ca3af; }
+
+/* ---- Toggle ---- */
+
+.hd-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text, #ccc);
+  cursor: pointer;
+}
+.hd-toggle-label input[type="checkbox"] {
+  accent-color: #6366f1;
+}
+
+/* ---- Sidebar button ---- */
+
 .hd-sidebar-btn {
   background: var(--bg-tertiary, #1a1a2e);
   border: 1px solid var(--border, #2a2a4a);
@@ -125,7 +396,6 @@
   padding: 6px 10px;
   margin: 4px;
   transition: background .15s, border-color .15s;
-  -webkit-app-region: no-drag;
 }
 .hd-sidebar-btn:hover { background: var(--accent, #6366f1); color: #fff; }
 .hd-sidebar-btn.hd-active { background: var(--accent, #6366f1); color: #fff; border-color: var(--accent, #6366f1); }
@@ -141,11 +411,15 @@
   border-radius: 12px;
 }
 
-/* Responsive */
+/* ---- Responsive ---- */
+
 @media (max-width: 768px) {
   .hd-panel {
     width: 95%;
     right: 2.5%;
     min-width: unset;
+  }
+  .hd-settings-panel {
+    width: 95%;
   }
 }

--- a/extensions/hermes-desktop/assets/desktop-extension.js
+++ b/extensions/hermes-desktop/assets/desktop-extension.js
@@ -1,0 +1,193 @@
+(function () {
+  'use strict';
+
+  if (window.__HERMES_DESKTOP_LOADED__) return;
+  window.__HERMES_DESKTOP_LOADED__ = true;
+
+  var EXT_ID = 'hermes-desktop';
+  var CFG = {
+    sidecar: 'http://127.0.0.1:17887',
+    novncPort: 6080,
+    pollMs: 3000,
+    panelId: 'hermes-desktop-panel',
+    btnId: 'hermes-desktop-btn'
+  };
+
+  var state = {
+    sidecarOk: false,
+    containerRunning: false,
+    panelOpen: false
+  };
+
+  // ---- DOM helpers ----
+
+  function el(id) { return document.getElementById(id); }
+  function cr(tag, cls, html) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html !== undefined) e.innerHTML = html;
+    return e;
+  }
+
+  // ---- Panel ----
+
+  function buildPanel() {
+    var panel = el(CFG.panelId);
+    if (!panel) {
+      panel = cr('div', 'hd-panel', '');
+      panel.id = CFG.panelId;
+      panel.innerHTML =
+        '<div class="hd-panel-header">' +
+          '<span>🐧 Hermes Desktop</span>' +
+          '<button class="hd-close-btn" id="hd-close">&times;</button>' +
+        '</div>' +
+        '<div class="hd-panel-body" id="hd-body">' +
+          '<div class="hd-status" id="hd-status">Checking sidecar…</div>' +
+          '<div class="hd-controls" id="hd-controls"></div>' +
+          '<div class="hd-desktop-wrap" id="hd-desktop-wrap" style="display:none">' +
+            '<iframe id="hd-vnc-frame" src="" allow="clipboard-read; clipboard-write" ' +
+              'style="width:100%;height:100%;border:none;min-height:480px"></iframe>' +
+          '</div>' +
+        '</div>';
+      document.body.appendChild(panel);
+      el('hd-close').onclick = closePanel;
+    }
+    return panel;
+  }
+
+  function openPanel() {
+    var panel = buildPanel();
+    panel.style.display = 'block';
+    state.panelOpen = true;
+    refreshStatus();
+    if (state.containerRunning) showDesktop();
+  }
+
+  function closePanel() {
+    var panel = el(CFG.panelId);
+    if (panel) panel.style.display = 'none';
+    state.panelOpen = false;
+  }
+
+  function showDesktop() {
+    var wrap = el('hd-desktop-wrap');
+    var frame = el('hd-vnc-frame');
+    if (wrap && frame) {
+      frame.src = 'http://127.0.0.1:' + CFG.novncPort + '/vnc.html';
+      wrap.style.display = 'block';
+    }
+  }
+
+  function hideDesktop() {
+    var wrap = el('hd-desktop-wrap');
+    var frame = el('hd-vnc-frame');
+    if (wrap) wrap.style.display = 'none';
+    if (frame) frame.src = '';
+  }
+
+  // ---- Sidecar API ----
+
+  function fetchSidecar(path, opts) {
+    return fetch(CFG.sidecar + path, opts || {})
+      .then(function (r) { return r.json(); })
+      .catch(function () { return { ok: false, error: 'sidecar unreachable' }; });
+  }
+
+  function checkHealth() {
+    return fetchSidecar('/health').then(function (data) {
+      state.sidecarOk = !!(data && data.ok);
+      state.containerRunning = !!(data && data.container === 'running');
+      return data;
+    });
+  }
+
+  function sidecarAction(action) {
+    return fetchSidecar('/container/' + action, { method: 'POST' });
+  }
+
+  // ---- UI updates ----
+
+  function refreshStatus() {
+    var st = el('hd-status');
+    var ct = el('hd-controls');
+    if (!st || !ct) return;
+
+    checkHealth().then(function (data) {
+      if (!state.sidecarOk) {
+        st.innerHTML = '<span class="hd-status-off">&#x26A0; Sidecar not running</span>';
+        ct.innerHTML = '<p>Start the Hermes Desktop sidecar:</p><pre>cd hermes-desktop && python3 sidecar/sidecar.py</pre>';
+        hideDesktop();
+      } else if (!state.containerRunning) {
+        st.innerHTML = '<span class="hd-status-warn">&#x23F3; Desktop container not running</span>';
+        ct.innerHTML =
+          '<button class="hd-btn hd-btn-start" id="hd-start-btn">Start Desktop</button>' +
+          '<p class="hd-hint">Launches the XFCE desktop container (first start may take 1-2 min to pull image)</p>';
+        el('hd-start-btn').onclick = function () {
+          sidecarAction('start').then(function () {
+            setTimeout(refreshStatus, 3000);
+          });
+        };
+        hideDesktop();
+      } else {
+        st.innerHTML = '<span class="hd-status-on">&#x2705; Desktop running</span>';
+        ct.innerHTML =
+          '<button class="hd-btn hd-btn-stop" id="hd-stop-btn">Stop Desktop</button>';
+        el('hd-stop-btn').onclick = function () {
+          sidecarAction('stop').then(function () {
+            hideDesktop();
+            setTimeout(refreshStatus, 2000);
+          });
+        };
+        if (state.panelOpen) showDesktop();
+      }
+    });
+  }
+
+  // ---- Sidebar button ----
+
+  function addSidebarButton() {
+    if (el(CFG.btnId)) return;
+
+    var btn = cr('button', 'hd-sidebar-btn', '🐧');
+    btn.id = CFG.btnId;
+    btn.title = 'Hermes Desktop — Linux desktop in a panel';
+    btn.onclick = function () {
+      if (state.panelOpen) { closePanel(); } else { openPanel(); }
+      btn.classList.toggle('hd-active', state.panelOpen);
+    };
+
+    // Try to add to sidebar nav, fallback to floating button
+    var sidebar = document.querySelector('[class*="sidebar"] nav') ||
+                  document.querySelector('.app-sidebar nav') ||
+                  document.querySelector('#sessionSidebar');
+    if (sidebar) {
+      sidebar.appendChild(btn);
+    } else {
+      btn.classList.add('hd-sidebar-btn--float');
+      document.body.appendChild(btn);
+    }
+  }
+
+  // ---- Init ----
+
+  function init() {
+    addSidebarButton();
+    buildPanel();
+
+    // Poll sidecar periodically
+    setInterval(function () {
+      if (state.panelOpen) refreshStatus();
+    }, CFG.pollMs);
+
+    // Initial health check
+    checkHealth().then(function (data) {
+      console.log('[Hermes Desktop] Sidecar status:', data);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/extensions/hermes-desktop/assets/desktop-extension.js
+++ b/extensions/hermes-desktop/assets/desktop-extension.js
@@ -7,16 +7,26 @@
   var EXT_ID = 'hermes-desktop';
   var CFG = {
     sidecar: 'http://127.0.0.1:17887',
-    novncPort: 6901,
+    novncContainer: 6901,
+    novncHost: 6081,
     pollMs: 3000,
     panelId: 'hermes-desktop-panel',
-    btnId: 'hermes-desktop-btn'
+    btnId: 'hermes-desktop-btn',
+    storageKey: 'hermes-desktop:target'
+  };
+
+  var TARGETS = {
+    container: { label: 'Container (Xfce :1)', port: CFG.novncContainer, display: ':1', desc: 'Full XFCE desktop in Docker container' },
+    host: { label: 'Host (Xvfb :0)', port: CFG.novncHost, display: ':0', desc: 'Host Xvfb framebuffer — lightweight' }
   };
 
   var state = {
     sidecarOk: false,
     containerRunning: false,
-    panelOpen: false
+    panelOpen: false,
+    target: localStorage.getItem(CFG.storageKey) || 'container',
+    cuaStatus: { host: 'unknown', container: 'unknown' },
+    transcriptOpen: false
   };
 
   // ---- DOM helpers ----
@@ -38,27 +48,95 @@
       panel.id = CFG.panelId;
       panel.innerHTML =
         '<div class="hd-panel-header">' +
-          '<span>🐧 Hermes Desktop</span>' +
-          '<button class="hd-close-btn" id="hd-close">&times;</button>' +
+          '<span>\u{1F427} Hermes Desktop</span>' +
+          '<div class="hd-header-actions">' +
+            '<button class="hd-header-btn" id="hd-settings-btn" title="Settings">\u2699</button>' +
+            '<button class="hd-close-btn" id="hd-close">&times;</button>' +
+          '</div>' +
         '</div>' +
         '<div class="hd-panel-body" id="hd-body">' +
-          '<div class="hd-status" id="hd-status">Checking sidecar…</div>' +
+          '<div class="hd-status" id="hd-status">Checking sidecar\u2026</div>' +
           '<div class="hd-controls" id="hd-controls"></div>' +
           '<div class="hd-desktop-wrap" id="hd-desktop-wrap" style="display:none">' +
             '<iframe id="hd-vnc-frame" src="" allow="clipboard-read; clipboard-write" ' +
-              'style="width:100%;height:100%;border:none;min-height:480px"></iframe>' +
+              'style="width:100%;height:100%;border:none;min-height:420px"></iframe>' +
+          '</div>' +
+          '<div class="hd-transcript" id="hd-transcript" style="display:none">' +
+            '<div class="hd-transcript-header">' +
+              '<span>Agent Transcript</span>' +
+              '<button class="hd-header-btn" id="hd-transcript-close" title="Close">&times;</button>' +
+            '</div>' +
+            '<div class="hd-transcript-body" id="hd-transcript-body"></div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="hd-settings-overlay" id="hd-settings" style="display:none">' +
+          '<div class="hd-settings-panel">' +
+            '<div class="hd-settings-header">' +
+              '<span>\u2699 Settings</span>' +
+              '<button class="hd-header-btn" id="hd-settings-close" title="Close">&times;</button>' +
+            '</div>' +
+            '<div class="hd-settings-body">' +
+              '<div class="hd-setting-group">' +
+                '<h4>Computer Use Target</h4>' +
+                '<p class="hd-setting-desc">Which display the agent drives via <code>computer_use</code> tool.</p>' +
+                '<div class="hd-target-options" id="hd-target-options"></div>' +
+              '</div>' +
+              '<div class="hd-setting-group">' +
+                '<h4>Computer Use Status</h4>' +
+                '<div id="hd-cua-status">' +
+                  '<div class="hd-cua-row"><span>Host (Xvfb :0):</span><span class="hd-cua-dot hd-cua-unknown" id="cua-host-status">unknown</span></div>' +
+                  '<div class="hd-cua-row"><span>Container (Xfce :1):</span><span class="hd-cua-dot hd-cua-unknown" id="cua-container-status">unknown</span></div>' +
+                '</div>' +
+              '</div>' +
+              '<div class="hd-setting-group">' +
+                '<h4>Transcript</h4>' +
+                '<label class="hd-toggle-label">' +
+                  '<input type="checkbox" id="hd-transcript-toggle"> ' +
+                  'Show agent transcript in panel' +
+                '</label>' +
+              '</div>' +
+            '</div>' +
           '</div>' +
         '</div>';
       document.body.appendChild(panel);
       el('hd-close').onclick = closePanel;
+      el('hd-settings-btn').onclick = toggleSettings;
+      el('hd-settings-close').onclick = toggleSettings;
+      el('hd-transcript-close').onclick = toggleTranscript;
+      buildTargetOptions();
     }
     return panel;
   }
 
+  function buildTargetOptions() {
+    var container = el('hd-target-options');
+    if (!container) return;
+    container.innerHTML = '';
+    Object.keys(TARGETS).forEach(function (key) {
+      var t = TARGETS[key];
+      var opt = cr('div', 'hd-target-option' + (key === state.target ? ' hd-target-active' : ''));
+      opt.setAttribute('data-target', key);
+      opt.innerHTML =
+        '<div class="hd-target-radio">' +
+          '<span class="hd-target-dot"></span>' +
+        '</div>' +
+        '<div class="hd-target-info">' +
+          '<div class="hd-target-label">' + t.label + '</div>' +
+          '<div class="hd-target-desc">' + t.desc + '</div>' +
+        '</div>';
+      opt.onclick = function () {
+        setTarget(key);
+        refreshStatus();
+      };
+      container.appendChild(opt);
+    });
+  }
+
   function openPanel() {
     var panel = buildPanel();
-    panel.style.display = 'block';
+    panel.style.display = 'flex';
     state.panelOpen = true;
+    document.body.classList.add('hd-panel-open');
     refreshStatus();
     if (state.containerRunning) showDesktop();
   }
@@ -67,13 +145,37 @@
     var panel = el(CFG.panelId);
     if (panel) panel.style.display = 'none';
     state.panelOpen = false;
+    document.body.classList.remove('hd-panel-open');
+  }
+
+  function toggleSettings() {
+    var s = el('hd-settings');
+    if (s) s.style.display = s.style.display === 'none' ? 'block' : 'none';
+  }
+
+  function toggleTranscript() {
+    state.transcriptOpen = !state.transcriptOpen;
+    var t = el('hd-transcript');
+    if (t) t.style.display = state.transcriptOpen ? 'block' : 'none';
+  }
+
+  function setTarget(key) {
+    state.target = key;
+    localStorage.setItem(CFG.storageKey, key);
+    // Update radio styles
+    var opts = document.querySelectorAll('.hd-target-option');
+    for (var i = 0; i < opts.length; i++) {
+      opts[i].classList.toggle('hd-target-active', opts[i].getAttribute('data-target') === key);
+    }
+    hideDesktop();
   }
 
   function showDesktop() {
     var wrap = el('hd-desktop-wrap');
     var frame = el('hd-vnc-frame');
     if (wrap && frame) {
-      frame.src = 'http://127.0.0.1:' + CFG.novncPort + '/vnc.html';
+      var port = TARGETS[state.target] ? TARGETS[state.target].port : CFG.novncContainer;
+      frame.src = 'http://127.0.0.1:' + port + '/vnc.html';
       wrap.style.display = 'block';
     }
   }
@@ -101,11 +203,38 @@
     });
   }
 
+  function checkCuaStatus() {
+    return fetchSidecar('/cua/status').then(function (data) {
+      if (data && data.ok) {
+        state.cuaStatus = {
+          host: data.host || 'unknown',
+          container: data.container || 'unknown'
+        };
+      }
+      return data;
+    }).catch(function () {
+      state.cuaStatus = { host: 'unknown', container: 'unknown' };
+    });
+  }
+
   function sidecarAction(action) {
     return fetchSidecar('/container/' + action, { method: 'POST' });
   }
 
   // ---- UI updates ----
+
+  function renderCuaStatus() {
+    var hostEl = el('cua-host-status');
+    var contEl = el('cua-container-status');
+    if (hostEl) {
+      hostEl.textContent = state.cuaStatus.host;
+      hostEl.className = 'hd-cua-dot hd-cua-' + state.cuaStatus.host;
+    }
+    if (contEl) {
+      contEl.textContent = state.cuaStatus.container;
+      contEl.className = 'hd-cua-dot hd-cua-' + state.cuaStatus.container;
+    }
+  }
 
   function refreshStatus() {
     var st = el('hd-status');
@@ -113,12 +242,14 @@
     if (!st || !ct) return;
 
     checkHealth().then(function (data) {
+      checkCuaStatus().then(renderCuaStatus);
+
       if (!state.sidecarOk) {
-        st.innerHTML = '<span class="hd-status-off">&#x26A0; Sidecar not running</span>';
-        ct.innerHTML = '<p>Start the Hermes Desktop sidecar:</p><pre>cd hermes-desktop && python3 sidecar/sidecar.py</pre>';
+        st.innerHTML = '<span class="hd-status-off">\u26A0 Sidecar not running</span>';
+        ct.innerHTML = '<p>Start the Hermes Desktop sidecar:</p><pre>python3 sidecar/sidecar.py</pre>';
         hideDesktop();
       } else if (!state.containerRunning) {
-        st.innerHTML = '<span class="hd-status-warn">&#x23F3; Desktop container not running</span>';
+        st.innerHTML = '<span class="hd-status-warn">\u23F3 Desktop container not running</span>';
         ct.innerHTML =
           '<button class="hd-btn hd-btn-start" id="hd-start-btn">Start Desktop</button>' +
           '<p class="hd-hint">Launches the XFCE desktop container (first start may take 1-2 min to pull image)</p>';
@@ -129,18 +260,38 @@
         };
         hideDesktop();
       } else {
-        st.innerHTML = '<span class="hd-status-on">&#x2705; Desktop running</span>';
+        var targetName = TARGETS[state.target] ? TARGETS[state.target].label : 'Container (Xfce :1)';
+        st.innerHTML = '<span class="hd-status-on">\u2705 Desktop running</span>' +
+          ' <span class="hd-target-badge">' + targetName + '</span>';
         ct.innerHTML =
-          '<button class="hd-btn hd-btn-stop" id="hd-stop-btn">Stop Desktop</button>';
+          '<button class="hd-btn hd-btn-stop" id="hd-stop-btn">Stop Desktop</button>' +
+          '<button class="hd-btn hd-btn-transcript" id="hd-transcript-btn">\u{1F4AC} Transcript</button>';
         el('hd-stop-btn').onclick = function () {
           sidecarAction('stop').then(function () {
             hideDesktop();
             setTimeout(refreshStatus, 2000);
           });
         };
+        el('hd-transcript-btn').onclick = toggleTranscript;
         if (state.panelOpen) showDesktop();
       }
     });
+  }
+
+  // ---- Transcript via renderTranscript hook ----
+
+  function tryRenderTranscript() {
+    if (!state.transcriptOpen) return;
+    var body = el('hd-transcript-body');
+    if (!body) return;
+
+    // Use the WebUI's renderTranscript if available (added by PR #5508)
+    if (typeof window.renderTranscript === 'function' &&
+        typeof window.__S !== 'undefined' && window.__S && window.__S.messages) {
+      window.renderTranscript(body, window.__S.messages, { skipEmpty: true });
+    } else {
+      body.innerHTML = '<p class="hd-hint">Agent transcript will appear here when available. Requires WebUI core hooks (PR #5508).</p>';
+    }
   }
 
   // ---- Sidebar button ----
@@ -148,9 +299,9 @@
   function addSidebarButton() {
     if (el(CFG.btnId)) return;
 
-    var btn = cr('button', 'hd-sidebar-btn', '🐧');
+    var btn = cr('button', 'hd-sidebar-btn', '\u{1F427}');
     btn.id = CFG.btnId;
-    btn.title = 'Hermes Desktop — Linux desktop in a panel';
+    btn.title = 'Hermes Desktop \u2014 Linux desktop in a panel';
     btn.onclick = function () {
       if (state.panelOpen) { closePanel(); } else { openPanel(); }
       btn.classList.toggle('hd-active', state.panelOpen);
@@ -168,19 +319,59 @@
     }
   }
 
+  // Hook into renderTranscript when WebUI broadcasts it
+  function hookRenderTranscript() {
+    // The WebUI exposes these globals after PR #5508 lands
+    Object.defineProperty(window, 'renderTranscript', {
+      configurable: true,
+      set: function (fn) {
+        // Store the real implementation
+        window.__renderTranscriptImpl = fn;
+        // If panel is open, re-render
+        if (state.transcriptOpen) tryRenderTranscript();
+      },
+      get: function () {
+        return window.__renderTranscriptImpl || function () {};
+      }
+    });
+
+    // Also hook session open so we can re-render on navigation
+    if (typeof window.registerHermesSessionOpenHandler === 'function') {
+      window.registerHermesSessionOpenHandler(function (sid, data, phase) {
+        if (phase && phase.loaded && state.transcriptOpen) {
+          setTimeout(tryRenderTranscript, 100);
+        }
+      });
+    }
+
+    // Poll for transcript updates when open
+    setInterval(function () {
+      if (state.transcriptOpen) tryRenderTranscript();
+    }, 2000);
+  }
+
   // ---- Init ----
 
   function init() {
     addSidebarButton();
     buildPanel();
+    hookRenderTranscript();
 
-    // Poll sidecar periodically
+    // Restore transcript toggle state
+    var toggle = el('hd-transcript-toggle');
+    if (toggle) {
+      toggle.checked = state.transcriptOpen;
+      toggle.onchange = function () { state.transcriptOpen = toggle.checked; };
+    }
+
+    // Poll sidecar + cua status periodically
     setInterval(function () {
       if (state.panelOpen) refreshStatus();
     }, CFG.pollMs);
 
     // Initial health check
     checkHealth().then(function (data) {
+      checkCuaStatus().then(renderCuaStatus);
       console.log('[Hermes Desktop] Sidecar status:', data);
     });
   }

--- a/extensions/hermes-desktop/assets/desktop-extension.js
+++ b/extensions/hermes-desktop/assets/desktop-extension.js
@@ -7,7 +7,7 @@
   var EXT_ID = 'hermes-desktop';
   var CFG = {
     sidecar: 'http://127.0.0.1:17887',
-    novncPort: 6080,
+    novncPort: 6901,
     pollMs: 3000,
     panelId: 'hermes-desktop-panel',
     btnId: 'hermes-desktop-btn'

--- a/extensions/hermes-desktop/extension.json
+++ b/extensions/hermes-desktop/extension.json
@@ -1,8 +1,8 @@
 {
   "id": "hermes-desktop",
   "name": "Hermes Desktop",
-  "description": "A full Linux XFCE desktop inside Hermes WebUI. Drive GUI applications (Blender, LibreOffice, terminals) from your browser — the agent and you share the same desktop. Ships a Docker container, a loopback sidecar, and a WebUI panel.",
-  "version": "0.1.0",
+  "description": "A full Linux desktop inside Hermes WebUI with Computer Use integration. Choose between Host (Xvfb :0) or Container (Xfce :1) as the agent's GUI target. Watch the agent drive the desktop via noVNC while you chat — the same session is rendered in a mini transcript panel.",
+  "version": "0.2.0",
   "author": "ChonSong",
   "homepage": "https://github.com/ChonSong/hermes-desktop",
   "assets": {
@@ -15,7 +15,8 @@
   },
   "capabilities": [
     "manifest-bundle",
-    "loopback-sidecar"
+    "loopback-sidecar",
+    "transcript-render"
   ],
   "sidecar": {
     "type": "loopback",
@@ -29,7 +30,7 @@
     "native_host_autostart": "none"
   },
   "post_install": {
-    "summary": "Install enables the WebUI desktop panel. Clone the companion repo, build the Docker container, and start the sidecar to launch the Linux desktop.",
+    "summary": "Install enables the WebUI desktop panel. Clone the companion repo, build the Docker container, and start the sidecar to launch the Linux desktop. Optionally install cua-driver (hermes computer-use install) for native Computer Use agent control.",
     "docs_url": "https://github.com/ChonSong/hermes-desktop#after-gallery-install",
     "requires_local_app": true,
     "local_app_label": "Hermes Desktop sidecar"

--- a/extensions/hermes-desktop/extension.json
+++ b/extensions/hermes-desktop/extension.json
@@ -1,0 +1,69 @@
+{
+  "id": "hermes-desktop",
+  "name": "Hermes Desktop",
+  "description": "A full Linux XFCE desktop inside Hermes WebUI. Drive GUI applications (Blender, LibreOffice, terminals) from your browser — the agent and you share the same desktop. Ships a Docker container, a loopback sidecar, and a WebUI panel.",
+  "version": "0.1.0",
+  "author": "ChonSong",
+  "homepage": "https://github.com/ChonSong/hermes-desktop",
+  "assets": {
+    "scripts": [
+      "assets/desktop-extension.js"
+    ],
+    "stylesheets": [
+      "assets/desktop-extension.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle",
+    "loopback-sidecar"
+  ],
+  "sidecar": {
+    "type": "loopback",
+    "origin": "http://127.0.0.1:17887",
+    "health_path": "/health"
+  },
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": true,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "post_install": {
+    "summary": "Install enables the WebUI desktop panel. Clone the companion repo, build the Docker container, and start the sidecar to launch the Linux desktop.",
+    "docs_url": "https://github.com/ChonSong/hermes-desktop#after-gallery-install",
+    "requires_local_app": true,
+    "local_app_label": "Hermes Desktop sidecar"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": false
+    },
+    "storage": {
+      "owned": true,
+      "shared_webui_keys": []
+    },
+    "sidecar_commands": {
+      "from_loopback": false,
+      "can_switch_sessions": false,
+      "can_write_drafts": false,
+      "can_autosend": false,
+      "can_respond_approval": false,
+      "can_respond_clarify": false,
+      "approval_clarify_response_default": false
+    },
+    "loopback_sidecar": true,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false
+  }
+}

--- a/extensions/hermes-desktop/manifest.json
+++ b/extensions/hermes-desktop/manifest.json
@@ -1,0 +1,20 @@
+{
+  "extensions": [
+    {
+      "id": "hermes-desktop",
+      "name": "Hermes Desktop",
+      "description": "A full Linux XFCE desktop inside Hermes WebUI.",
+      "scripts": [
+        "assets/desktop-extension.js"
+      ],
+      "stylesheets": [
+        "assets/desktop-extension.css"
+      ],
+      "sidecar": {
+        "type": "loopback",
+        "origin": "http://127.0.0.1:17887",
+        "health_path": "/health"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Thinking Path

- User wanted Linux desktop app integration in Hermes, comparable to Agent Zero
- Desktop Companion (existing extension) is a reactive pet, not a desktop gateway
- The missing piece: an extension that launches a containerized XFCE desktop and renders it in a WebUI panel via noVNC
- v0.2.0 adds dual-target Computer Use: drive Host (Xvfb :0) or Container (Xfce :1) via cua-driver

## What Changed (v0.2.0)

### Files Changed

- **`extensions/hermes-desktop/extension.json`** — v0.2.0, added `transcript-render` capability
- **`extensions/hermes-desktop/manifest.json`** — unchanged
- **`extensions/hermes-desktop/assets/desktop-extension.js`** — fully rewritten:
  - Target selector: choose Host (Xvfb :0) or Container (Xfce :1) via Settings overlay
  - Computer Use status indicators per target (installed/running/unknown)
  - Mini transcript via `renderTranscript` hook (requires WebUI PR #5508)
  - Settings panel with persistent localStorage configuration
  - Dual-target VNC: container on :6901, host on :6081
- **`extensions/hermes-desktop/assets/desktop-extension.css`** — expanded:
  - Settings overlay + target selector radio buttons
  - CUA status dots (installed/running/not-installed/unknown)
  - Transcript styles with role-colored borders
  - Responsive layout
- **`extensions/hermes-desktop/README.md`** — comprehensive rewrite:
  - Full ASCII architecture diagram (browser → sidecar → Docker container → host)
  - Dual-target reference table
  - Sidecar API reference (/health, /container/start, /container/stop, /cua/status, /cua/target)
  - WebUI core API reference (PR #5508 hooks)
  - Installation guide for cua-driver (host + container)
  - Usage flow and manual control commands

### New Architecture

Two cua-driver instances, selectable from the panel:

| Target | DISPLAY | Desktop | VNC | Use Case |
|--------|---------|---------|-----|----------|
| **Host (Xvfb :0)** | :0 | Headless framebuffer | x11vnc → noVNC :6081 | Lightweight, fast |
| **Container (Xfce :1)** | :1 | Full XFCE4 | TigerVNC → noVNC :6901 | Real desktop apps |

### Dependencies

- **PR #5508** (nesquena/hermes-webui) — provides `registerHermesSessionOpenHandler` and `renderTranscript` for the mini transcript panel
- **cua-driver** (`hermes computer-use install`) — enables the `computer_use` tool for agent-driven desktop control

## Why It Matters

- **First extension with Computer Use integration** — agent drives the desktop natively via AT-SPI, not pixel scraping
- **Dual-target architecture** scales from lightweight Xvfb to full XFCE without core changes
- **Mini transcript** lets users chat with the agent while watching it drive the desktop — same session, split layout
- **Self-contained trust model**: loopback only, no WebUI API reads/writes, owned DOM panel, no core view mutation