### PR TITLE
docs: clarify settings_schema retrofit boundaries

### DIFF
--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -84,6 +84,19 @@ in **Settings → Extensions → [extension]** rather than building a bespoke pa
   key when running against older core without the settings system (see `mobile-haptics`
   for the reference pattern).
 
+Use `settings_schema` for **small user preferences and scalar configuration**: toggles,
+mode selectors, labels, URLs, numeric limits, and simple color strings. Do **not** force
+user content or collections into settings fields. Message pins, model favorites, pinned
+MCP tools, custom theme collections, uploaded/avatar image blobs, and generated artifacts
+belong in extension-owned storage (or future sanctioned storage APIs), not in the native
+settings form.
+
+When retrofitting existing entries, keep the slice reviewable: one extension per PR,
+preserve the legacy localStorage / owned-storage fallback when practical, softly migrate
+existing values instead of dropping user config, use `permissions.storage.owned === true`
+whenever `settings_schema` is present, and update the README trust / compatibility notes
+with the new storage behavior.
+
 ### Skins — `registerHermesSkin` with a base `scheme`
 
 Skin extensions call `window.registerHermesSkin({ name, value, tokens, ... })`. A skin


### PR DESCRIPTION
## Thinking Path

#33/#34 are pushing the extension library toward the sanctioned Settings → Extensions settings system. After reviewing the current entries, the biggest maintenance risk is over-applying `settings_schema`: many extensions use localStorage for user data collections, not simple preferences. This docs-only slice clarifies that boundary before more retrofit PRs land.

## What Changed

- Updated `docs/extension-entry.md` near the `settings_schema` guidance to define good candidates:
  - toggles
  - mode selectors
  - labels
  - URLs
  - numeric limits
  - simple color strings
- Clarified what should not be forced into `settings_schema`:
  - message pins
  - model favorites
  - pinned MCP tools
  - custom theme collections
  - uploaded/avatar image blobs
  - generated artifacts
- Added retrofit guidance:
  - one extension per PR
  - preserve legacy localStorage / owned-storage fallback where practical
  - softly migrate existing values instead of dropping config
  - use `permissions.storage.owned === true` whenever `settings_schema` is present
  - keep README trust / compatibility notes in sync

## Why It Matters

This keeps the productized Settings surface clean. Settings should expose small user preferences and scalar configuration, while user content and collections should remain in extension-owned storage or future sanctioned storage APIs.

That distinction lowers review churn for #33/#34 and avoids future PRs that mechanically migrate every localStorage key into Settings fields.

## Verification

```bash
git diff --check
node scripts/validate-extensions.mjs
```

Result:

```text
validated 13 extension entries
```

## Risks / Follow-ups

- Docs-only. No runtime behavior changes.
- This does not close #33 or #34; it clarifies the retrofit boundary for future one-extension PRs.

## Model Used

- Provider: OpenAI Codex
- Model: gpt-5.5
- AI-assisted implementation and verification via Hermes Agent.
