### PR TITLE
docs: clarify safety scan scope

### DIFF
--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -252,6 +252,14 @@ obvious secrets, symlinks or unsafe paths, blocked JavaScript execution patterns
 undeclared external network literals, localStorage writes without owned-key
 declarations, and generated artifact hash/size consistency.
 
+Treat the safety scan as a fast fail-closed heuristic, not as a full security
+proof. A green scan means the entry avoided the currently automated high-risk
+patterns; it does not clear adversarial JavaScript that hides behavior through
+split strings, aliased/computed `Function` or `import()`, `XMLHttpRequest`, or
+other semantic obfuscation. Those deeper malicious-code checks, broader
+browser-capability drift checks, and artifact-author provenance binding remain
+tracked under #8.
+
 Generate the registry locally with:
 
 ```bash

--- a/scripts/scan-extension-safety.mjs
+++ b/scripts/scan-extension-safety.mjs
@@ -3,6 +3,15 @@ import { lstatSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { buildRegistryWithArtifacts, repoRelative, validateAllEntries } from './extension-registry-lib.mjs';
 
+// Fast fail-closed safety gate for obvious extension entry risks.
+//
+// This is intentionally a heuristic scan, not a complete malicious-code proof.
+// It catches review-proven high-risk shapes before registry generation, but it
+// should not be treated as an adversarial JavaScript analysis engine. Known
+// follow-up work remains tracked in #8: split-string URL construction,
+// aliased/computed Function/import/XMLHttpRequest patterns, broader DOM/network
+// capability drift, and artifact-author provenance binding.
+
 const TEXT_EXTENSIONS = new Set([
   '.css',
   '.html',


### PR DESCRIPTION
## Thinking Path

#8 remains open because the current safety scan is a fast, fail-closed gate, not a complete adversarial security analysis. After #43 added another concrete gate, this docs-only slice makes that boundary explicit in the scanner source and contributor docs so future reviewers do not treat a green scan as a full security proof.

## What Changed

- Added a top-of-file scope note to `scripts/scan-extension-safety.mjs` explaining that it catches review-proven high-risk shapes before registry generation, but is still heuristic.
- Updated `docs/extension-entry.md` to tell contributors and reviewers what a green safety scan does and does not mean.
- Named the remaining #8 follow-ups explicitly: split-string / aliased / computed JavaScript patterns, broader DOM/network capability drift, and artifact-author provenance binding.

## Why It Matters

The one-click install flow now makes this repo's gates part of the trust boundary. The current scanner is useful, but overclaiming its coverage would be risky. This keeps the shipped gate honest while leaving deeper adversarial scanning and provenance work tracked under #8.

## Verification

```bash
git diff --check
node scripts/validate-extensions.mjs
node scripts/test-extension-validator.mjs
node scripts/scan-extension-safety.mjs
node scripts/generate-registry.mjs --out dist/registry.json
```

Result:

```text
validated 13 extension entries
extension validator self-tests passed
safety scan passed for 13 extension entries
wrote dist/registry.json with 13 extension entries
wrote 13 extension artifacts to dist/artifacts
```

## Risks / Follow-ups

- Docs/comment only; no runtime or gate behavior change.
- Addresses part of #8. Does not complete the #8 umbrella.

## Model Used

- Provider: OpenAI Codex
- Model: gpt-5
- AI-assisted implementation and verification via Codex.
