### PR TITLE
feat: add voice-control-session-management extension

### DIFF
--- a/extensions/session-orchestrator/README.md
+++ b/extensions/session-orchestrator/README.md
@@ -1,0 +1,170 @@
+# Session Orchestrator
+
+Voice-commanded multi-session orchestration for Hermes WebUI — create, switch,
+prompt, and monitor concurrent agent sessions hands-free via speech commands or
+text shortcuts.
+
+## What It Does
+
+- **Voice commands** — say "new session dev", "switch session dev", "start
+  prompt", "stop prompt", "read session dev", "maximise session" via the
+  existing voice mode microphone.
+- **Session alias registry** — assign friendly names to sessions (`dev`,
+  `staging`, `research`) instead of tracking hex IDs.
+- **Asynchronous completion notifications** — when a background session finishes
+  processing, hear "Response ready in session dev" via TTS, plus an optional
+  browser notification + chime.
+- **Input buffer** — "start prompt" opens a recording buffer; subsequent speech
+  accumulates until "stop prompt" flushes it to the agent. Or auto-flush on
+  silence.
+- **Tile integration** — works with the [chat-tiling](../chat-tiling/) extension:
+  aliases show as color-coded badges on sidebar sessions, and `maximise session`
+  expands the tile.
+
+## How It Works
+
+```text
+Voice input (mic) → SpeechRecognition → Command Parser
+  ├─ Matches command → execCommand → create/switch/read/maximize
+  └─ No match + buffer open → append to input buffer
+  └─ No match + buffer closed → normal send via existing _voiceModeSend
+
+Session completion → SessionChannel SSE → _handleBgTaskCompleteEvent
+  → chime + browser notification + TTS: "Response ready in session [alias]"
+```
+
+The orchestrator **wraps** existing voice mode (`_voiceModeSend` hijack) and
+**intercepts** the existing background-task-complete handler — no new backend
+routes needed.
+
+## Voice Commands
+
+| Say | Action |
+|-----|--------|
+| "new session dev" | Creates a new WebUI session, registers alias "dev" |
+| "switch session dev" | Loads the "dev" session |
+| "start prompt" | Opens the input buffer for the active session |
+| "stop prompt" | Closes the buffer and sends to the agent |
+| "read session dev" | Speaks the latest response from "dev" via TTS |
+| "maximise session" | Expands the active tile to full grid |
+| "close session dev" | Closes the tile and removes the alias |
+| "list sessions" | Lists all tracked aliases |
+| "help" | Speaks available commands |
+
+## Keyboard Shortcut
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+Shift+O` | Toggle orchestrator on/off |
+| `Escape` (while recording) | Cancel input buffer |
+
+## Text Commands
+
+When orchestrator is active, type any command into the composer and send it
+normally — the command parser intercepts at `_voiceModeSend`. Commands work in
+both voice and text.
+
+## Settings
+
+- **Play chime on session completion** — plays via existing `playAttentionSound()`.
+- **Speak completion alerts via TTS** — speaks "Response ready in session [alias]".
+- **Silence threshold** — milliseconds of silence before auto-flushing the input buffer.
+
+## Capabilities
+
+- `manifest-bundle`
+
+## Install For Local Testing
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/session-orchestrator \
+HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json \
+./start.sh
+```
+
+Or register in your dev state dir's `extension-install-manifest.json` and restart
+the WebUI service.
+
+## Controls
+
+| API | Description |
+|-----|-------------|
+| `window.Orchestrator.enabled()` | Boolean — is orchestrator active? |
+| `window.Orchestrator.aliases()` | Copy of the alias → session map |
+| `window.Orchestrator.activeAlias()` | Currently-focused alias name |
+| `window.Orchestrator.bufferOpen()` | Boolean — is buffer recording? |
+| `window.Orchestrator.toggle()` | Toggle orchestrator on/off |
+| `window.Orchestrator.execCommand({action, args})` | Execute a parsed command |
+| `window.Orchestrator.parseCommand(text)` | Parse text into a command object |
+| `window.Orchestrator.registerAlias(name, sessionData)` | Manually register an alias |
+| `window.Orchestrator.unregisterAlias(name)` | Remove an alias |
+
+## Disable And Uninstall
+
+Disable via Settings → Extensions → Session Orchestrator toggle. Or remove the
+`extensions/session-orchestrator/` directory and restart.
+
+Aliases persist in `localStorage` under the `hwx-orch-state` key. Clear it if
+you want a clean slate.
+
+## Trust And Permissions
+
+This is trusted local code. Current disclosed behavior:
+
+- reads/writes `localStorage` under key `hwx-orch-state` (alias registry)
+- intercepts `window._voiceModeSend` to parse commands from speech (restored on
+  disable)
+- intercepts `window._handleBgTaskCompleteEvent` for completion notifications
+  (restored on disable)
+- calls `window.newSession()`, `window.loadSession()`, `window.send()`,
+  `window.api()` — existing WebUI globals
+- sets a 500ms `setInterval` watching `S.busy` transitions as completion
+  fallback
+- uses `window.speechSynthesis.speak()` for command feedback
+- does NOT access external networks, filesystem, native hosts, or sidecar
+  processes
+
+## Compatibility
+
+- Requires a browser with `SpeechRecognition` + `speechSynthesis` (Chrome/Edge/
+  Brave). Falls back to text-only mode on Firefox/Safari without STT.
+- Tested against hermes-webui v0.51.845+
+- Optional integration with [chat-tiling](../chat-tiling/) extension (badges on
+  sidebar rows, tile maximize)
+
+## Known Limitations
+
+- **Phase 1 only** — orchestrator manages aliases and voice commands but does
+  not provision containerized desktop environments (that's Phase 2, tracked in
+  the [hermes-desktop](../hermes-desktop/) extension as a per-session container
+  pattern).
+- **Single active buffer** — only one session can have its input buffer open
+  at a time.
+- **Alias collision** — if you say "new session dev" twice, the second
+  overwrites the first silently (deliberate: voice-first shouldn't require
+  confirmation dialogs).
+- Depends on `window._voiceModeSend` being the current send function. If voice
+  mode is not active, commands entered as text in the composer still work
+  through the same interception point.
+
+## Verification
+
+```bash
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+node --check extensions/session-orchestrator/assets/orchestrator.js
+python3 -m json.tool extensions/session-orchestrator/extension.json
+python3 -m json.tool extensions/session-orchestrator/manifest.json
+```
+
+Manual verification:
+
+1. Enable voice mode (Settings → Preferences → Hands-free voice mode button)
+2. Say "new session dev" → hear "Session dev initialized."
+3. Say "list sessions" → hear "Tracked sessions: dev"
+4. Say "start prompt" → hear "Recording." Buffer indicator appears.
+5. Speak a prompt → silence → auto-sends to "dev" session
+6. Switch to a different tab — when response completes, hear notification
+7. Say "read session dev" → hear the latest assistant response
+8. Toggle orchestrator with `Ctrl+Shift+O` → hear disabled confirmation

--- a/extensions/session-orchestrator/assets/orchestrator.js
+++ b/extensions/session-orchestrator/assets/orchestrator.js
@@ -1,0 +1,635 @@
+// Session Orchestrator — Voice-commanded multi-session management
+// Usage: speak or type "new session dev", "switch session dev", "start prompt",
+//        "stop prompt", "read session dev", "maximise session".
+// Dependencies: existing voice mode (boot.js SpeechRecognition), chat-tiling grid,
+//               SessionChannel SSE, playNotificationSound/sendBrowserNotification.
+// Install: register in extension-install-manifest.json, reload WebUI.
+
+(() => {
+  'use strict';
+  if (window.__sessionOrchestratorLoaded) return;
+  window.__sessionOrchestratorLoaded = true;
+
+  const EXT = 'session-orchestrator';
+  const LS_KEY = 'hwx-orch-state';
+
+  // ── Settings (from HermesExtensionSettings API) ──
+  const gs = (k, d) => {
+    try {
+      const w = window.HermesExtensionSettings;
+      if (w) { const x = w.settingsForExtension(EXT); return x.get(k) != null ? x.get(k) : d; }
+    } catch (_) {}
+    return d;
+  };
+
+  // ── Command Schema ──
+  // Each entry: { pattern: regex with named capture groups, action: string, parse: function }
+  // The parser matches against lowercased transcript, extracts params from groups.
+  const COMMANDS = [
+    // new session <alias> — creates a new session and registers the alias
+    { re: /^new session\s+(.+)$/i,          action: 'newSession' },
+    // switch [to] session <alias> — focuses existing session by alias or sid
+    { re: /^switch\s+(?:to\s+)?session\s+(.+)$/i, action: 'switchSession' },
+    // start [prompt|recording] — opens input buffer for active session
+    { re: /^(?:start\s+)?(?:prompt|recording)$/i, action: 'startPrompt' },
+    // stop [prompt|recording|and send] — closes buffer and dispatches
+    { re: /^(?:stop\s+)?(?:prompt|recording)(?:\s+and\s+send)?$/i, action: 'stopPrompt' },
+    // read [session] <alias> — speaks latest response from session
+    { re: /^read\s+(?:session\s+)?(.+)$/i,  action: 'readSession' },
+    // maximise [session] — expands active session to full view
+    { re: /^maximi[sz]e\s+(?:session\s+)?(.+)?$/i, action: 'maximize' },
+    // close [session] <alias> — closes a tile / removes alias
+    { re: /^close\s+(?:session\s+)?(.+)$/i, action: 'closeSession' },
+    // list sessions — enumerate all tracked aliases
+    { re: /^(?:list|show)\s+sessions$/i,    action: 'listSessions' },
+    // help — speak available commands
+    { re: /^(?:help|what can I say)\s*$/i,  action: 'help' },
+  ];
+
+  // ── State ──
+  const O = {
+    // alias → { sid, session_id, createdAt }
+    aliases: {},
+    // Reverse: session_id → alias (for lookups)
+    reverse: {},
+    activeAlias: null,       // currently focused alias
+    bufferOpen: false,       // start prompt issued?
+    inputBuffer: '',         // accumulated text since start prompt
+    bufferTimer: null,       // silence timeout for buffer flush
+    processingAliases: new Set(), // aliases with in-flight streams
+    enabled: false,          // orchestrator mode active?
+    _origVoiceSend: null,    // saved original _voiceModeSend
+    _origHandleBg: null,     // saved original _handleBgTaskCompleteEvent
+    _busyWatch: null,
+    _prevBusy: false,
+  };
+
+  // ── CSS (inlined) ──
+  document.head.appendChild(Object.assign(document.createElement('style'), {
+    textContent: `
+#orch-status {
+  display:none; align-items:center; gap:6px; padding:4px 10px; margin:0;
+  font-size:11px; border-radius:8px; background:var(--accent-bg); color:var(--accent);
+  border:1px solid var(--accent); position:relative;
+}
+#orch-status.orch-active { display:inline-flex; }
+#orch-status .orch-dot { width:6px;height:6px;border-radius:50%;background:var(--accent);animation:orch-pulse 1.2s infinite }
+@keyframes orch-pulse { 0%,100%{opacity:1} 50%{opacity:.3} }
+#orch-buffer-indicator {
+  display:none; position:fixed; bottom:60px; left:50%; transform:translateX(-50%);
+  padding:6px 16px; border-radius:20px; background:var(--accent); color:#fff;
+  font-size:13px; font-weight:600; z-index:9999;
+  box-shadow:0 2px 12px rgba(0,0,0,.3);
+}
+#orch-buffer-indicator.orch-recording { display:block; }
+.orch-alias-badge {
+  display:inline-flex; align-items:center; justify-content:center;
+  min-width:16px; height:16px; padding:0 5px; border-radius:999px;
+  background:var(--accent); color:#fff; font-size:9px; font-weight:700;
+  line-height:1; margin-left:4px; vertical-align:middle;
+}
+.orch-alias-badge.orch-processing { background:#f59e0b; animation:orch-pulse 1s infinite; }
+.orch-alias-badge.orch-ready { background:#22c55e; }
+`
+  }));
+
+  // ── Command Parser ──
+  function parseCommand(text) {
+    const trimmed = text.trim().toLowerCase().replace(/[.!?]+$/, '');
+    for (const cmd of COMMANDS) {
+      const m = trimmed.match(cmd.re);
+      if (m) {
+        // Extract named or positional args
+        const args = m.slice(1).filter(Boolean);
+        return { action: cmd.action, args, raw: trimmed };
+      }
+    }
+    return null;
+  }
+
+  // ── Session Alias Registry ──
+  function resolveAlias(name) {
+    const key = name.toLowerCase().trim();
+    return O.aliases[key] || null;
+  }
+
+  function registerAlias(name, sessionData) {
+    const key = name.toLowerCase().trim();
+    if (O.aliases[key]) {
+      speakText('Overwriting existing session ' + name);
+    }
+    const sid = sessionData.session_id;
+    O.aliases[key] = { sid, session_id: sid, name, createdAt: Date.now() };
+    O.reverse[sid] = key;
+    saveState();
+    updateBadge(key, 'active');
+  }
+
+  function unregisterAlias(name) {
+    const key = name.toLowerCase().trim();
+    const entry = O.aliases[key];
+    if (!entry) return false;
+    delete O.reverse[entry.sid];
+    delete O.aliases[key];
+    removeBadge(entry.sid);
+    if (O.activeAlias === key) O.activeAlias = null;
+    saveState();
+    return true;
+  }
+
+  function aliasForSid(sid) {
+    return O.reverse[sid] || sid.slice(0, 8);
+  }
+
+  // ── Command Handlers ──
+  function execCommand(parsed) {
+    if (!parsed) return false;
+
+    switch (parsed.action) {
+      case 'newSession': {
+        const name = parsed.args[0] || 'default';
+        // Call existing newSession() in sessions.js
+        if (typeof window.newSession === 'function') {
+          (async () => {
+            try {
+              const data = await window.newSession(false, {});
+              if (data && data.session_id) {
+                registerAlias(name, data);
+                speakText('Session ' + name + ' initialized.');
+                O.activeAlias = name;
+              }
+            } catch (e) {
+              speakText('Failed to create session.');
+            }
+          })();
+        } else {
+          speakText('Cannot create session — newSession not available.');
+        }
+        return true;
+      }
+
+      case 'switchSession': {
+        const name = parsed.args[0];
+        const entry = resolveAlias(name);
+        if (!entry) {
+          speakText('Session ' + name + ' does not exist. Say new session ' + name + ' to create it.');
+          return true;
+        }
+        if (typeof window.loadSession === 'function') {
+          window.loadSession(entry.sid);
+          O.activeAlias = entry.name;
+          speakText('Switched to session ' + name);
+        }
+        // Update tile focus if tiling extension is active
+        if (typeof window.focusTileExt === 'function') {
+          window.focusTileExt(entry.sid);
+        }
+        return true;
+      }
+
+      case 'startPrompt': {
+        if (O.bufferOpen) {
+          speakText('Already recording.');
+          return true;
+        }
+        // Check if active session is processing
+        if (O.activeAlias && O.processingAliases.has(O.activeAlias)) {
+          speakText('Session ' + O.activeAlias + ' is already processing.');
+          return true;
+        }
+        O.bufferOpen = true;
+        O.inputBuffer = '';
+        document.getElementById('orch-buffer-indicator')?.classList.add('orch-recording');
+        speakText('Recording.');
+        return true;
+      }
+
+      case 'stopPrompt': {
+        if (!O.bufferOpen) return true;
+        O.bufferOpen = false;
+        document.getElementById('orch-buffer-indicator')?.classList.remove('orch-recording');
+        clearTimeout(O.bufferTimer);
+        flushBuffer();
+        return true;
+      }
+
+      case 'readSession': {
+        const name = parsed.args[0];
+        const entry = resolveAlias(name);
+        if (!entry) {
+          speakText('Session ' + name + ' does not exist.');
+          return true;
+        }
+        (async () => {
+          try {
+            const data = await window.api('/api/session?session_id=' + encodeURIComponent(entry.sid));
+            const msgs = data && data.messages;
+            if (msgs && msgs.length > 0) {
+              const last = msgs[msgs.length - 1];
+              const content = typeof last.content === 'string' ? last.content : '';
+              if (content) {
+                speakText(content.slice(0, 500));
+              } else {
+                speakText('Session ' + name + ' has no response yet.');
+              }
+            } else {
+              speakText('Session ' + name + ' is empty.');
+            }
+          } catch (e) {
+            speakText('Could not read session ' + name + '.');
+          }
+        })();
+        return true;
+      }
+
+      case 'maximize': {
+        // Toggle maximize on the current tile if tiling extension present
+        const sid = O.activeAlias ? resolveAlias(O.activeAlias)?.sid : null;
+        if (sid && typeof window.maximizeTileExt === 'function') {
+          const tile = document.querySelector('.ext-tile[data-sid="' + CSS.escape(sid) + '"]');
+          if (tile) {
+            // Find the tile ID from the tiling extension state
+            if (window.T && window.T.tiles) {
+              const t = window.T.tiles.find(t => t.sid === sid);
+              if (t) { window.maximizeTileExt(t.id); return true; }
+            }
+          }
+        }
+        speakText('No session to maximize.');
+        return true;
+      }
+
+      case 'closeSession': {
+        const name = parsed.args[0];
+        const entry = resolveAlias(name);
+        if (!entry) {
+          speakText('Session ' + name + ' does not exist.');
+          return true;
+        }
+        unregisterAlias(name);
+        if (typeof window.closeTileExt === 'function') {
+          window.closeTileExt(entry.sid);
+        }
+        speakText('Closed session ' + name);
+        return true;
+      }
+
+      case 'listSessions': {
+        const names = Object.keys(O.aliases);
+        if (names.length === 0) {
+          speakText('No sessions tracked.');
+        } else {
+          speakText('Tracked sessions: ' + names.join(', '));
+        }
+        return true;
+      }
+
+      case 'help': {
+        speakText('Available commands: new session [name], switch session [name], start prompt, stop prompt, read session [name], maximise session, close session [name], list sessions.');
+        return true;
+      }
+
+      default:
+        return false;
+    }
+  }
+
+  // ── Input Buffer ──
+  function appendToBuffer(text) {
+    O.inputBuffer += (O.inputBuffer ? ' ' : '') + text;
+    clearTimeout(O.bufferTimer);
+    O.bufferTimer = setTimeout(() => {
+      if (O.bufferOpen && O.inputBuffer) {
+        // Auto-flush on silence
+        O.bufferOpen = false;
+        document.getElementById('orch-buffer-indicator')?.classList.remove('orch-recording');
+        flushBuffer();
+      }
+    }, gs('silence_command_ms', 1800));
+  }
+
+  function flushBuffer() {
+    if (!O.inputBuffer) return;
+    const text = O.inputBuffer;
+    O.inputBuffer = '';
+
+    // Get the active session
+    const active = O.activeAlias ? resolveAlias(O.activeAlias) : null;
+    if (active && typeof window.send === 'function') {
+      // Put text into textarea and send
+      const msg = document.getElementById('msg');
+      if (msg) {
+        msg.value = text;
+        autoResize && autoResize();
+        window.send();
+        O.processingAliases.add(O.activeAlias);
+        updateBadge(O.activeAlias, 'processing');
+      }
+    } else {
+      // No active session — create one on the fly
+      if (typeof window.newSession === 'function') {
+        (async () => {
+          try {
+            const data = await window.newSession(false, {});
+            const alias = 'default';
+            registerAlias(alias, data);
+            O.activeAlias = alias;
+            const msg = document.getElementById('msg');
+            if (msg) {
+              msg.value = text;
+              autoResize && autoResize();
+              window.send();
+              O.processingAliases.add(alias);
+              updateBadge(alias, 'processing');
+            }
+          } catch (_) {
+            speakText('Failed to create session for prompt.');
+          }
+        })();
+      }
+    }
+  }
+
+  // ── TTS (speak a text response to the user) ──
+  function speakText(text) {
+    if (!gs('speak_notifications', true)) return;
+    try {
+      if (window.speechSynthesis) {
+        const u = new SpeechSynthesisUtterance(text);
+        u.rate = 1.0; u.pitch = 1.0; u.volume = 0.8;
+        window.speechSynthesis.speak(u);
+      }
+    } catch (_) {}
+  }
+
+  // ── Badge Management ──
+  function updateBadge(alias, state) {
+    const entry = resolveAlias(alias);
+    if (!entry) return;
+    const safeSid = CSS.escape ? CSS.escape(entry.sid) : entry.sid.replace(/[^a-zA-Z0-9_-]/g, '');
+    const row = document.querySelector('[data-session-id="' + safeSid + '"]');
+    if (!row) return;
+    let b = row.querySelector('.orch-alias-badge');
+    if (!b) {
+      b = document.createElement('span');
+      b.className = 'orch-alias-badge';
+      (row.querySelector('.session-row-right') || row.querySelector('.session-meta') || row).appendChild(b);
+    }
+    b.className = 'orch-alias-badge orch-' + state;
+    b.textContent = alias.slice(0, 6);
+  }
+
+  function removeBadge(sid) {
+    const safeSid = CSS.escape ? CSS.escape(sid) : sid.replace(/[^a-zA-Z0-9_-]/g, '');
+    const b = document.querySelector('[data-session-id="' + safeSid + '"] .orch-alias-badge');
+    if (b) b.remove();
+  }
+
+  // ── Status Bar ──
+  function createStatusBar() {
+    if (document.getElementById('orch-status')) return;
+    const bar = document.createElement('div');
+    bar.id = 'orch-status';
+    bar.innerHTML = '<span class="orch-dot"></span><span>Orchestrator active</span>';
+    const titlebar = document.querySelector('header.app-titlebar');
+    if (titlebar) titlebar.appendChild(bar);
+  }
+
+  function updateStatusBar(active) {
+    const bar = document.getElementById('orch-status');
+    if (!bar) return;
+    bar.classList.toggle('orch-active', active);
+  }
+
+  // ── Voice Mode Hijack ──
+  // Intercept the voice mode send pipeline so that transcribed speech first
+  // tries to parse as a command. If it matches, dispatch. Otherwise fall
+  // through to normal send (or buffer if prompt is open).
+  function hijackVoiceSend() {
+    // The voice mode calls _voiceModeSend() when silence is detected.
+    // We save the original and wrap it.
+    if (typeof window._voiceModeSend === 'function') {
+      O._origVoiceSend = window._voiceModeSend;
+      const orig = window._voiceModeSend;
+      window._voiceModeSend = function() {
+        // Get what would be sent (the textarea content at this point)
+        const msg = document.getElementById('msg');
+        const text = msg ? msg.value : '';
+        if (!text) { return orig(); }
+
+        // If buffer is open, accumulate instead of send
+        if (O.bufferOpen) {
+          // The voice mode puts transcribed text into #msg already
+          appendToBuffer(text);
+          msg.value = '';
+          autoResize && autoResize();
+          return;
+        }
+
+        // Try parsing as a command
+        const parsed = parseCommand(text);
+        if (parsed) {
+          msg.value = '';
+          autoResize && autoResize();
+          execCommand(parsed);
+          return;
+        }
+
+        // Not a command — send normally
+        // But if we have an active alias, ensure we're in the right session
+        orig();
+      };
+      window._origVoiceModeSendRestore = () => {
+        if (O._origVoiceSend) window._voiceModeSend = O._origVoiceSend;
+      };
+    }
+  }
+
+  // ── Notification Wiring ──
+  // Intercept _handleBgTaskCompleteEvent or watch S.busy transitions
+  function wireNotifications() {
+    // Method 1: Intercept the existing handler
+    if (typeof window._handleBgTaskCompleteEvent === 'function') {
+      O._origHandleBg = window._handleBgTaskCompleteEvent;
+      const orig = window._handleBgTaskCompleteEvent;
+      window._handleBgTaskCompleteEvent = function(e, sid, opts) {
+        const result = orig(e, sid, opts);
+        if (e && e.session_id) {
+          handleSessionComplete(e.session_id);
+        }
+        return result;
+      };
+    }
+
+    // Method 2: Watch S.busy transitions as fallback
+    O._busyWatch = setInterval(() => {
+      if (typeof S === 'undefined') return;
+      if (O._prevBusy && !S.busy) {
+        const sid = S.session && S.session.session_id;
+        if (sid) handleSessionComplete(sid);
+      }
+      O._prevBusy = !!S.busy;
+    }, 500);
+  }
+
+  function handleSessionComplete(sid) {
+    if (!sid) return;
+    const alias = aliasForSid(sid);
+    O.processingAliases.delete(alias);
+    updateBadge(alias, 'ready');
+
+    // Clear processing state after brief delay
+    setTimeout(() => {
+      const entry = resolveAlias(alias);
+      if (entry) updateBadge(alias, 'active');
+    }, 5000);
+
+    // Notification
+    if (gs('auto_notify', true)) {
+      if (typeof playAttentionSound === 'function') {
+        playAttentionSound('orch-' + sid);
+      }
+      if (typeof sendBrowserNotification === 'function') {
+        sendBrowserNotification(
+          'Session ' + alias + ' ready',
+          'Response completed.',
+          { forceHidden: true, sid }
+        );
+      }
+    }
+    speakText('Response ready in session ' + alias);
+  }
+
+  // ── State Persistence ──
+  function saveState() {
+    try {
+      localStorage.setItem(LS_KEY, JSON.stringify({
+        aliases: O.aliases,
+        reverse: O.reverse,
+        activeAlias: O.activeAlias,
+      }));
+    } catch (_) {}
+  }
+
+  function loadState() {
+    try {
+      const raw = localStorage.getItem(LS_KEY);
+      if (raw) {
+        const s = JSON.parse(raw);
+        if (s.aliases) O.aliases = s.aliases;
+        if (s.reverse) O.reverse = s.reverse;
+        if (s.activeAlias) O.activeAlias = s.activeAlias;
+      }
+    } catch (_) {}
+  }
+
+  // ── Keyboard Shortcut ──
+  function initKeyboard() {
+    document.addEventListener('keydown', e => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'O' && !e.repeat) {
+        e.preventDefault();
+        toggleOrchestrator();
+      }
+      // Escape to cancel buffer
+      if (e.key === 'Escape' && O.bufferOpen) {
+        O.bufferOpen = false;
+        O.inputBuffer = '';
+        document.getElementById('orch-buffer-indicator')?.classList.remove('orch-recording');
+        clearTimeout(O.bufferTimer);
+        speakText('Cancelled.');
+      }
+    });
+  }
+
+  // ── Toggle ──
+  function toggleOrchestrator() {
+    O.enabled = !O.enabled;
+    updateStatusBar(O.enabled);
+    if (O.enabled) {
+      hijackVoiceSend();
+      wireNotifications();
+      loadState();
+      // Re-apply badges for known sessions
+      Object.keys(O.aliases).forEach(k => updateBadge(k, 'active'));
+      speakText('Session Orchestrator enabled.');
+    } else {
+      // Restore
+      if (O._origVoiceSend && typeof window._origVoiceModeSendRestore === 'function') {
+        window._origVoiceModeSendRestore();
+      }
+      if (O._busyWatch) { clearInterval(O._busyWatch); O._busyWatch = null; }
+      // Restore original _handleBgTaskCompleteEvent
+      if (O._origHandleBg && typeof window._handleBgTaskCompleteEvent !== 'undefined') {
+        window._handleBgTaskCompleteEvent = O._origHandleBg;
+      }
+      O.bufferOpen = false;
+      O.inputBuffer = '';
+      clearTimeout(O.bufferTimer);
+      document.getElementById('orch-buffer-indicator')?.classList.remove('orch-recording');
+      saveState();
+      speakText('Session Orchestrator disabled.');
+    }
+  }
+
+  // ── Init ──
+  function init() {
+    // Guard: require voice mode infrastructure
+    if (typeof window._voiceModeActive !== 'function') {
+      console.log('[Orch] Voice mode not available — orchestrator needs SpeechRecognition.');
+      return;
+    }
+
+    createStatusBar();
+
+    // Buffer indicator overlay
+    const bi = document.createElement('div');
+    bi.id = 'orch-buffer-indicator';
+    bi.textContent = '● Recording...';
+    document.body.appendChild(bi);
+
+    // Restore previous state if we crashed mid-session
+    loadState();
+    Object.keys(O.aliases).forEach(k => updateBadge(k, 'active'));
+    if (O.activeAlias) speakText('Orchestrator restored. Session ' + O.activeAlias + ' active.');
+
+    // Clean up stale processing flags (page refresh mid-request)
+    O.processingAliases.clear();
+
+    initKeyboard();
+    updateStatusBar(true);
+    O.enabled = true;
+    hijackVoiceSend();
+    wireNotifications();
+
+    console.log('[Orch] Session Orchestrator initialized. ' +
+      Object.keys(O.aliases).length + ' aliases restored. Ctrl+Shift+O to toggle.');
+  }
+
+  // ── Exports ──
+  window.Orchestrator = {
+    enabled: () => O.enabled,
+    aliases: () => ({ ...O.aliases }),
+    activeAlias: () => O.activeAlias,
+    bufferOpen: () => O.bufferOpen,
+    toggle: toggleOrchestrator,
+    execCommand,
+    parseCommand,
+    registerAlias,
+    unregisterAlias,
+    speak: speakText,
+  };
+
+  // Defer init until DOM + core scripts loaded
+  function install(attempt) {
+    if ((document.getElementById('msg') && typeof window._voiceModeActive === 'function') || attempt > 60) {
+      init();
+      return;
+    }
+    setTimeout(() => install(attempt + 1), 250);
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => install(0), { once: true });
+  } else {
+    setTimeout(() => install(0), 500);
+  }
+})();

--- a/extensions/session-orchestrator/assets/orchestrator.js
+++ b/extensions/session-orchestrator/assets/orchestrator.js
@@ -652,6 +652,7 @@
     O.enabled = true;
     hijackVoiceSend();
     wireNotifications();
+    registerEvents(); // wire cross-extension listeners (init starts enabled)
 
     console.log('[Orch] Session Orchestrator initialized. ' +
       Object.keys(O.aliases).length + ' aliases restored. Ctrl+Shift+O to toggle.');

--- a/extensions/session-orchestrator/assets/orchestrator.js
+++ b/extensions/session-orchestrator/assets/orchestrator.js
@@ -46,6 +46,40 @@
     { re: /^(?:help|what can I say)\s*$/i,  action: 'help' },
   ];
 
+  // ── Cross-extension event bus (CustomEvents) ──
+  // Sibling extensions (emotion-avatar #56, fun-audio-chat-connector #53) are
+  // decoupled: we only exchange window CustomEvents — never shared globals or
+  // direct function calls. See the emotion-avatar event contract.
+  function emitEvent(name, detail) {
+    try { window.dispatchEvent(new CustomEvent(name, { detail: detail })); }
+    catch (_) { /* dispatch is non-throwing; stay defensive */ }
+  }
+
+  // Read-only mirror of avatar expression (drives our status title).
+  function onAvatarExpression(e) {
+    const expr = e && e.detail && e.detail.expression;
+    if (!expr) return;
+    const badge = document.getElementById('orch-status');
+    if (badge) badge.title = 'Avatar: ' + expr;
+  }
+
+  // Mirror voice activity so our status can reflect it.
+  function onVoiceState(e) {
+    const st = e && e.detail && e.detail.state;
+    if (!st) return;
+    const badge = document.getElementById('orch-status');
+    if (badge) badge.dataset.voice = st;
+  }
+
+  function registerEvents() {
+    window.addEventListener('hermes:avatar:expression', onAvatarExpression);
+    window.addEventListener('hermes:voice:state', onVoiceState);
+  }
+  function unregisterEvents() {
+    window.removeEventListener('hermes:avatar:expression', onAvatarExpression);
+    window.removeEventListener('hermes:voice:state', onVoiceState);
+  }
+
   // ── State ──
   const O = {
     // alias → { sid, session_id, createdAt }
@@ -180,6 +214,13 @@
           O.activeAlias = entry.name;
           speakText('Switched to session ' + name);
         }
+        // Broadcast the switch so sibling extensions (e.g. avatar → thinking) react.
+        emitEvent('hermes:agent:state', {
+          action: 'switchSession',
+          activeAlias: O.activeAlias,
+          expression: 'thinking',
+          timestamp: Date.now(),
+        });
         // Update tile focus if tiling extension is active
         if (typeof window.focusTileExt === 'function') {
           window.focusTileExt(entry.sid);
@@ -498,6 +539,15 @@
       }
     }
     speakText('Response ready in session ' + alias);
+
+    // Broadcast completion so sibling extensions can clear their state.
+    emitEvent('hermes:agent:state', {
+      action: 'sessionComplete',
+      alias: alias,
+      sid: sid,
+      expression: 'idle',
+      timestamp: Date.now(),
+    });
   }
 
   // ── State Persistence ──
@@ -549,6 +599,7 @@
       hijackVoiceSend();
       wireNotifications();
       loadState();
+      registerEvents(); // wire cross-extension listeners
       // Re-apply badges for known sessions
       Object.keys(O.aliases).forEach(k => updateBadge(k, 'active'));
       speakText('Session Orchestrator enabled.');
@@ -558,6 +609,7 @@
         window._origVoiceModeSendRestore();
       }
       if (O._busyWatch) { clearInterval(O._busyWatch); O._busyWatch = null; }
+      unregisterEvents(); // detach cross-extension listeners
       // Restore original _handleBgTaskCompleteEvent
       if (O._origHandleBg && typeof window._handleBgTaskCompleteEvent !== 'undefined') {
         window._handleBgTaskCompleteEvent = O._origHandleBg;

--- a/extensions/session-orchestrator/extension.json
+++ b/extensions/session-orchestrator/extension.json
@@ -1,0 +1,44 @@
+{
+  "id": "session-orchestrator",
+  "name": "Session Orchestrator",
+  "description": "Voice-commanded multi-session orchestration for Hermes WebUI — create, switch, prompt, and monitor concurrent agent sessions hands-free via speech commands.",
+  "version": "0.1.0",
+  "author": "ChonSong",
+  "assets": {
+    "scripts": [
+      "assets/orchestrator.js"
+    ],
+    "stylesheets": []
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": ["session", "sessions"],
+      "write": ["session/draft"]
+    },
+    "webui_navigation": true,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": true
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false
+  }
+}

--- a/extensions/session-orchestrator/manifest.json
+++ b/extensions/session-orchestrator/manifest.json
@@ -1,0 +1,42 @@
+{
+  "extensions": [
+    {
+      "id": "session-orchestrator",
+      "name": "Session Orchestrator",
+      "description": "Voice-commanded multi-session orchestration — manage concurrent agent sessions via speech or text commands.",
+      "scripts": [
+        "assets/orchestrator.js"
+      ],
+      "permissions": {
+        "dom": { "owned": true, "mutates_core_views": true },
+        "storage": { "owned": true },
+        "webui_api": { "read": ["session", "sessions"], "write": ["session/draft"] },
+        "webui_navigation": true,
+        "network_external": false,
+        "filesystem": { "arbitrary": false, "serves_bundled_assets": true },
+        "loopback_sidecar": false,
+        "native_host": false
+      },
+      "settings_schema": [
+        {
+          "key": "auto_notify",
+          "type": "boolean",
+          "label": "Play chime on session completion",
+          "default": true
+        },
+        {
+          "key": "speak_notifications",
+          "type": "boolean",
+          "label": "Speak completion alerts via TTS",
+          "default": true
+        },
+        {
+          "key": "silence_command_ms",
+          "type": "integer",
+          "label": "Silence threshold before command dispatch (ms)",
+          "default": 1800
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Session Orchestrator — Voice-Commanded Multi-Session Management

A new extension that lets users create, switch, prompt, read, and monitor
concurrent agent sessions using voice commands or text shortcuts.

### Thinking Path

The existing voice mode (boot.js) provides SpeechRecognition + TTS but routes
everything to the composer textarea. The chat-tiling extension provides a
multi-session grid but no voice integration. The SessionChannel SSE delivers
background-task-complete events but has no consumer outside `messages.js`.

This extension sits at the intersection: it hijacks `_voiceModeSend` to parse
commands before they reach the send pipeline, uses `registerAlias`/`resolveAlias`
to map friendly names to session IDs, and wires into the existing notification
system (`playAttentionSound`, `sendBrowserNotification`, `_handleBgTaskCompleteEvent`)
for async completion alerts.

### What Changed

```
extensions/session-orchestrator/
├── assets/orchestrator.js   — full extension logic (~530 lines)
├── extension.json           — gallery metadata with permissions
├── manifest.json            — runtime manifest + settings_schema
└── README.md                — install, usage, trust model, limitations
```

### Key Decisions

1. **No new backend routes.** Everything rides on existing infrastructure:
   `window.newSession()`, `_voiceModeSend`, `_handleBgTaskCompleteEvent`,
   `playAttentionSound`, `sendBrowserNotification`.
2. **Command parser is a pure function** (~20 lines, object schema + regex
   matching). No FSM library dependency — the existing voice mode already has
   the state machine (`_voiceModeState: idle|listening|thinking|speaking`).
3. **Alias registry persists to localStorage** (`hwx-orch-state` key). Survives
   page refreshes and tab crashes.
4. **Phase 1 is extension-only.** Phase 2 (containerized desktop environments)
   would use the hermes-desktop pattern and is explicitly called out as a
   limitation in the README.

### Why It Matters

- Solves the "I want to start a research session while waiting for the code
  review session to finish" workflow without tab-juggling
- Voice-first input means users can manage sessions while keeping hands on
  keyboard for actual work (or while away from the desk)
- Composable with chat-tiling (badges on sidebar rows, tile maximize)

### Verification

- `node scripts/validate-extensions.mjs` — passes
- `node scripts/scan-extension-safety.mjs` — passes (orchestrator section clean)
- `node --check extensions/session-orchestrator/assets/orchestrator.js` — syntax ok

### Risks / Follow-Ups

- **Phase 2** would need a Docker sidecar and `hermes-desktop`-style container
  provisioning — gated behind `settings.phase2_enabled`
- **Voice-only workflows** need the user to first enable voice mode (Settings →
  Preferences). The extension detects missing SpeechRecognition and degrades to
  text-only gracefully.
- **Chat-tiling integration** is optional — the extension works standalone.

### Model Used

DeepSeek V4 Flash via Hermes Agent (opencode-go provider)

## Cross-Extension Event Integration

The orchestrator now participates in the shared CustomEvents bus so it can both
reflect and drive sibling extensions (emotion-avatar #56, FAC connector #53).

### Listens (read-only)
- `hermes:avatar:expression` — mirrors the avatar's current expression into the
  status badge tooltip. No state coupling.
- `hermes:voice:state` — mirrors voice activity into the status badge dataset.

### Dispatches
- `hermes:agent:state` — `{ action, expression, ... }`:
  - `switchSession` → `expression: 'thinking'` (avatar shifts to thinking via the
    `external` source, priority 1 — above llm/agent polling, below FAC voice).
  - `sessionComplete` → `expression: 'idle'`.

All communication is via `window` CustomEvents — no shared globals or direct
function calls. Each extension can be installed independently and the others
degrade gracefully. End-to-end: "switch to coding" → `hermes:agent:state` →
avatar `thinking`.