### PR TITLE
Add custom-branding extension (custom logo + favicon)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -26,6 +26,8 @@ need it and maintainers agree on the shared contract.
   ★ Favorites group at the top of the composer model picker.
 - `custom-avatar`: give the assistant a custom avatar image in the chat
   transcript (downscaled + stored locally; assistant-only).
+- `custom-branding`: white-label the app with your own logo + favicon (titlebar
+  mark, empty-state hero logo, and browser-tab icon; downscaled + stored locally).
 - `theme-creator`: build your own theme with a live color editor; custom themes
   register into the native Appearance picker (needs core theme-registration).
 - `session-export-pdf`: export the current conversation to PDF (print) or copy

--- a/extensions/custom-branding/README.md
+++ b/extensions/custom-branding/README.md
@@ -141,3 +141,6 @@ Manual verification:
   core rename would need an update.
 - Uploads are rasterized to PNG/JPEG (no live SVG) and downscaled (logo ≤ 256px,
   favicon ≤ 64px) to keep localStorage small and avoid SVG-XSS.
+- Swapping the `apple-touch-icon` / favicon `<link>` changes the **browser-tab**
+  icon only. An **installed PWA / iOS home-screen** icon is read from the web app
+  manifest at install time, so it is not affected by this extension.

--- a/extensions/custom-branding/README.md
+++ b/extensions/custom-branding/README.md
@@ -1,0 +1,143 @@
+# Custom Branding
+
+Custom Branding is a trusted local Hermes WebUI extension that lets you
+white-label the app chrome with **your own logo and favicon**. The Hermes
+titlebar mark, the empty-state hero logo, and the browser-tab favicon are all
+swapped for images of your choice.
+
+## What It Does
+
+- Click the titlebar logo (`.app-titlebar-icon`) to open a small picker:
+  - **Logo** — upload an image; it replaces the inline titlebar SVG mark and the
+    large empty-state hero logo (`.empty-logo`).
+  - **Favicon** — upload an image; it replaces the browser-tab icon (the
+    `<link rel="icon">` / `shortcut icon` / `apple-touch-icon` nodes in `<head>`).
+- Each image is **downscaled and stored locally** as a data-URL in
+  `localStorage` (logo ≤ 256px, favicon ≤ 64px), so it stays small and survives
+  reloads.
+- Re-applies after the UI re-renders (transcript rebuilds, panel toggles,
+  reload) via a `MutationObserver`, so your branding persists.
+- Restores the original Hermes logo / favicon when you remove a custom image.
+
+## Credit
+
+This extension was **rebuilt as a client-side extension from closed core PR
+[nesquena/hermes-webui#3307](https://github.com/nesquena/hermes-webui/pull/3307)**
+("Add custom logo and favicon uploads") by **[@gavinssr](https://github.com/gavinssr)**.
+The original PR shipped a server-side upload endpoint plus `config.yaml`
+persistence; that scope was a core-curation call (instance branding is optional,
+opt-in, and self-contained — an extension-model fit, not core). Because
+extensions cannot add core endpoints, this is a **client-side rebuild**:
+localStorage data-URLs applied by DOM swaps rather than a server round-trip. The
+validation/downscale approach preserves @gavinssr's original design intent
+(only ever apply a validated raster image, sized down aggressively).
+
+## Current Shape
+
+```text
+Hermes WebUI page
+  -> manifest-bundled extension assets
+  -> /extensions/assets/custom-branding.js + .css
+  -> swaps .app-titlebar-icon SVG + .empty-logo SVG for an <img> when a logo is set
+  -> swaps the <head> favicon <link> nodes for a managed <link> when a favicon is set
+  -> localStorage: hermes-ext-custom-branding-logo, hermes-ext-custom-branding-favicon
+```
+
+This extension is `static-ui` / manifest-bundle only. It does not add backend
+routes, start a sidecar, access external networks, or use native host APIs.
+Image processing happens entirely in the browser (`FileReader` + `<canvas>`
+downscale); nothing is uploaded anywhere.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/custom-branding \
+  HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+Then click the small Hermes logo in the top-left titlebar and upload a logo
+and/or favicon.
+
+## Controls
+
+Also exposed on `window.HermesCustomBrandingExtension`:
+
+- `.getLogo()` / `.getFavicon()` — current data-URL (or empty)
+- `.setLogo(dataUrl)` / `.setFavicon(dataUrl)` — set a `data:image/...` value
+- `.clearLogo()` / `.clearFavicon()` — remove it
+- `.refresh()` — re-apply to the current DOM
+
+## Disable And Uninstall
+
+Restart Hermes WebUI without `HERMES_WEBUI_EXTENSION_DIR` /
+`HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the `extensions/custom-branding/`
+directory. Your images live under the `hermes-ext-custom-branding-logo` and
+`hermes-ext-custom-branding-favicon` localStorage keys.
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- creates extension-owned DOM (an `<img>` inside the logo containers, a managed
+  favicon `<link>`, and a picker popover) and mutates core views (swaps the
+  titlebar / empty-state logo and neutralizes the core favicon `<link>` nodes)
+- reads the uploaded image file locally (`FileReader`) and downscales it via a
+  `<canvas>`; the result is a small data-URL
+- reads and writes `localStorage` under exactly two keys:
+  `hermes-ext-custom-branding-logo` and `hermes-ext-custom-branding-favicon`
+- does not call WebUI HTTP APIs (`webui_api.read/write` are empty)
+- does not navigate the WebUI (`webui_navigation: false`)
+- does not access cookies
+- does not contact loopback or external network services (`network_external:
+  false` — the image never leaves the browser)
+- does not use arbitrary filesystem or native host APIs (the file picker is the
+  standard browser `<input type=file>`)
+
+### Security note (SVG-XSS)
+
+Uploads are restricted to raster **PNG / JPEG / WebP** and are **rasterized via
+`<canvas>`** before storage (`canvas.toDataURL` emits `image/png` or
+`image/jpeg` only). A stored value therefore can never carry raw SVG markup, so
+the SVG-XSS surface an `<svg>` favicon/logo would open is avoided by design.
+Only validated `data:image/(png|jpeg|webp);base64,...` values are ever applied.
+
+## Compatibility
+
+- manifest-bundled extension assets + same-origin serving under `/extensions/`
+- titlebar logo container `.app-titlebar-icon`, empty-state logo container
+  `.empty-logo`, and the `<head>` favicon `<link>` nodes (the integration
+  contract; a core rename would need an update)
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node scripts/test-extension-validator.mjs
+node scripts/generate-registry.mjs --out dist/registry.json
+node --check extensions/custom-branding/assets/custom-branding.js
+python3 -m json.tool extensions/custom-branding/extension.json
+python3 -m json.tool extensions/custom-branding/manifest.json
+```
+
+Manual verification:
+
+- clicking the titlebar logo opens the picker; uploading a logo replaces the
+  titlebar mark and the empty-state hero logo
+- uploading a favicon swaps the browser-tab icon
+- both persist across a reload and re-apply after a re-render
+- removing a logo / favicon restores the Hermes default
+- a non-raster or oversized file is rejected with a message, not applied
+
+## Known Limitations
+
+- Branding is per-browser (`localStorage`), not synced across devices.
+- Relies on `.app-titlebar-icon` / `.empty-logo` / the `<head>` favicon links; a
+  core rename would need an update.
+- Uploads are rasterized to PNG/JPEG (no live SVG) and downscaled (logo ≤ 256px,
+  favicon ≤ 64px) to keep localStorage small and avoid SVG-XSS.

--- a/extensions/custom-branding/assets/custom-branding.css
+++ b/extensions/custom-branding/assets/custom-branding.css
@@ -1,0 +1,117 @@
+/* Custom Branding extension for Hermes WebUI.
+   Scoped to hwx-branding-* classes; uses core CSS variables for theme-fit. */
+
+/* Logo image fills the existing logo container, preserving its box size. */
+.app-titlebar-icon.hwx-branding-logo-set,
+.empty-logo.hwx-branding-logo-set {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.hwx-branding-logo-img {
+  display: block;
+  object-fit: contain;
+}
+.hwx-branding-logo-titlebar {
+  width: 16px;
+  height: 16px;
+}
+.hwx-branding-logo-hero {
+  width: 80px;
+  height: 80px;
+}
+
+/* Picker popover. */
+.hwx-branding-picker {
+  position: fixed;
+  z-index: 1000;
+  min-width: 220px;
+  max-width: 280px;
+  background: var(--surface, #fff);
+  color: var(--text, #111);
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, .28);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.hwx-branding-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--muted, #888);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.hwx-branding-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border2, rgba(127, 127, 127, .18));
+}
+.hwx-branding-section:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+.hwx-branding-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text, #111);
+}
+.hwx-branding-preview {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--border2, rgba(127, 127, 127, .25));
+  border-radius: 8px;
+  background: var(--code-bg, rgba(127, 127, 127, .06));
+  overflow: hidden;
+}
+.hwx-branding-preview img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+}
+.hwx-branding-preview-logo {
+  width: 64px;
+  height: 64px;
+}
+.hwx-branding-preview-favicon {
+  width: 32px;
+  height: 32px;
+}
+.hwx-branding-preview-none {
+  font-size: 11px;
+  color: var(--muted, #888);
+}
+.hwx-branding-btn {
+  appearance: none;
+  border: 1px solid var(--border2, rgba(127, 127, 127, .25));
+  background: var(--code-bg, rgba(127, 127, 127, .1));
+  color: var(--text, #111);
+  border-radius: 7px;
+  padding: 7px 10px;
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background .12s ease, border-color .12s ease;
+}
+.hwx-branding-btn:hover {
+  background: var(--hover-bg, rgba(127, 127, 127, .16));
+  border-color: var(--border, rgba(127, 127, 127, .4));
+}
+.hwx-branding-btn--clear {
+  color: var(--danger, #e5534b);
+}
+.hwx-branding-status {
+  font-size: 11px;
+  color: var(--muted, #888);
+  min-height: 14px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hwx-branding-btn { transition: none; }
+}

--- a/extensions/custom-branding/assets/custom-branding.css
+++ b/extensions/custom-branding/assets/custom-branding.css
@@ -114,7 +114,7 @@
   border-color: var(--border, rgba(127, 127, 127, .4));
 }
 .hwx-branding-btn--clear {
-  color: var(--danger, #e5534b);
+  color: var(--error, #e5534b);
 }
 .hwx-branding-status {
   font-size: 11px;

--- a/extensions/custom-branding/assets/custom-branding.css
+++ b/extensions/custom-branding/assets/custom-branding.css
@@ -17,8 +17,13 @@
   height: 16px;
 }
 .hwx-branding-logo-hero {
-  width: 80px;
-  height: 80px;
+  width: 88px;
+  height: 88px;
+}
+/* Suppress core's Hermes-tinted glow behind a custom hero logo so it doesn't
+   tint the customer's mark (undercuts the white-label intent). */
+.empty-logo.hwx-branding-logo-set::before {
+  display: none;
 }
 
 /* Picker popover. */
@@ -82,6 +87,11 @@
 .hwx-branding-preview-favicon {
   width: 32px;
   height: 32px;
+}
+.hwx-branding-preview-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .hwx-branding-preview-none {
   font-size: 11px;

--- a/extensions/custom-branding/assets/custom-branding.js
+++ b/extensions/custom-branding/assets/custom-branding.js
@@ -280,8 +280,14 @@
       downscaleToDataUrl(f, maxDim, maxBytes, (dataUrl, err) => {
         if (err) { setStatus(err); return; }
         const ok = (kind === 'favicon') ? setFavicon(dataUrl) : setLogo(dataUrl);
-        setStatus(ok ? 'Applied.' : 'Couldn’t save — storage full.');
+        // rebuildPicker() wipes the popover body (incl. the status node), so set
+        // the message AFTER the rebuild — otherwise the honest quota-fail status
+        // is erased before the browser paints it. Re-focus the first control too,
+        // since the button the user activated was just destroyed by the rebuild.
         rebuildPicker();
+        const firstBtn = picker && picker.querySelector('button');
+        if (firstBtn) { try { firstBtn.focus(); } catch (_) {} }
+        setStatus(ok ? 'Applied.' : 'Couldn’t save — storage full.');
       });
     });
 
@@ -334,7 +340,9 @@
     picker = document.createElement('div');
     picker.className = 'hwx-branding-picker';
     picker.setAttribute('role', 'dialog');
-    picker.setAttribute('aria-modal', 'true');
+    // Light-dismiss popover (outside-click / Esc closes it); we don't trap Tab,
+    // so don't claim aria-modal — that would tell a screen reader focus is
+    // trapped when it isn't.
     picker.setAttribute('aria-label', 'Custom Branding');
     picker.setAttribute('tabindex', '-1');
     picker.appendChild(buildPickerBody());

--- a/extensions/custom-branding/assets/custom-branding.js
+++ b/extensions/custom-branding/assets/custom-branding.js
@@ -34,7 +34,6 @@
   const FAVICON_MAX_DIM = 64;          // downscale target for the favicon (px)
   const LOGO_MAX_BYTES = 512 * 1024;   // refuse logos that won't downscale small enough
   const FAVICON_MAX_BYTES = 128 * 1024;// refuse favicons that won't downscale small enough
-  const LOGO_APPLIED_FLAG = 'hwxBrandingLogo';
 
   // Titlebar logo container + empty-state hero logo container.
   const LOGO_CONTAINERS = [
@@ -46,6 +45,7 @@
 
   let observer = null;
   let picker = null;
+  let lastAnchor = null;
 
   // ── storage helpers ──────────────────────────────────────────────────────
   function getLogo() {
@@ -54,19 +54,36 @@
   function getFavicon() {
     try { return localStorage.getItem(FAVICON_KEY) || ''; } catch (_) { return ''; }
   }
+  // Returns true on success, false if the value was rejected or storage failed
+  // (e.g. quota exceeded) so the caller can show honest status instead of a
+  // false "Applied." Storage is gated by isDataImage() as defense-in-depth — the
+  // apply-time sinks already guard, but gating here keeps a bad value from ever
+  // being persisted (protects future refactors + the picker's Change/Remove state).
   function setLogo(dataUrl) {
+    let ok = true;
     try {
-      if (dataUrl) localStorage.setItem(LOGO_KEY, dataUrl);
-      else localStorage.removeItem(LOGO_KEY);
-    } catch (_) {}
+      if (dataUrl) {
+        if (!isDataImage(dataUrl)) return false;
+        localStorage.setItem(LOGO_KEY, dataUrl);
+      } else {
+        localStorage.removeItem(LOGO_KEY);
+      }
+    } catch (_) { ok = false; }
     applyLogos();
+    return ok;
   }
   function setFavicon(dataUrl) {
+    let ok = true;
     try {
-      if (dataUrl) localStorage.setItem(FAVICON_KEY, dataUrl);
-      else localStorage.removeItem(FAVICON_KEY);
-    } catch (_) {}
+      if (dataUrl) {
+        if (!isDataImage(dataUrl)) return false;
+        localStorage.setItem(FAVICON_KEY, dataUrl);
+      } else {
+        localStorage.removeItem(FAVICON_KEY);
+      }
+    } catch (_) { ok = false; }
     applyFavicon();
+    return ok;
   }
 
   // ── validation ───────────────────────────────────────────────────────────
@@ -89,7 +106,10 @@
     let img = container.querySelector(':scope > img.hwx-branding-logo-img');
 
     if (dataUrl && isDataImage(dataUrl)) {
-      if (container.dataset[LOGO_APPLIED_FLAG] !== dataUrl) {
+      // Compare against the live <img> src rather than stashing the full ≤512KB
+      // data-URL in a DOM dataset attribute (cheaper, and no giant attribute write
+      // on every rAF-coalesced re-render pass).
+      if (!img || img.getAttribute('src') !== dataUrl) {
         if (nativeSvg && nativeSvg.style.display !== 'none') nativeSvg.style.display = 'none';
         if (!img) {
           img = document.createElement('img');
@@ -99,13 +119,11 @@
         }
         img.src = dataUrl;
         container.classList.add('hwx-branding-logo-set');
-        container.dataset[LOGO_APPLIED_FLAG] = dataUrl;
       }
     } else {
       if (img) img.remove();
       if (nativeSvg && nativeSvg.style.display === 'none') nativeSvg.style.display = '';
       container.classList.remove('hwx-branding-logo-set');
-      delete container.dataset[LOGO_APPLIED_FLAG];
     }
     wireClick(container);
   }
@@ -206,6 +224,9 @@
     if (picker) { picker.remove(); picker = null; }
     document.removeEventListener('pointerdown', outside, true);
     document.removeEventListener('keydown', esc, true);
+    // restore focus to the trigger the picker was opened from (a11y)
+    if (lastAnchor && typeof lastAnchor.focus === 'function') { try { lastAnchor.focus(); } catch (_) {} }
+    lastAnchor = null;
   }
   function outside(ev) { if (picker && !picker.contains(ev.target)) closePicker(); }
   function esc(ev) { if (ev.key === 'Escape') closePicker(); }
@@ -219,6 +240,11 @@
     label.textContent = labelText;
     section.appendChild(label);
 
+    // Preview box + a "Default" label. The label is a SIBLING of the box (not a
+    // child) so the box's fixed size + overflow:hidden can't clip it — a 32px
+    // favicon box was clipping "Default" to "efaul".
+    const previewRow = document.createElement('div');
+    previewRow.className = 'hwx-branding-preview-row';
     const preview = document.createElement('div');
     preview.className = 'hwx-branding-preview hwx-branding-preview-' + kind;
     if (currentValue && isDataImage(currentValue)) {
@@ -226,13 +252,15 @@
       pimg.src = currentValue;
       pimg.alt = labelText + ' preview';
       preview.appendChild(pimg);
+      previewRow.appendChild(preview);
     } else {
+      previewRow.appendChild(preview);
       const none = document.createElement('span');
       none.className = 'hwx-branding-preview-none';
       none.textContent = 'Default';
-      preview.appendChild(none);
+      previewRow.appendChild(none);
     }
-    section.appendChild(preview);
+    section.appendChild(previewRow);
 
     const input = document.createElement('input');
     input.type = 'file';
@@ -251,8 +279,8 @@
       setStatus('Processing…');
       downscaleToDataUrl(f, maxDim, maxBytes, (dataUrl, err) => {
         if (err) { setStatus(err); return; }
-        if (kind === 'favicon') setFavicon(dataUrl); else setLogo(dataUrl);
-        setStatus('Applied.');
+        const ok = (kind === 'favicon') ? setFavicon(dataUrl) : setLogo(dataUrl);
+        setStatus(ok ? 'Applied.' : 'Couldn’t save — storage full.');
         rebuildPicker();
       });
     });
@@ -302,15 +330,21 @@
 
   function openPicker(anchor) {
     closePicker();
+    lastAnchor = anchor || null;
     picker = document.createElement('div');
     picker.className = 'hwx-branding-picker';
     picker.setAttribute('role', 'dialog');
+    picker.setAttribute('aria-modal', 'true');
     picker.setAttribute('aria-label', 'Custom Branding');
+    picker.setAttribute('tabindex', '-1');
     picker.appendChild(buildPickerBody());
     document.body.appendChild(picker);
     position(anchor);
     document.addEventListener('pointerdown', outside, true);
     document.addEventListener('keydown', esc, true);
+    // move focus into the dialog on open (first focusable, else the dialog)
+    const focusTarget = picker.querySelector('button, input, [tabindex]') || picker;
+    try { focusTarget.focus(); } catch (_) {}
   }
 
   function setStatus(msg) {
@@ -336,11 +370,23 @@
     if (!container || container.dataset.hwxBrandingWired) return;
     container.dataset.hwxBrandingWired = '1';
     container.style.cursor = 'pointer';
+    // The titlebar is a PWA drag region (core .app-titlebar sets
+    // -webkit-app-region:drag). Opt this control out — otherwise, in an installed
+    // desktop PWA, clicking the titlebar logo starts a window drag and the picker
+    // never opens (core does the same for its own titlebar buttons).
+    container.style.setProperty('-webkit-app-region', 'no-drag');
+    container.style.setProperty('app-region', 'no-drag');
     container.title = 'Click to set a custom logo / favicon';
-    container.addEventListener('click', (ev) => {
-      ev.preventDefault();
-      ev.stopPropagation();
-      openPicker(container);
+    // a11y: the core mark is aria-hidden with no keyboard role. Make our edit
+    // affordance reachable by keyboard + screen readers once we own the click.
+    container.removeAttribute('aria-hidden');
+    if (!container.hasAttribute('role')) container.setAttribute('role', 'button');
+    if (!container.hasAttribute('tabindex')) container.setAttribute('tabindex', '0');
+    container.setAttribute('aria-label', 'Set a custom logo or favicon');
+    const open = (ev) => { ev.preventDefault(); ev.stopPropagation(); openPicker(container); };
+    container.addEventListener('click', open);
+    container.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Enter' || ev.key === ' ' || ev.key === 'Spacebar') open(ev);
     });
   }
 
@@ -370,8 +416,10 @@
         version: '0.1.0',
         getLogo: getLogo,
         getFavicon: getFavicon,
-        setLogo: (dataUrl) => { if (isDataImage(dataUrl)) setLogo(dataUrl); return getLogo(); },
-        setFavicon: (dataUrl) => { if (isDataImage(dataUrl)) setFavicon(dataUrl); return getFavicon(); },
+        // setLogo/setFavicon gate the value internally (isDataImage) and return
+        // true on success / false if rejected or storage failed.
+        setLogo: (dataUrl) => setLogo(dataUrl),
+        setFavicon: (dataUrl) => setFavicon(dataUrl),
         clearLogo: () => setLogo(''),
         clearFavicon: () => setFavicon(''),
         refresh: applyAll

--- a/extensions/custom-branding/assets/custom-branding.js
+++ b/extensions/custom-branding/assets/custom-branding.js
@@ -1,0 +1,391 @@
+(() => {
+  'use strict';
+
+  // ── Custom Branding extension for Hermes WebUI ───────────────────────────
+  // White-label the Hermes chrome with your own logo + favicon. Click the
+  // titlebar logo to open a small picker (upload / clear a logo, upload / clear
+  // a favicon). Uploaded images are processed entirely in the browser
+  // (FileReader -> <canvas> downscale -> data-URL) and stored in localStorage;
+  // nothing is uploaded anywhere.
+  //
+  // On boot and on every DOM re-render it swaps:
+  //   - the app titlebar logo (the inline <svg> inside .app-titlebar-icon)
+  //   - the empty-state hero logo (the inline <svg> inside .empty-logo)
+  //   - the favicon <link> nodes in <head> (rel="icon" / "shortcut icon" /
+  //     "apple-touch-icon")
+  // with your stored images, and restores the originals when you clear them.
+  //
+  // Rebuilt as a client-side extension from closed core PR
+  // nesquena/hermes-webui#3307 (author: @gavinssr, "Add custom logo and favicon
+  // uploads"). #3307 shipped a server-side upload endpoint + config.yaml
+  // persistence; extensions cannot add core endpoints, so this is a pure
+  // client-side rebuild using localStorage data-URLs.
+  //
+  // Pure DOM-injection, client-side only — no core changes, no backend.
+
+  const EXT = 'custom-branding';
+  if (window.__hermesCustomBrandingLoaded) return;
+  window.__hermesCustomBrandingLoaded = true;
+
+  const LOGO_KEY = 'hermes-ext-custom-branding-logo';        // stores a data-URL (or empty)
+  const FAVICON_KEY = 'hermes-ext-custom-branding-favicon';  // stores a data-URL (or empty)
+
+  const LOGO_MAX_DIM = 256;            // downscale target for the logo (px)
+  const FAVICON_MAX_DIM = 64;          // downscale target for the favicon (px)
+  const LOGO_MAX_BYTES = 512 * 1024;   // refuse logos that won't downscale small enough
+  const FAVICON_MAX_BYTES = 128 * 1024;// refuse favicons that won't downscale small enough
+  const LOGO_APPLIED_FLAG = 'hwxBrandingLogo';
+
+  // Titlebar logo container + empty-state hero logo container.
+  const LOGO_CONTAINERS = [
+    { sel: '.app-titlebar-icon', size: 'titlebar' },
+    { sel: '.empty-logo', size: 'hero' }
+  ];
+  // Core favicon links we neutralize while a custom favicon is active.
+  const FAVICON_SELECTOR = 'link[rel="icon"], link[rel="shortcut icon"], link[rel="apple-touch-icon"]';
+
+  let observer = null;
+  let picker = null;
+
+  // ── storage helpers ──────────────────────────────────────────────────────
+  function getLogo() {
+    try { return localStorage.getItem(LOGO_KEY) || ''; } catch (_) { return ''; }
+  }
+  function getFavicon() {
+    try { return localStorage.getItem(FAVICON_KEY) || ''; } catch (_) { return ''; }
+  }
+  function setLogo(dataUrl) {
+    try {
+      if (dataUrl) localStorage.setItem(LOGO_KEY, dataUrl);
+      else localStorage.removeItem(LOGO_KEY);
+    } catch (_) {}
+    applyLogos();
+  }
+  function setFavicon(dataUrl) {
+    try {
+      if (dataUrl) localStorage.setItem(FAVICON_KEY, dataUrl);
+      else localStorage.removeItem(FAVICON_KEY);
+    } catch (_) {}
+    applyFavicon();
+  }
+
+  // ── validation ───────────────────────────────────────────────────────────
+  // MVP restricts to raster png/jpeg/webp. Uploaded images are rasterized via
+  // <canvas> before storage (canvas.toDataURL emits png/jpeg only), so a stored
+  // value can never carry raw SVG markup — this avoids the SVG-XSS surface that
+  // an <svg> favicon/logo would otherwise open up.
+  function isDataImage(s) {
+    return typeof s === 'string' && /^data:image\/(png|jpeg|jpg|webp);base64,[A-Za-z0-9+/=]+$/.test(s);
+  }
+  function mimeFromDataUrl(s) {
+    const m = /^data:(image\/[a-z+]+);base64,/.exec(s || '');
+    return m ? m[1] : 'image/png';
+  }
+
+  // ── logo swap ──────────────────────────────────────────────────────────────
+  function applyLogoToContainer(container, sizeKind, dataUrl) {
+    if (!container) return;
+    const nativeSvg = container.querySelector(':scope > svg');
+    let img = container.querySelector(':scope > img.hwx-branding-logo-img');
+
+    if (dataUrl && isDataImage(dataUrl)) {
+      if (container.dataset[LOGO_APPLIED_FLAG] !== dataUrl) {
+        if (nativeSvg && nativeSvg.style.display !== 'none') nativeSvg.style.display = 'none';
+        if (!img) {
+          img = document.createElement('img');
+          img.className = 'hwx-branding-logo-img hwx-branding-logo-' + sizeKind;
+          img.alt = 'Custom logo';
+          container.appendChild(img);
+        }
+        img.src = dataUrl;
+        container.classList.add('hwx-branding-logo-set');
+        container.dataset[LOGO_APPLIED_FLAG] = dataUrl;
+      }
+    } else {
+      if (img) img.remove();
+      if (nativeSvg && nativeSvg.style.display === 'none') nativeSvg.style.display = '';
+      container.classList.remove('hwx-branding-logo-set');
+      delete container.dataset[LOGO_APPLIED_FLAG];
+    }
+    wireClick(container);
+  }
+
+  function applyLogos() {
+    const dataUrl = getLogo();
+    LOGO_CONTAINERS.forEach(({ sel, size }) => {
+      document.querySelectorAll(sel).forEach((container) => applyLogoToContainer(container, size, dataUrl));
+    });
+  }
+
+  // ── favicon swap ─────────────────────────────────────────────────────────
+  // Neutralize the core favicon links (remember their rel so we can restore),
+  // then inject a single managed <link rel="icon"> with the stored data-URL.
+  // A custom SVG favicon can otherwise win the browser's icon-priority race, so
+  // disabling the originals is required, not cosmetic.
+  function coreFaviconLinks() {
+    return Array.from(document.querySelectorAll(FAVICON_SELECTOR))
+      .filter((l) => l.dataset.hwxBrandingFavicon !== '1');
+  }
+
+  function applyFavicon() {
+    const head = document.head || document.getElementsByTagName('head')[0];
+    if (!head) return;
+    const dataUrl = getFavicon();
+    let injected = head.querySelector('link[data-hwx-branding-favicon="1"]');
+
+    if (dataUrl && isDataImage(dataUrl)) {
+      coreFaviconLinks().forEach((l) => {
+        if (l.dataset.hwxBrandingOrigRel === undefined) {
+          l.dataset.hwxBrandingOrigRel = l.getAttribute('rel') || '';
+        }
+        l.setAttribute('rel', 'hwx-branding-disabled-icon');
+      });
+      if (!injected) {
+        injected = document.createElement('link');
+        injected.setAttribute('rel', 'icon');
+        injected.dataset.hwxBrandingFavicon = '1';
+        head.appendChild(injected);
+      }
+      if (injected.getAttribute('href') !== dataUrl) {
+        // Remove + re-add a fresh node to force the browser to refresh the icon.
+        const fresh = injected.cloneNode(false);
+        fresh.setAttribute('type', mimeFromDataUrl(dataUrl));
+        fresh.setAttribute('href', dataUrl);
+        injected.replaceWith(fresh);
+        injected = fresh;
+      }
+    } else {
+      if (injected) injected.remove();
+      document.querySelectorAll('link[data-hwx-branding-orig-rel]').forEach((l) => {
+        l.setAttribute('rel', l.dataset.hwxBrandingOrigRel || 'icon');
+        delete l.dataset.hwxBrandingOrigRel;
+      });
+    }
+  }
+
+  function applyAll() {
+    applyLogos();
+    applyFavicon();
+  }
+
+  // ── image handling: downscale to a small data-URL (aspect preserved) ───────
+  function downscaleToDataUrl(file, maxDim, maxBytes, cb) {
+    if (!file || !/^image\//.test(file.type)) { cb(null, 'Not an image file.'); return; }
+    if (!/^image\/(png|jpeg|jpg|webp)$/.test(file.type)) {
+      cb(null, 'Only PNG, JPEG, or WebP images are supported.');
+      return;
+    }
+    if (file.size > 8 * 1024 * 1024) { cb(null, 'Image too large (max 8 MB before downscale).'); return; }
+    const reader = new FileReader();
+    reader.onerror = () => cb(null, 'Could not read the file.');
+    reader.onload = () => {
+      const img = new Image();
+      img.onerror = () => cb(null, 'Could not decode the image.');
+      img.onload = () => {
+        try {
+          const scale = Math.min(1, maxDim / Math.max(img.width, img.height));
+          const w = Math.max(1, Math.round(img.width * scale));
+          const h = Math.max(1, Math.round(img.height * scale));
+          const canvas = document.createElement('canvas');
+          canvas.width = w; canvas.height = h;
+          const ctx = canvas.getContext('2d');
+          ctx.drawImage(img, 0, 0, w, h);
+          let out = canvas.toDataURL('image/png');
+          if (out.length > maxBytes) out = canvas.toDataURL('image/jpeg', 0.85);
+          if (out.length > maxBytes) { cb(null, 'Image could not be reduced small enough.'); return; }
+          cb(out, null);
+        } catch (e) { cb(null, 'Image processing failed.'); }
+      };
+      img.src = reader.result;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  // ── picker popover ─────────────────────────────────────────────────────────
+  function closePicker() {
+    if (picker) { picker.remove(); picker = null; }
+    document.removeEventListener('pointerdown', outside, true);
+    document.removeEventListener('keydown', esc, true);
+  }
+  function outside(ev) { if (picker && !picker.contains(ev.target)) closePicker(); }
+  function esc(ev) { if (ev.key === 'Escape') closePicker(); }
+
+  function makeSection(labelText, currentValue, kind, maxDim, maxBytes) {
+    const section = document.createElement('div');
+    section.className = 'hwx-branding-section';
+
+    const label = document.createElement('div');
+    label.className = 'hwx-branding-label';
+    label.textContent = labelText;
+    section.appendChild(label);
+
+    const preview = document.createElement('div');
+    preview.className = 'hwx-branding-preview hwx-branding-preview-' + kind;
+    if (currentValue && isDataImage(currentValue)) {
+      const pimg = document.createElement('img');
+      pimg.src = currentValue;
+      pimg.alt = labelText + ' preview';
+      preview.appendChild(pimg);
+    } else {
+      const none = document.createElement('span');
+      none.className = 'hwx-branding-preview-none';
+      none.textContent = 'Default';
+      preview.appendChild(none);
+    }
+    section.appendChild(preview);
+
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/png,image/jpeg,image/webp';
+    input.style.display = 'none';
+
+    const uploadBtn = document.createElement('button');
+    uploadBtn.type = 'button';
+    uploadBtn.className = 'hwx-branding-btn';
+    uploadBtn.textContent = currentValue ? 'Change…' : 'Upload…';
+    uploadBtn.addEventListener('click', () => input.click());
+
+    input.addEventListener('change', () => {
+      const f = input.files && input.files[0];
+      if (!f) return;
+      setStatus('Processing…');
+      downscaleToDataUrl(f, maxDim, maxBytes, (dataUrl, err) => {
+        if (err) { setStatus(err); return; }
+        if (kind === 'favicon') setFavicon(dataUrl); else setLogo(dataUrl);
+        setStatus('Applied.');
+        rebuildPicker();
+      });
+    });
+
+    section.appendChild(uploadBtn);
+    section.appendChild(input);
+
+    if (currentValue) {
+      const clearBtn = document.createElement('button');
+      clearBtn.type = 'button';
+      clearBtn.className = 'hwx-branding-btn hwx-branding-btn--clear';
+      clearBtn.textContent = 'Remove';
+      clearBtn.addEventListener('click', () => {
+        if (kind === 'favicon') setFavicon(''); else setLogo('');
+        rebuildPicker();
+      });
+      section.appendChild(clearBtn);
+    }
+
+    return section;
+  }
+
+  function buildPickerBody() {
+    const frag = document.createDocumentFragment();
+
+    const title = document.createElement('div');
+    title.className = 'hwx-branding-title';
+    title.textContent = 'Custom Branding';
+    frag.appendChild(title);
+
+    frag.appendChild(makeSection('Logo', getLogo(), 'logo', LOGO_MAX_DIM, LOGO_MAX_BYTES));
+    frag.appendChild(makeSection('Favicon', getFavicon(), 'favicon', FAVICON_MAX_DIM, FAVICON_MAX_BYTES));
+
+    const status = document.createElement('div');
+    status.className = 'hwx-branding-status';
+    status.id = 'hwxBrandingStatus';
+    frag.appendChild(status);
+
+    return frag;
+  }
+
+  function rebuildPicker() {
+    if (!picker) return;
+    picker.textContent = '';
+    picker.appendChild(buildPickerBody());
+  }
+
+  function openPicker(anchor) {
+    closePicker();
+    picker = document.createElement('div');
+    picker.className = 'hwx-branding-picker';
+    picker.setAttribute('role', 'dialog');
+    picker.setAttribute('aria-label', 'Custom Branding');
+    picker.appendChild(buildPickerBody());
+    document.body.appendChild(picker);
+    position(anchor);
+    document.addEventListener('pointerdown', outside, true);
+    document.addEventListener('keydown', esc, true);
+  }
+
+  function setStatus(msg) {
+    const s = document.getElementById('hwxBrandingStatus');
+    if (s) s.textContent = msg || '';
+  }
+
+  function position(anchor) {
+    if (!picker || !anchor) return;
+    const r = anchor.getBoundingClientRect();
+    const w = picker.offsetWidth || 240;
+    let left = r.left;
+    if (left + w > window.innerWidth - 8) left = window.innerWidth - w - 8;
+    if (left < 8) left = 8;
+    picker.style.left = left + 'px';
+    let top = r.bottom + 6;
+    const h = picker.offsetHeight || 0;
+    if (top + h > window.innerHeight - 8) top = Math.max(8, r.top - h - 6);
+    picker.style.top = top + 'px';
+  }
+
+  function wireClick(container) {
+    if (!container || container.dataset.hwxBrandingWired) return;
+    container.dataset.hwxBrandingWired = '1';
+    container.style.cursor = 'pointer';
+    container.title = 'Click to set a custom logo / favicon';
+    container.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      openPicker(container);
+    });
+  }
+
+  // ── observe re-renders ─────────────────────────────────────────────────────
+  let raf = false;
+  function schedule() {
+    if (raf) return;
+    raf = true;
+    requestAnimationFrame(() => { raf = false; try { applyAll(); } catch (_) {} });
+  }
+
+  function startObserver() {
+    if (observer) return true;
+    const container = document.body;
+    observer = new MutationObserver(schedule);
+    observer.observe(container, { childList: true, subtree: true });
+    return true;
+  }
+
+  function install(attempt) {
+    attempt = attempt || 0;
+    const haveLogo = document.querySelector('.app-titlebar-icon') || document.querySelector('.empty-logo');
+    if (haveLogo || document.getElementById('messages')) {
+      startObserver();
+      applyAll();
+      window.HermesCustomBrandingExtension = {
+        version: '0.1.0',
+        getLogo: getLogo,
+        getFavicon: getFavicon,
+        setLogo: (dataUrl) => { if (isDataImage(dataUrl)) setLogo(dataUrl); return getLogo(); },
+        setFavicon: (dataUrl) => { if (isDataImage(dataUrl)) setFavicon(dataUrl); return getFavicon(); },
+        clearLogo: () => setLogo(''),
+        clearFavicon: () => setFavicon(''),
+        refresh: applyAll
+      };
+      return true;
+    }
+    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
+    console.warn('[' + EXT + '] titlebar/logo containers not found; not installed');
+    return false;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
+  } else {
+    install();
+  }
+})();

--- a/extensions/custom-branding/assets/custom-branding.js
+++ b/extensions/custom-branding/assets/custom-branding.js
@@ -280,13 +280,10 @@
       downscaleToDataUrl(f, maxDim, maxBytes, (dataUrl, err) => {
         if (err) { setStatus(err); return; }
         const ok = (kind === 'favicon') ? setFavicon(dataUrl) : setLogo(dataUrl);
-        // rebuildPicker() wipes the popover body (incl. the status node), so set
-        // the message AFTER the rebuild — otherwise the honest quota-fail status
-        // is erased before the browser paints it. Re-focus the first control too,
-        // since the button the user activated was just destroyed by the rebuild.
+        // rebuildPicker() wipes the popover body (incl. the status node) and
+        // restores focus to the first control, so set the message AFTER it —
+        // otherwise the honest quota-fail status is erased before paint.
         rebuildPicker();
-        const firstBtn = picker && picker.querySelector('button');
-        if (firstBtn) { try { firstBtn.focus(); } catch (_) {} }
         setStatus(ok ? 'Applied.' : 'Couldn’t save — storage full.');
       });
     });
@@ -323,6 +320,9 @@
     const status = document.createElement('div');
     status.className = 'hwx-branding-status';
     status.id = 'hwxBrandingStatus';
+    // role="status" (implicit aria-live="polite") so the "Couldn't save — storage
+    // full." message is announced to screen-reader users, not just shown visually.
+    status.setAttribute('role', 'status');
     frag.appendChild(status);
 
     return frag;
@@ -332,6 +332,12 @@
     if (!picker) return;
     picker.textContent = '';
     picker.appendChild(buildPickerBody());
+    // Any rebuild destroys the control the user just activated (Upload/Remove),
+    // dropping keyboard focus to <body>. Restore it to the first control so a
+    // keyboard user stays inside the dialog. Centralized here so every call-site
+    // (upload + remove) is covered.
+    const firstBtn = picker.querySelector('button');
+    if (firstBtn) { try { firstBtn.focus(); } catch (_) {} }
   }
 
   function openPicker(anchor) {

--- a/extensions/custom-branding/extension.json
+++ b/extensions/custom-branding/extension.json
@@ -1,0 +1,50 @@
+{
+  "id": "custom-branding",
+  "name": "Custom Branding",
+  "description": "White-label the Hermes WebUI chrome with your own logo and favicon. Click the titlebar logo to upload a custom logo (swaps the titlebar + empty-state marks) and a custom favicon (swaps the browser tab icon). Images are downscaled and stored locally, and re-applied as the UI re-renders.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/custom-branding.js"
+    ],
+    "stylesheets": [
+      "assets/custom-branding.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-custom-branding-logo",
+        "hermes-ext-custom-branding-favicon"
+      ],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false
+  }
+}

--- a/extensions/custom-branding/manifest.json
+++ b/extensions/custom-branding/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "custom-branding",
+      "name": "Custom Branding",
+      "description": "White-label the Hermes WebUI chrome with your own logo and favicon.",
+      "scripts": [
+        "assets/custom-branding.js"
+      ],
+      "stylesheets": [
+        "assets/custom-branding.css"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Custom Branding — white-label the app with your own logo + favicon

A client-side static-UI extension that lets a user replace the Hermes chrome with their own branding: a custom **logo** (swaps the titlebar mark and the empty-state hero logo) and a custom **favicon** (swaps the browser-tab icon). Clicking the small titlebar logo opens a picker to upload / preview / clear each image.

Images are processed entirely in the browser (`FileReader` → `<canvas>` downscale → data-URL), stored in `localStorage`, and re-applied via a `MutationObserver` as the UI re-renders. Nothing is uploaded anywhere.

### Credit / provenance

Rebuilt as an extension from **closed core PR nesquena/hermes-webui#3307** ("Add custom logo and favicon uploads") by **@gavinssr**. The original shipped a server-side upload endpoint + `config.yaml` persistence; that scope was a core-curation call (instance branding is optional, opt-in, self-contained → an extension-model fit, not core). Extensions can't add core endpoints, so this is a **client-side rebuild** using localStorage data-URLs + DOM swaps. @gavinssr is credited as `Co-authored-by` on the commit and in the entry README's Credit section.

### DOM contract (read from `static/index.html` on current master)

- titlebar logo: inline `<svg>` inside `.app-titlebar-icon` (index.html:132–133) → hidden + overlaid with an `<img>` of the stored logo
- empty-state hero logo: inline `<svg>` inside `.empty-logo` (index.html:430) → same swap
- favicon: `<link rel="icon" | "shortcut icon" | "apple-touch-icon">` (index.html:11–13,19) → core links neutralized (rel stashed for restore) + a managed `<link rel="icon">` injected with the stored data-URL, replaced fresh on change to force the browser to refresh
- re-renders wipe injected DOM → re-applied via a `MutationObserver` on `document.body`

### Security (SVG-XSS)

Uploads are restricted to raster **PNG / JPEG / WebP** and **rasterized via `<canvas>`** before storage (`canvas.toDataURL` emits png/jpeg only), so a stored value can never carry raw SVG markup — the SVG-XSS surface an `<svg>` favicon/logo would open is avoided by design. Only validated `data:image/(png|jpeg|webp);base64,...` values are ever applied. Images are downscaled (logo ≤ 256px, favicon ≤ 64px) to stay under the localStorage ceiling.

### Permissions — cross-checked against the code, claim by claim

| Declared | Code reality |
|---|---|
| `capabilities: ["manifest-bundle"]` | assets-only bundle; no other capability used |
| `network_external: false` | no `fetch` of any external origin; image processed in-browser |
| `webui_api.read/write: []` | no `/api/*` calls at all |
| `webui_navigation: false` | never navigates (no `loadSession`/`location.assign`) |
| `dom.owned: true`, `mutates_core_views: true` | injects an `<img>` + managed favicon `<link>` + picker; swaps core logo/favicon nodes |
| `storage.owned: ["hermes-ext-custom-branding-logo", "hermes-ext-custom-branding-favicon"]` | exactly the two `localStorage` keys written |
| `loopback_sidecar/native_host: false`, `filesystem.arbitrary: false` | none used; standard `<input type=file>` only |

### Repo gates — all pass (run from the clone)

```
node --check extensions/custom-branding/assets/custom-branding.js   → PASS
node scripts/validate-extensions.mjs        → validated 13 entries (ok custom-branding)
node scripts/scan-extension-safety.mjs      → safety scan passed for 13 entries
node scripts/test-extension-validator.mjs   → extension validator self-tests passed
node scripts/generate-registry.mjs --out dist/registry.json → wrote registry + 13 artifacts
```

`dist/` is gitignored and not committed; staged only `extensions/custom-branding/` + the additive `extensions/README.md` Entries line.

### Live headless-CDP browser proof (isolated server, extension loaded via env vars)

Driven with `agent-browser` over CDP against an isolated server (NOT prod 8787). Each behavior asserted via state-reading `eval` (not just screenshots):

- ✅ **Booted** — `window.__hermesCustomBrandingLoaded === true` and `window.HermesCustomBrandingExtension` present
- ✅ **Logo swap** — after `setLogo(dataUrl)`: titlebar `<img>` present with `src === stored`, native titlebar `<svg>` hidden; empty-state `<img>` present with `src === stored`, native hero `<svg>` hidden
- ✅ **Favicon swap** — after `setFavicon(dataUrl)`: managed `<link data-hwx-branding-favicon>` injected with `href === stored`, `rel="icon"`, `type="image/png"`; all 4 core icon links neutralized; 0 active core icons remain
- ✅ **Persistence across a full reload** (cache-busted `?_cb=<ts>`): booted again, titlebar + empty-state logo persisted, favicon persisted with `href === localStorage`, 0 active core icons
- ✅ **Survives a forced re-render** — after wiping the injected nodes (simulating a `renderMessages()`/panel rebuild) the MutationObserver re-applied logo + favicon within a rAF
- ✅ **Clear restores originals** — `clearLogo()`/`clearFavicon()` remove the `<img>`/managed favicon, un-hide the native SVGs, restore the 4 core icon links, and clear both localStorage keys
- ✅ **No console errors**; one vision-verified screenshot confirms a red test logo showing in both the titlebar and the empty-state hero.

### Notes

- Agent-authored entry → **not self-merging**; leaving this for a maintainer's review/merge call.
- Archetype: scaffolded from the existing `custom-avatar` extension (same in-browser image-processing + localStorage + MutationObserver shape).
