### PR TITLE
Add Paperclip session hider extension

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -22,6 +22,8 @@ need it and maintainers agree on the shared contract.
   drawer close X, and long-press shortcuts for the existing Hermes WebUI mobile drawer.
 - `message-pins`: pin individual messages in a conversation, with a header
   popover, click-to-jump, and client-side per-session persistence.
+- `paperclip-session-hider`: hide repeated Paperclip/Hermes tool-origin
+  `Tool Session` rows from the conversation sidebar without deleting sessions.
 - `model-favorites`: star your most-used models; favorites are promoted to a
   ★ Favorites group at the top of the composer model picker.
 - `custom-avatar`: give the assistant a custom avatar image in the chat

--- a/extensions/paperclip-session-hider/README.md
+++ b/extensions/paperclip-session-hider/README.md
@@ -1,0 +1,114 @@
+# Paperclip Session Hider
+
+Paperclip Session Hider keeps Hermes WebUI's conversation sidebar focused by
+hiding Paperclip/Hermes **tool-origin** rows such as repeated generic
+`Tool Session` entries.
+
+It is intentionally narrow:
+
+- it does **not** delete, archive, rename, or modify sessions;
+- it only hides rows in the current browser DOM;
+- sessions remain available through WebUI search/API/storage and reappear when
+  the extension is disabled;
+- by default it hides only generic `Tool Session` rows, so named tool-origin
+  sessions such as approval or merge-gate sessions remain visible.
+
+## Why not a built-in WebUI setting?
+
+Hermes WebUI currently has native settings for broader source classes:
+
+- **Settings → Preferences → Show non-WebUI sessions** (`show_cli_sessions`) hides
+  or shows external/agent sessions as a coarse group.
+- Recent WebUI builds also include **Show Claude Code sessions**
+  (`show_claude_code_sessions`) for the Claude Code source.
+- Webhook and cron sources have their own toggles where supported.
+
+There is no native Paperclip/tool-origin equivalent such as `show_tool_sessions`
+or a per-source Paperclip sidebar filter. This extension fills that gap without a
+core WebUI patch.
+
+## Settings
+
+Open **Settings → Extensions → Paperclip Session Hider**.
+
+- **Hide Paperclip tool sessions** — master enable/disable toggle.
+- **Rows to hide**:
+  - **Generic Tool Session rows only** (default): hides rows whose source metadata
+    is `tool`/`paperclip` and whose title is `Tool Session` or `Tool`.
+  - **All tool-origin rows**: hides every row with `tool`/`paperclip` source
+    metadata, including named approval sessions.
+
+The default mode is conservative so important named approval sessions are not
+hidden by accident.
+
+## Install
+
+Install it from the Hermes WebUI extension gallery/registry when available. For a
+manual trusted-local install, copy this directory into the configured WebUI
+extension directory and enable its manifest bundle.
+
+```text
+extensions/paperclip-session-hider/
+  README.md
+  extension.json
+  manifest.json
+  assets/
+```
+
+Refresh the WebUI tab after installation if your WebUI build does not hot-reload
+extension manifests.
+
+## Disable or uninstall
+
+- Disable it from **Settings → Extensions** to show all rows again.
+- Or uninstall/remove the extension directory from the configured extension
+  directory.
+
+No session data cleanup is required because the extension does not write to
+session storage or backend APIs. Browser-local settings may remain under the
+extension-owned settings namespace.
+
+## Trust model and permissions
+
+This is a trusted local static UI extension. It:
+
+- reads `/api/sessions` from the same WebUI origin to map rendered sidebar row IDs
+  to session source metadata;
+- uses a scoped `MutationObserver` on `#sessionList` so rows stay hidden after
+  sidebar refreshes, polling updates, search changes, and virtualization rerenders;
+- adds/removes extension-owned CSS classes on `.session-item[data-sid]` and
+  `.session-child-session[data-sid]` rows;
+- uses WebUI's sanctioned `HermesExtensionSettings` API for browser-local
+  settings, with a legacy localStorage fallback for older builds.
+
+It does not use external network access, a sidecar, native host, filesystem
+access, cookies, or WebUI write APIs.
+
+## Compatibility and limitations
+
+Tested against Hermes WebUI builds that expose:
+
+- manifest-bundle extension loading;
+- `/api/sessions` with `session_source` / `raw_source` / `source_tag` /
+  `source_label` metadata;
+- sidebar rows with `.session-item[data-sid]` (and child rows with
+  `.session-child-session[data-sid]`);
+- `HermesExtensionSettings` for native extension settings.
+
+If metadata is temporarily unavailable, the extension falls back only when a DOM
+row has a generated timestamp-style session id and is titled exactly `Tool Session`
+/ `Tool`. Once `/api/sessions` is available, explicit non-tool metadata wins and
+prevents hiding ordinary WebUI/cron/messaging sessions even if they happen to have
+the same title.
+
+While WebUI batch-select mode is active, the extension unhides rows temporarily so
+bulk selection actions are not applied to an invisible subset.
+
+## Verification
+
+```bash
+node --check extensions/paperclip-session-hider/assets/paperclip-session-hider.js
+node scripts/test-paperclip-session-hider.mjs
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+```

--- a/extensions/paperclip-session-hider/assets/paperclip-session-hider.css
+++ b/extensions/paperclip-session-hider/assets/paperclip-session-hider.css
@@ -1,0 +1,5 @@
+.session-item.hwx-psh-hidden,
+.session-child-session.hwx-psh-hidden,
+.session-date-group.hwx-psh-date-group-hidden {
+  display: none !important;
+}

--- a/extensions/paperclip-session-hider/assets/paperclip-session-hider.js
+++ b/extensions/paperclip-session-hider/assets/paperclip-session-hider.js
@@ -1,0 +1,293 @@
+(() => {
+  'use strict';
+
+  // ── Paperclip Session Hider for Hermes WebUI ─────────────────────────────
+  // Hides Paperclip/Hermes tool-origin session rows from the conversation
+  // sidebar. It does not delete, archive, rename, or mutate sessions; it only
+  // applies extension-owned CSS classes to rendered sidebar rows.
+
+  const EXT = 'paperclip-session-hider';
+  if (window.__hermesPaperclipSessionHiderLoaded) return;
+  window.__hermesPaperclipSessionHiderLoaded = true;
+
+  const LEGACY_SETTINGS_KEY = 'hermes-ext-paperclip-session-hider';
+  const HIDDEN_ROW_CLASS = 'hwx-psh-hidden';
+  const HIDDEN_GROUP_CLASS = 'hwx-psh-date-group-hidden';
+  const MODE_GENERIC = 'generic-tool';
+  const MODE_ALL_TOOL = 'all-tool-source';
+  const MODE_VALUES = new Set([MODE_GENERIC, MODE_ALL_TOOL]);
+  const FETCH_DEBOUNCE_MS = 400;
+  const REFRESH_AFTER_MS = 15000;
+
+  const DEFAULT_SETTINGS = Object.freeze({
+    enabled: true,
+    mode: MODE_GENERIC,
+  });
+
+  let sessionsById = new Map();
+  let observer = null;
+  let applyTimer = 0;
+  let fetchTimer = 0;
+  let fetchInFlight = false;
+  let lastFetchAt = 0;
+  let lastFetchAttemptAt = 0;
+
+  function normalizeString(value) {
+    return String(value == null ? '' : value).trim();
+  }
+
+  function normalizeTitle(value) {
+    return normalizeString(value).replace(/\s+/g, ' ').toLowerCase();
+  }
+
+  function normalizeMode(value) {
+    return MODE_VALUES.has(value) ? value : DEFAULT_SETTINGS.mode;
+  }
+
+  function readLegacySettings() {
+    try {
+      const raw = localStorage.getItem(LEGACY_SETTINGS_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch (_) {
+      return {};
+    }
+  }
+
+  function extensionSettings() {
+    try {
+      const api = window.HermesExtensionSettings;
+      if (api && typeof api.settingsForExtension === 'function') {
+        const settings = api.settingsForExtension(EXT);
+        if (settings && settings.supported) return settings;
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  function loadSettings() {
+    const api = extensionSettings();
+    if (api) {
+      return {
+        enabled: api.get('enabled') !== false,
+        mode: normalizeMode(api.get('mode')),
+      };
+    }
+    const source = readLegacySettings();
+    return {
+      enabled: source.enabled !== false,
+      mode: normalizeMode(source.mode),
+    };
+  }
+
+  function sourceValues(session) {
+    if (!session || typeof session !== 'object') return [];
+    return [
+      session.session_source,
+      session.raw_source,
+      session.source_tag,
+      session.source,
+      session.source_label,
+    ].map((value) => normalizeString(value).toLowerCase()).filter(Boolean);
+  }
+
+  function isToolSourceSession(session) {
+    const values = sourceValues(session);
+    return values.includes('tool') || values.includes('paperclip');
+  }
+
+  function isGenericToolTitle(title) {
+    const clean = normalizeTitle(title);
+    return clean === 'tool session' || clean === 'tool';
+  }
+
+  function isGeneratedToolSessionId(sessionId) {
+    return /^\d{8}_\d{6}_[a-f0-9]{6,}$/i.test(normalizeString(sessionId));
+  }
+
+  function rowTitle(row) {
+    if (!row) return '';
+    const title = row.querySelector && row.querySelector('.session-title');
+    return title ? title.textContent : row.textContent;
+  }
+
+  function shouldHideSession(session, settings, fallbackTitle = '', fallbackSid = '') {
+    const effective = settings || DEFAULT_SETTINGS;
+    if (!effective.enabled) return false;
+
+    const title = normalizeString((session && session.title) || fallbackTitle);
+    const sid = normalizeString((session && session.session_id) || fallbackSid);
+    const sources = sourceValues(session);
+    const toolSource = sources.includes('tool') || sources.includes('paperclip');
+
+    // If the server tells us this is a normal WebUI/cron/messaging row, do not
+    // hide it just because a user or automation named it "Tool Session". The
+    // metadata-unavailable fallback is deliberately stricter: it requires the
+    // generic title AND the generated timestamp-style session id shape used by
+    // Paperclip/Hermes tool-origin sessions. Session objects can exist before
+    // source metadata is populated, so only explicit non-tool source values block
+    // the fallback.
+    if (!toolSource) {
+      if (sources.length > 0) return false;
+      return isGenericToolTitle(title) && isGeneratedToolSessionId(sid);
+    }
+    if (effective.mode === MODE_ALL_TOOL) return true;
+    return isGenericToolTitle(title);
+  }
+
+  function sameOriginSessionsUrl() {
+    const qs = new URLSearchParams();
+    qs.set('exclude_hidden', '1');
+    return '/api/sessions?' + qs.toString();
+  }
+
+  async function refreshSessions() {
+    if (fetchInFlight) return;
+    fetchInFlight = true;
+    lastFetchAttemptAt = Date.now();
+    try {
+      const response = await fetch(sameOriginSessionsUrl(), {
+        credentials: 'same-origin',
+        cache: 'no-store',
+      });
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      const payload = await response.json();
+      const next = new Map();
+      const rows = [];
+      if (Array.isArray(payload && payload.sessions)) rows.push(...payload.sessions);
+      if (Array.isArray(payload && payload.sidebar_reference_sessions)) rows.push(...payload.sidebar_reference_sessions);
+      for (const session of rows) {
+        if (session && session.session_id) next.set(String(session.session_id), session);
+      }
+      sessionsById = next;
+      lastFetchAt = Date.now();
+    } catch (_) {
+      // Metadata fetch failures should not break the sidebar. The DOM title
+      // fallback still hides generic "Tool Session" rows until the API recovers.
+    } finally {
+      fetchInFlight = false;
+      scheduleApply();
+    }
+  }
+
+  function scheduleFetch(delay = FETCH_DEBOUNCE_MS) {
+    if (fetchTimer) clearTimeout(fetchTimer);
+    fetchTimer = setTimeout(() => {
+      fetchTimer = 0;
+      refreshSessions();
+    }, Math.max(0, delay));
+  }
+
+  function shouldPauseForBatchSelection(list) {
+    return !!(list && list.querySelector('.session-select-bar'));
+  }
+
+  function applyGroupVisibility(list) {
+    if (!list) return;
+    const groups = list.querySelectorAll('.session-date-group');
+    for (const group of groups) {
+      const body = group.querySelector('.session-date-body');
+      if (!body || body.querySelector('.session-virtual-spacer')) {
+        group.classList.remove(HIDDEN_GROUP_CLASS);
+        continue;
+      }
+      const visibleRows = body.querySelectorAll(
+        '.session-item:not(.' + HIDDEN_ROW_CLASS + '), .session-child-session:not(.' + HIDDEN_ROW_CLASS + ')'
+      );
+      group.classList.toggle(HIDDEN_GROUP_CLASS, visibleRows.length === 0);
+    }
+  }
+
+  function unhideAll(list) {
+    if (!list) return;
+    for (const row of list.querySelectorAll('.' + HIDDEN_ROW_CLASS)) {
+      row.classList.remove(HIDDEN_ROW_CLASS);
+      row.removeAttribute('aria-hidden');
+    }
+    for (const group of list.querySelectorAll('.' + HIDDEN_GROUP_CLASS)) {
+      group.classList.remove(HIDDEN_GROUP_CLASS);
+    }
+  }
+
+  function applyHiddenRows() {
+    const list = document.getElementById('sessionList');
+    if (!list) return;
+
+    if (shouldPauseForBatchSelection(list)) {
+      unhideAll(list);
+      return;
+    }
+
+    const settings = loadSettings();
+    let sawUnknownSid = false;
+    const rows = list.querySelectorAll('.session-item[data-sid], .session-child-session[data-sid]');
+    for (const row of rows) {
+      const sid = row.dataset && row.dataset.sid;
+      const session = sid ? sessionsById.get(String(sid)) : null;
+      if (sid && !session) sawUnknownSid = true;
+      const hide = shouldHideSession(session, settings, rowTitle(row), sid);
+      row.classList.toggle(HIDDEN_ROW_CLASS, hide);
+      if (hide) row.setAttribute('aria-hidden', 'true');
+      else row.removeAttribute('aria-hidden');
+    }
+    applyGroupVisibility(list);
+    try {
+      document.documentElement.dataset.hwxPaperclipSessionHider = settings.enabled ? 'enabled' : 'disabled';
+    } catch (_) {}
+
+    if (sawUnknownSid && Date.now() - lastFetchAttemptAt > REFRESH_AFTER_MS) scheduleFetch();
+  }
+
+  function scheduleApply() {
+    if (applyTimer) return;
+    applyTimer = requestAnimationFrame(() => {
+      applyTimer = 0;
+      applyHiddenRows();
+    });
+  }
+
+  function observeSidebar() {
+    const list = document.getElementById('sessionList');
+    if (!list || observer) return;
+    observer = new MutationObserver((mutations) => {
+      let shouldFetch = false;
+      for (const mutation of mutations) {
+        if (mutation.type === 'childList' && mutation.addedNodes && mutation.addedNodes.length) {
+          shouldFetch = true;
+          break;
+        }
+      }
+      scheduleApply();
+      if (shouldFetch) scheduleFetch();
+    });
+    observer.observe(list, { childList: true, subtree: true });
+  }
+
+  function start() {
+    observeSidebar();
+    scheduleFetch(0);
+    scheduleApply();
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) scheduleFetch(0);
+    });
+    document.addEventListener('change', scheduleApply, true);
+    window.addEventListener('storage', (event) => {
+      if (!event.key || event.key.includes(EXT) || event.key.includes(encodeURIComponent(EXT))) scheduleApply();
+    });
+  }
+
+  window.hermesExt = window.hermesExt || {};
+  window.hermesExt.paperclipSessionHider = {
+    shouldHideSession,
+    isToolSourceSession,
+    isGenericToolTitle,
+    isGeneratedToolSessionId,
+    loadSettings,
+    applyHiddenRows,
+    refreshSessions,
+  };
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start, { once: true });
+  else start();
+})();

--- a/extensions/paperclip-session-hider/extension.json
+++ b/extensions/paperclip-session-hider/extension.json
@@ -1,0 +1,75 @@
+{
+  "id": "paperclip-session-hider",
+  "name": "Paperclip Session Hider",
+  "description": "Hide Paperclip/Hermes tool-origin session rows such as repeated generic \"Tool Session\" entries from the Hermes WebUI conversation sidebar without deleting or archiving them.",
+  "version": "0.1.0",
+  "author": "nesquena-hermes",
+  "assets": {
+    "scripts": [
+      "assets/paperclip-session-hider.js"
+    ],
+    "stylesheets": [
+      "assets/paperclip-session-hider.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [
+        "sessions"
+      ],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": true,
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": false
+  },
+  "settings_schema": [
+    {
+      "key": "enabled",
+      "type": "boolean",
+      "label": "Hide Paperclip tool sessions",
+      "description": "Hide matching tool-origin rows from the conversation sidebar. This only changes visibility in this browser.",
+      "default": true
+    },
+    {
+      "key": "mode",
+      "type": "enum",
+      "label": "Rows to hide",
+      "description": "Generic mode hides repeated Tool Session rows only. All tool-origin mode also hides named tool-origin rows such as approval sessions.",
+      "options": [
+        {
+          "value": "generic-tool",
+          "label": "Generic Tool Session rows only"
+        },
+        {
+          "value": "all-tool-source",
+          "label": "All tool-origin rows"
+        }
+      ],
+      "default": "generic-tool"
+    }
+  ]
+}

--- a/extensions/paperclip-session-hider/manifest.json
+++ b/extensions/paperclip-session-hider/manifest.json
@@ -1,0 +1,15 @@
+{
+  "extensions": [
+    {
+      "id": "paperclip-session-hider",
+      "name": "Paperclip Session Hider",
+      "description": "Hide Paperclip/Hermes tool-origin rows from the conversation sidebar.",
+      "scripts": [
+        "assets/paperclip-session-hider.js"
+      ],
+      "stylesheets": [
+        "assets/paperclip-session-hider.css"
+      ]
+    }
+  ]
+}

--- a/scripts/test-paperclip-session-hider.mjs
+++ b/scripts/test-paperclip-session-hider.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../extensions/paperclip-session-hider/assets/paperclip-session-hider.js', import.meta.url), 'utf8');
+
+class FakeClassList {
+  constructor() { this.values = new Set(); }
+  add(name) { this.values.add(name); }
+  remove(name) { this.values.delete(name); }
+  toggle(name, force) {
+    const on = force === undefined ? !this.values.has(name) : !!force;
+    if (on) this.add(name);
+    else this.remove(name);
+    return on;
+  }
+  contains(name) { return this.values.has(name); }
+}
+
+const fakeDocument = {
+  readyState: 'loading',
+  addEventListener() {},
+  getElementById() { return null; },
+  documentElement: { dataset: {} },
+};
+
+const context = {
+  window: {},
+  document: fakeDocument,
+  localStorage: {
+    getItem() { return null; },
+    setItem() {},
+    removeItem() {},
+  },
+  URLSearchParams,
+  Map,
+  Set,
+  Date,
+  JSON,
+  String,
+  Array,
+  Number,
+  Object,
+  Error,
+  console,
+  fetch: async () => ({ ok: true, json: async () => ({ sessions: [] }) }),
+  MutationObserver: class { observe() {} disconnect() {} },
+  requestAnimationFrame(fn) { fn(); return 1; },
+  clearTimeout() {},
+  setTimeout(fn) { fn(); return 1; },
+};
+context.window = context;
+vm.runInNewContext(source, context, { filename: 'paperclip-session-hider.js' });
+
+const api = context.window.hermesExt.paperclipSessionHider;
+assert.equal(typeof api.shouldHideSession, 'function');
+assert.equal(typeof api.isToolSourceSession, 'function');
+
+const generic = { session_id: 'a', title: 'Tool Session', session_source: 'tool', raw_source: 'tool' };
+const named = { session_id: 'b', title: 'PATA-434 Final Merge Approval', session_source: 'tool', raw_source: 'tool' };
+const webuiNamedTool = { session_id: 'c', title: 'Tool Session', session_source: 'webui', raw_source: 'webui' };
+const cron = { session_id: 'd', title: 'Daily Infrastructure Cheatsheet', session_source: 'cron', raw_source: 'cron' };
+const paperclipSource = { session_id: 'e', title: 'Tool', source_label: 'Paperclip' };
+
+assert.equal(api.shouldHideSession(generic, { enabled: true, mode: 'generic-tool' }), true, 'generic tool source rows are hidden by default');
+assert.equal(api.shouldHideSession(named, { enabled: true, mode: 'generic-tool' }), false, 'named approval/tool rows stay visible by default');
+assert.equal(api.shouldHideSession(named, { enabled: true, mode: 'all-tool-source' }), true, 'all-tool mode hides named tool-origin rows');
+assert.equal(api.shouldHideSession(webuiNamedTool, { enabled: true, mode: 'generic-tool' }), false, 'explicit WebUI metadata prevents title-only false positives');
+assert.equal(api.shouldHideSession({ session_id: '20260710_080154_1fa39a', title: 'Tool Session' }, { enabled: true, mode: 'generic-tool' }), true, 'missing source metadata still uses generated-id fallback');
+assert.equal(api.shouldHideSession({ session_id: '20260710_080154_1fa39a', title: 'Tool Session', source_label: 'WebUI' }, { enabled: true, mode: 'generic-tool' }), false, 'explicit non-tool source blocks generated-id fallback');
+assert.equal(api.shouldHideSession(cron, { enabled: true, mode: 'all-tool-source' }), false, 'cron rows are never hidden');
+assert.equal(api.shouldHideSession(null, { enabled: true, mode: 'generic-tool' }, 'Tool Session'), false, 'DOM fallback without a generated session id does not hide user rows');
+assert.equal(api.shouldHideSession(null, { enabled: true, mode: 'generic-tool' }, 'Tool Session', '20260710_080154_1fa39a'), true, 'DOM fallback hides generic generated tool session ids while metadata is unavailable');
+assert.equal(api.shouldHideSession(null, { enabled: true, mode: 'generic-tool' }, 'PATA-434 Final Merge Approval', '20260709_235243_5be8d5'), false, 'DOM fallback does not hide named sessions');
+assert.equal(api.shouldHideSession(paperclipSource, { enabled: true, mode: 'generic-tool' }), true, 'Paperclip source label is treated as tool-origin');
+assert.equal(api.shouldHideSession(generic, { enabled: false, mode: 'all-tool-source' }), false, 'disabled setting unhides rows');
+
+const settingsApiCalls = [];
+context.window.HermesExtensionSettings = {
+  settingsForExtension(id) {
+    assert.equal(id, 'paperclip-session-hider');
+    return {
+      supported: true,
+      get(key) {
+        settingsApiCalls.push(key);
+        return key === 'enabled' ? false : 'all-tool-source';
+      },
+    };
+  },
+};
+const loadedSettings = api.loadSettings();
+assert.equal(loadedSettings.enabled, false, 'settings enabled flag is read through the documented .get(key) API');
+assert.equal(loadedSettings.mode, 'all-tool-source', 'settings mode is read through the documented .get(key) API');
+assert.deepEqual(settingsApiCalls, ['enabled', 'mode'], 'settings API reads both declared keys');
+delete context.window.HermesExtensionSettings;
+
+const row = {
+  dataset: { sid: 'a' },
+  classList: new FakeClassList(),
+  attrs: {},
+  titleText: 'Tool Session',
+  querySelector(selector) {
+    if (selector === '.session-title') return { textContent: this.titleText };
+    return null;
+  },
+  setAttribute(name, value) { this.attrs[name] = value; },
+  removeAttribute(name) { delete this.attrs[name]; },
+};
+
+assert.equal(api.isGenericToolTitle('  Tool   Session  '), true, 'title normalization is whitespace tolerant');
+assert.equal(api.isGeneratedToolSessionId('20260710_080154_1fa39a'), true, 'generated tool session id fallback shape is recognized');
+assert.equal(api.isGeneratedToolSessionId('ed941f8728f3'), false, 'normal WebUI hex ids are not treated as generated tool session ids');
+assert.equal(api.isToolSourceSession({ source_tag: 'TOOL' }), true, 'source matching is case-insensitive');
+assert.equal(api.isToolSourceSession({ source_label: 'WebUI' }), false, 'ordinary source label is not matched');
+
+console.log('paperclip-session-hider tests passed');


### PR DESCRIPTION
## Summary
- add a trusted local Paperclip Session Hider extension for Hermes WebUI
- hide repeated generic `Tool Session` sidebar rows from tool-origin metadata by default
- expose Settings → Extensions toggles for enablement and conservative/all-tool matching modes

## Verification
- `node --check extensions/paperclip-session-hider/assets/paperclip-session-hider.js`
- `node --check scripts/test-paperclip-session-hider.mjs`
- `node scripts/test-paperclip-session-hider.mjs`
- `python3 -m json.tool extensions/paperclip-session-hider/extension.json >/dev/null`
- `python3 -m json.tool extensions/paperclip-session-hider/manifest.json >/dev/null`
- `node scripts/validate-extensions.mjs`
- `node scripts/scan-extension-safety.mjs`
- `node scripts/generate-registry.mjs --out /tmp/paperclip-session-hider-registry.json`
- `node scripts/test-extension-validator.mjs`
- `git diff --check origin/main...HEAD`

## Notes
- The default mode hides generic `Tool Session` rows only; named tool-origin rows remain visible unless the user opts into hiding all tool-origin rows.
- The extension is DOM-only for visibility and does not delete, archive, rename, or modify sessions.
