### PR TITLE
gates: require iframe clipboard disclosure

### DIFF
--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -112,8 +112,9 @@ where the backend has length limits.
 - **Sanitize any cloned/exported HTML** — strip off-origin `src`/`href`, `on*` handlers,
   script/style/iframe — so `network_external:false` stays honest.
 - **Declare every permission you actually use** (`webui_api.write`, `shared_webui_keys`,
-  `network_external`, `device_vibration`, sandbox attrs) — the README and `extension.json`
-  must match the code; the safety scan checks this.
+  `network_external`, `device_vibration`, iframe `allow` grants such as `clipboard-read` /
+  `clipboard-write`, sandbox attrs) — the README and `extension.json` must match the code;
+  the safety scan checks this.
 
 ## Sidecar Metadata
 

--- a/scripts/scan-extension-safety.mjs
+++ b/scripts/scan-extension-safety.mjs
@@ -112,10 +112,24 @@ function scanJavaScriptFile(entry, file, text, errors) {
   }
 }
 
+function grantsIframeClipboard(text) {
+  return /\ballow\s*=\s*['"][^'"]*clipboard-(?:read|write)/i.test(text)
+    || /\.setAttribute\s*\(\s*['"]allow['"]\s*,\s*['"][^'"]*clipboard-(?:read|write)/i.test(text)
+    || /\.allow\s*=\s*['"][^'"]*clipboard-(?:read|write)/i.test(text);
+}
+
+function disclosesIframeClipboard(readmeText) {
+  return /clipboard-(?:read|write)/i.test(readmeText)
+    || /clipboard\s+(?:read|write|access|permission|grant)/i.test(readmeText);
+}
+
 function scanEntry(result) {
   const errors = [];
   const files = collectEntryFiles(result.root);
   if (!files.length) errors.push(`${result.id} has no files`);
+
+  let iframeClipboardGrant = false;
+  let readmeText = '';
 
   for (const file of files) {
     if (file.symlink) {
@@ -125,8 +139,14 @@ function scanEntry(result) {
     if (!isSafeRelativePath(file.rel)) errors.push(`${repoRelative(file.path)} has an unsafe relative path`);
     if (!isTextFile(file.path)) continue;
     const text = readFileSync(file.path, 'utf8');
+    if (file.rel === 'README.md') readmeText = text;
+    if (/\.(?:html|cjs|js|mjs)$/i.test(file.path) && grantsIframeClipboard(text)) iframeClipboardGrant = true;
     scanTextFile(file, text, errors);
     if (/\.(?:cjs|js|mjs)$/i.test(file.path)) scanJavaScriptFile(result.entry, file, text, errors);
+  }
+
+  if (iframeClipboardGrant && !disclosesIframeClipboard(readmeText)) {
+    errors.push(`${result.id} grants iframe clipboard permission without README trust disclosure`);
   }
 
   return errors;

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -161,15 +161,16 @@ try {
   assert.equal(safetyScanFromScripts.status, 0, safetyScanFromScripts.stderr || safetyScanFromScripts.stdout);
   assert.match(safetyScanFromScripts.stdout, /safety scan passed for \d+ extension entr(?:y|ies)/);
 
+  const repoRoot = path.resolve(scriptsDir, '..');
+
   // Regression: an entry that writes localStorage and declares storage.owned === true
   // (the boolean form core REQUIRES to enable settings_schema) must PASS the safety scan.
   // Before the fix the scan crashed with "boolean true is not iterable"; the key-array
   // form must still be accepted, and an undeclared write must still fail closed.
-  const repoRoot = path.resolve(scriptsDir, '..');
-  const extDir = path.join(repoRoot, 'extensions', 'scan-owned-true-case');
+  const ownedTrueDir = path.join(repoRoot, 'extensions', 'scan-owned-true-case');
   try {
-    mkdirSync(path.join(extDir, 'assets'), { recursive: true });
-    writeJson(path.join(extDir, 'extension.json'), {
+    mkdirSync(path.join(ownedTrueDir, 'assets'), { recursive: true });
+    writeJson(path.join(ownedTrueDir, 'extension.json'), {
       id: 'scan-owned-true-case', name: 'Scan Case', description: 'temp test entry',
       version: '0.0.1', author: 'test',
       assets: { scripts: ['assets/x.js'], stylesheets: [] },
@@ -186,18 +187,81 @@ try {
       },
       settings_schema: [{ key: 'enabled', type: 'boolean', label: 'Enabled', default: true }]
     });
-    writeJson(path.join(extDir, 'manifest.json'), {
+    writeJson(path.join(ownedTrueDir, 'manifest.json'), {
       extensions: [{ id: 'scan-owned-true-case', name: 'Scan Case', description: 'temp test entry', scripts: ['assets/x.js'], stylesheets: [] }]
     });
-    writeFileSync(path.join(extDir, 'README.md'), '# Scan Case\n', 'utf8');
-    writeFileSync(path.join(extDir, 'assets', 'x.js'), "localStorage.setItem('k','v');\n", 'utf8');
+    writeFileSync(path.join(ownedTrueDir, 'README.md'), '# Scan Case\n', 'utf8');
+    writeFileSync(path.join(ownedTrueDir, 'assets', 'x.js'), "localStorage.setItem('k','v');\n", 'utf8');
     const scanOwnedTrue = spawnSync(process.execPath, ['scan-extension-safety.mjs'], {
       cwd: scriptsDir, encoding: 'utf8', timeout: 30000
     });
     assert.equal(scanOwnedTrue.status, 0,
       `storage.owned:true + localStorage write should pass the safety scan, got: ${scanOwnedTrue.stderr || scanOwnedTrue.stdout}`);
   } finally {
-    rmSync(extDir, { recursive: true, force: true });
+    rmSync(ownedTrueDir, { recursive: true, force: true });
+  }
+
+  function writeIframeClipboardCase({ id, readme }) {
+    const dir = path.join(repoRoot, 'extensions', id);
+    mkdirSync(path.join(dir, 'assets'), { recursive: true });
+    writeJson(path.join(dir, 'extension.json'), {
+      id, name: 'Scan Iframe Case', description: 'temp test entry',
+      version: '0.0.1', author: 'test',
+      assets: { scripts: ['assets/x.js'], stylesheets: [] },
+      capabilities: ['manifest-bundle'],
+      lifecycle: { webui_restart_required: false, sidecar_start_required: false, native_host_start_required: false, native_host_autostart: 'none' },
+      screenshots: [],
+      permissions: {
+        webui_api: { read: [], write: [] }, webui_navigation: false,
+        dom: { owned: true, mutates_core_views: false },
+        storage: { owned: [], shared_webui_keys: [] },
+        loopback_sidecar: true, native_host: false,
+        filesystem: { arbitrary: false, serves_bundled_assets: true },
+        network_external: false
+      }
+    });
+    writeJson(path.join(dir, 'manifest.json'), {
+      extensions: [{ id, name: 'Scan Iframe Case', description: 'temp test entry', scripts: ['assets/x.js'], stylesheets: [] }]
+    });
+    writeFileSync(path.join(dir, 'README.md'), readme, 'utf8');
+    writeFileSync(path.join(dir, 'assets', 'x.js'),
+      "const frame = document.createElement('iframe');\nframe.setAttribute('allow', 'clipboard-read; clipboard-write');\n",
+      'utf8');
+    return dir;
+  }
+
+  // Regression: iframe clipboard grants are user-visible browser capabilities.
+  // A gallery entry that enables clipboard-read / clipboard-write on an iframe must
+  // disclose that grant in its README trust section, otherwise one-click install
+  // cannot present an honest permission story.
+  let iframeCaseDir = writeIframeClipboardCase({
+    id: 'scan-iframe-clipboard-case',
+    readme: '# Scan Iframe Case\n\n## Trust Model\n\nUses a loopback iframe.\n'
+  });
+  try {
+    const scanIframe = spawnSync(process.execPath, ['scan-extension-safety.mjs'], {
+      cwd: scriptsDir, encoding: 'utf8', timeout: 30000
+    });
+    assert.notEqual(scanIframe.status, 0, 'iframe clipboard grant without README disclosure should fail the safety scan');
+    assert.match(scanIframe.stderr, /iframe clipboard permission/i);
+  } finally {
+    rmSync(iframeCaseDir, { recursive: true, force: true });
+  }
+
+  // Positive fixture: the gate should not block iframe extensions that honestly
+  // disclose the browser clipboard grant in the README trust model.
+  iframeCaseDir = writeIframeClipboardCase({
+    id: 'scan-iframe-clipboard-disclosed-case',
+    readme: '# Scan Iframe Case\n\n## Trust Model\n\nUses a loopback iframe and grants clipboard-read / clipboard-write permission to the frame.\n'
+  });
+  try {
+    const scanIframeDisclosed = spawnSync(process.execPath, ['scan-extension-safety.mjs'], {
+      cwd: scriptsDir, encoding: 'utf8', timeout: 30000
+    });
+    assert.equal(scanIframeDisclosed.status, 0,
+      `iframe clipboard grant with README disclosure should pass the safety scan, got: ${scanIframeDisclosed.stderr || scanIframeDisclosed.stdout}`);
+  } finally {
+    rmSync(iframeCaseDir, { recursive: true, force: true });
   }
 
   console.log('extension validator self-tests passed');


### PR DESCRIPTION
## Thinking Path

#8 tracks the automated safety gates that protect the curated extension library now that one-click install is live. A recent review finding on the Hermes Desktop extension showed a concrete gap: an extension can grant an iframe browser capability such as `clipboard-read` / `clipboard-write` without disclosing it in the README trust model. This PR turns that review-memory item into an automated gate.

This is intentionally a small slice of #8, not a closure of the umbrella.

## What Changed

- Extended `scripts/scan-extension-safety.mjs` to detect iframe clipboard grants in JS/HTML assets:
  - inline `allow="...clipboard-read..."`
  - `frame.setAttribute('allow', '...clipboard-write...')`
  - `frame.allow = '...clipboard-read...'`
- Fails the safety scan when those grants are present but the entry `README.md` does not disclose clipboard permission/access in its trust notes.
- Added regression fixtures to `scripts/test-extension-validator.mjs` proving both sides of the gate:
  - an undisclosed iframe clipboard grant fails the safety scan
  - a README-disclosed iframe clipboard grant passes the safety scan
- Updated `docs/extension-entry.md` so contributors know iframe `allow` grants must be disclosed alongside other permissions.

## Why It Matters

Extensions run in the authenticated WebUI origin, and the registry/gallery install path trusts merged entries as vetted local code. Browser iframe grants are user-visible capabilities and should not depend on maintainers remembering to catch them manually during review.

This makes one real review finding enforceable in CI and keeps #8 moving as a series of maintainable safety-gate slices.

## Verification

Ran locally from a clean worktree based on `origin/main`:

```bash
node scripts/validate-extensions.mjs
node scripts/test-extension-validator.mjs
node scripts/scan-extension-safety.mjs
node scripts/generate-registry.mjs --out dist/registry.json
node -e "JSON.parse(require('node:fs').readFileSync('dist/registry.json','utf8')); console.log('registry json ok')"
```

Result:

```text
validated 13 extension entries
extension validator self-tests passed
safety scan passed for 13 extension entries
wrote dist/registry.json with 13 extension entries
wrote 13 extension artifacts to dist/artifacts
registry json ok
```

RED check performed before implementation: the new regression initially failed because the existing safety scan did not reject the undisclosed iframe clipboard grant.

Post self-review update: added a positive fixture to ensure disclosed iframe clipboard grants still pass, then re-ran the validator and safety scan and force-pushed with `--force-with-lease`.

## Risks / Follow-ups

- This intentionally checks clipboard iframe grants only. Broader iframe sandbox/allow drift and richer DOM/network permission drift remain tracked in #8.
- README disclosure matching is lexical by design; if a future entry needs a more structured permissions vocabulary for iframe grants, that can be a follow-up gate.
- Addresses part of #8; does not complete the #8 umbrella.

## Model Used

- Provider: OpenAI Codex
- Model: gpt-5.5
- AI-assisted implementation and verification via Hermes Agent.