### PR TITLE
external-app-tab: adopt settings_schema

### DIFF
--- a/extensions/external-app-tab/README.md
+++ b/extensions/external-app-tab/README.md
@@ -15,7 +15,9 @@ Limitations** for the third-party-iframe auth/cookie caveats).
 - Adds a rail button (with the content tabs, above Settings).
 - Clicking it opens a full-area overlay with a top bar (title, **Configure**,
   **Open ↗**, **Close**) and the framed app below.
-- **Configure** dialog: set a label + an `http(s)` URL; stored locally.
+- **Configure** dialog: set a label + an `http(s)` URL; stored in the native
+  Settings → Extensions → External App Tab settings store when available, with a
+  legacy localStorage fallback on older core.
 - Falls back to a "no app configured" prompt until you set a URL.
 - Escape or the ✕ closes the overlay; the rail stays accessible.
 
@@ -43,7 +45,8 @@ Hermes WebUI page
   -> manifest-bundled extension assets
   -> /extensions/assets/external-app-tab.js + .css
   -> rail button -> full-area overlay -> <iframe src="<your URL>">
-  -> localStorage: hermes-ext-external-app  ({ url, label })
+  -> Settings → Extensions → External App Tab settings: { url, label }
+  -> legacy fallback: localStorage hermes-ext-external-app ({ url, label })
 ```
 
 This extension is `static-ui` / manifest-bundle only. It does not add backend
@@ -80,7 +83,9 @@ Also on `window.HermesExternalAppTabExtension`:
 
 Restart Hermes WebUI without `HERMES_WEBUI_EXTENSION_DIR` /
 `HERMES_WEBUI_EXTENSION_MANIFEST`, or remove the `extensions/external-app-tab/`
-directory. Config lives under the `hermes-ext-external-app` localStorage key.
+directory. Config lives in the native Settings → Extensions store on supported
+core builds; older builds use the legacy `hermes-ext-external-app` localStorage
+key.
 
 ## Trust And Permissions
 
@@ -91,7 +96,10 @@ This is trusted local code. Current disclosed behavior:
 - embeds a **user-configured external URL** in an `<iframe>`
   (`permissions.network_external: true`) — this is the whole point of the
   extension; the URL is whatever the operator sets and is subject to the page CSP
-- reads and writes `localStorage` under the single key `hermes-ext-external-app`
+- reads/writes `url` and `label` through the native
+  `HermesExtensionSettings` store (`permissions.storage.owned: true`), with a
+  legacy fallback to the single `hermes-ext-external-app` localStorage key on
+  older core builds
 - does NOT call WebUI HTTP APIs
 - does NOT access cookies, loopback sidecars, the filesystem, or native hosts
 - does NOT itself `fetch()` any remote resource — it only sets an iframe `src`
@@ -112,6 +120,8 @@ rendered.
 ## Compatibility
 
 - manifest-bundled extension assets + same-origin serving under `/extensions/`
+- native Settings → Extensions fields via `settings_schema` /
+  `HermesExtensionSettings`, with localStorage fallback on older core builds
 - the left rail (`.rail`) to host the button
 - for external origins: the core `HERMES_WEBUI_CSP_FRAME_EXTRA` knob (PR #5091)
 
@@ -128,6 +138,7 @@ python3 -m json.tool extensions/external-app-tab/manifest.json
 
 Manual verification:
 
+- Settings → Extensions → External App Tab exposes **App URL** and **Rail label**
 - the rail button appears; clicking it opens the overlay
 - with no URL set, the empty-state prompt + Configure appear
 - configuring a same-origin URL frames it immediately

--- a/extensions/external-app-tab/assets/external-app-tab.js
+++ b/extensions/external-app-tab/assets/external-app-tab.js
@@ -15,20 +15,21 @@
   //   change. If the configured URL is blocked by CSP, the browser refuses to
   //   load the frame; the extension shows a hint explaining the knob.
   //
-  // Pure DOM-injection + localStorage. No backend, no network calls of its own
-  // (it only sets an <iframe src>, which the browser loads under the page CSP).
+  // Pure DOM-injection + HermesExtensionSettings (with legacy localStorage fallback).
+  // No backend, no network calls of its own (it only sets an <iframe src>, which
+  // the browser loads under the page CSP).
 
   const EXT = 'external-app-tab';
   if (window.__hermesExternalAppTabLoaded) return;
   window.__hermesExternalAppTabLoaded = true;
 
-  const CFG_KEY = 'hermes-ext-external-app';   // { url, label }
+  const CFG_KEY = 'hermes-ext-external-app';   // legacy localStorage key (pre-settings_schema): { url, label }
   const RAIL_BTN_ID = 'hwxExtAppRailBtn';
   const OVERLAY_ID = 'hwxExtAppOverlay';
 
   let overlayOpen = false;
 
-  function loadCfg() {
+  function legacyLoadCfg() {
     try {
       const raw = localStorage.getItem(CFG_KEY);
       if (!raw) return { url: '', label: 'App' };
@@ -36,8 +37,47 @@
       return { url: typeof c.url === 'string' ? c.url : '', label: (c && c.label) || 'App' };
     } catch (_) { return { url: '', label: 'App' }; }
   }
+
+  function extSettings() {
+    try {
+      const api = window.HermesExtensionSettings;
+      if (api && typeof api.settingsForExtension === 'function') {
+        const s = api.settingsForExtension('external-app-tab');
+        if (s && s.supported) return s;
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  function loadCfg() {
+    const s = extSettings();
+    if (s) {
+      const legacy = legacyLoadCfg();
+      let url = s.get('url');
+      let label = s.get('label');
+      // One-time soft migration for users who configured the extension before
+      // settings_schema existed. Keep the legacy key as a harmless fallback for
+      // older core; writes go through HermesExtensionSettings once supported.
+      if (!url && validUrl(legacy.url)) {
+        try { s.set('url', legacy.url); } catch (_) {}
+        url = legacy.url;
+      }
+      if ((!label || label === 'App') && legacy.label && legacy.label !== 'App') {
+        try { s.set('label', legacy.label); } catch (_) {}
+        label = legacy.label;
+      }
+      return { url: typeof url === 'string' ? url : '', label: typeof label === 'string' && label ? label : 'App' };
+    }
+    return legacyLoadCfg();
+  }
+
   function saveCfg(cfg) {
-    try { localStorage.setItem(CFG_KEY, JSON.stringify(cfg)); } catch (_) {}
+    const next = { url: cfg.url || '', label: cfg.label || 'App' };
+    const s = extSettings();
+    if (s) {
+      try { s.set('url', next.url); s.set('label', next.label); return; } catch (_) {}
+    }
+    try { localStorage.setItem(CFG_KEY, JSON.stringify(next)); } catch (_) {}
   }
 
   // Only http(s) absolute URLs are accepted (an iframe src must be http(s)).

--- a/extensions/external-app-tab/extension.json
+++ b/extensions/external-app-tab/extension.json
@@ -33,9 +33,7 @@
       "mutates_core_views": true
     },
     "storage": {
-      "owned": [
-        "hermes-ext-external-app"
-      ],
+      "owned": true,
       "shared_webui_keys": []
     },
     "loopback_sidecar": false,
@@ -47,5 +45,19 @@
     "network_external": true,
     "embeds_iframe": true,
     "requires_csp_frame_extra": true
-  }
+  },
+  "settings_schema": [
+    {
+      "key": "url",
+      "type": "string",
+      "label": "App URL",
+      "default": ""
+    },
+    {
+      "key": "label",
+      "type": "string",
+      "label": "Rail label",
+      "default": "App"
+    }
+  ]
 }

--- a/scripts/extension-registry-lib.mjs
+++ b/scripts/extension-registry-lib.mjs
@@ -452,6 +452,17 @@ function validateSidecar(entry, errors) {
   }
 }
 
+function validateSettingsSchema(entry, errors) {
+  if (entry.settings_schema === undefined) return;
+  if (!Array.isArray(entry.settings_schema)) {
+    errors.push('settings_schema must be an array');
+    return;
+  }
+  if (entry.permissions?.storage?.owned !== true) {
+    errors.push('settings_schema requires permissions.storage.owned to be true');
+  }
+}
+
 function validateCapabilities(entry, errors) {
   const capabilities = assertArray(entry.capabilities, 'capabilities', errors);
   for (const capability of capabilities) {
@@ -491,6 +502,7 @@ export function validateEntry(discovered) {
   validateLifecycle(entry, errors);
   validatePostInstall(entry, errors);
   validateSidecar(entry, errors);
+  validateSettingsSchema(entry, errors);
 
   const scriptText = assets.scripts
     .map((rel) => (existsSync(localFile(discovered.root, rel)) ? readFileSync(localFile(discovered.root, rel), 'utf8') : ''))

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -14,7 +14,20 @@ function writeJson(filePath, value) {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
-function validationErrors(scriptText) {
+function mergeDeep(base, overrides) {
+  const out = { ...base };
+  for (const [key, value] of Object.entries(overrides || {})) {
+    if (value && typeof value === 'object' && !Array.isArray(value)
+      && base[key] && typeof base[key] === 'object' && !Array.isArray(base[key])) {
+      out[key] = mergeDeep(base[key], value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+function validationErrors(scriptText, extensionOverrides = {}) {
   const id = `validator-case-${Math.random().toString(36).slice(2, 8)}`;
   const root = path.join(tmpRoot, id);
   const asset = 'assets/adapter.js';
@@ -31,7 +44,7 @@ function validationErrors(scriptText) {
       }
     ]
   });
-  writeJson(path.join(root, 'extension.json'), {
+  const extensionJson = mergeDeep({
     id,
     name: 'Validator Fixture',
     description: 'Temporary validator test fixture.',
@@ -71,7 +84,8 @@ function validationErrors(scriptText) {
       },
       network_external: false
     }
-  });
+  }, extensionOverrides);
+  writeJson(path.join(root, 'extension.json'), extensionJson);
   return validateEntry({
     idFromDir: id,
     root,
@@ -104,6 +118,19 @@ try {
 
   errors = validationErrors("fetch('http://[::1]:17787/health');\n");
   assert(!errors.includes('permissions.network_external is false but scripts appear to fetch an external origin'));
+
+  errors = validationErrors('', {
+    permissions: {
+      storage: {
+        owned: ['validator-case-settings'],
+        shared_webui_keys: []
+      }
+    },
+    settings_schema: [
+      { key: 'enabled', type: 'boolean', label: 'Enabled', default: true }
+    ]
+  });
+  assert(errors.includes('settings_schema requires permissions.storage.owned to be true'));
 
   const first = buildRegistryWithArtifacts({
     publishedAt: '2026-01-01T00:00:00.000Z',


### PR DESCRIPTION
## Thinking Path

#33 and #34 both point at the same maintenance/productization gap: gallery extensions that expose user-configurable options should use the sanctioned Settings → Extensions settings system instead of each entry relying only on ad-hoc localStorage patterns.

`external-app-tab` is the smallest useful slice because its configuration is exactly two user-facing settings: the framed app URL and the rail label. This PR migrates those settings without changing the extension's iframe/CSP behavior.

## What Changed

- `external-app-tab` now declares a `settings_schema` with:
  - `url` — App URL
  - `label` — Rail label
- Its permissions now use `permissions.storage.owned: true`, which is the core-required form for enabling `settings_schema`.
- Runtime configuration now reads/writes through `window.HermesExtensionSettings.settingsForExtension('external-app-tab')` when supported.
- Older core builds still work via the legacy `hermes-ext-external-app` localStorage fallback.
- Existing legacy config is softly migrated into the sanctioned settings store the first time the extension loads on a supported core build.
- README trust, compatibility, uninstall, and manual verification notes now describe the native settings store plus the legacy fallback.
- Validator coverage now fails any entry that declares `settings_schema` without `permissions.storage.owned === true`, preventing future drift from the core contract.

## Why It Matters

This is a small entry retrofit that makes the gallery feel more productized: users can configure the extension in the native Settings → Extensions surface, and maintainers get an automated guard for the settings contract instead of relying on review memory.

It also establishes a low-risk pattern for the broader #34 retrofit work: one extension per PR, preserve fallback behavior, and add a validator check when the contract is reusable.

## Verification

Ran locally from a clean worktree based on `origin/main`:

```bash
node scripts/validate-extensions.mjs
node scripts/test-extension-validator.mjs
node scripts/scan-extension-safety.mjs
node scripts/generate-registry.mjs --out dist/registry.json
node --check extensions/external-app-tab/assets/external-app-tab.js
node -e "JSON.parse(require('node:fs').readFileSync('dist/registry.json','utf8')); console.log('registry json ok')"
```

Result:

```text
validated 13 extension entries
extension validator self-tests passed
safety scan passed for 13 extension entries
wrote dist/registry.json with 13 extension entries
wrote 13 extension artifacts to dist/artifacts
registry json ok
```

RED check performed before implementation: the new validator regression initially failed because `settings_schema` with array-form `permissions.storage.owned` was not rejected.

## Risks / Follow-ups

- The in-overlay Configure dialog remains for convenience, but now writes through `HermesExtensionSettings` when available. If maintainers want settings to live only in the native panel, that can be simplified in follow-up.
- This handles `external-app-tab` only. Other #34 candidates should stay one-extension-per-PR.
- Addresses part of #33 and #34; does not close either umbrella.

## Model Used

- Provider: OpenAI Codex
- Model: gpt-5.5
- AI-assisted implementation and verification via Hermes Agent.
