### PR TITLE
feat: sidecar scaffold + contract (companion to core token-v1 auth)

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -6,6 +6,7 @@ on:
       - 'extensions/**'
       - 'scripts/**'
       - 'examples/sidecar-scaffold/**'
+      - 'examples/loopback-sidecar/**'
       - 'README.md'
       - 'docs/extension-entry.md'
       - 'docs/SIDECAR_CONTRACT.md'
@@ -18,6 +19,7 @@ on:
       - 'extensions/**'
       - 'scripts/**'
       - 'examples/sidecar-scaffold/**'
+      - 'examples/loopback-sidecar/**'
       - 'README.md'
       - 'docs/extension-entry.md'
       - 'docs/SIDECAR_CONTRACT.md'
@@ -69,6 +71,9 @@ jobs:
 
       - name: Check sidecar usage (no rogue servers / correct ExecStart)
         run: node scripts/check-sidecar-usage.mjs
+
+      - name: Validate Desktop Companion and loopback example
+        run: node scripts/validate-desktop-companion.mjs
 
       - name: Generate registry
         run: node scripts/generate-registry.mjs --out dist/registry.json

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -5,8 +5,10 @@ on:
     paths:
       - 'extensions/**'
       - 'scripts/**'
+      - 'examples/sidecar-scaffold/**'
       - 'README.md'
       - 'docs/extension-entry.md'
+      - 'docs/SIDECAR_CONTRACT.md'
       - 'docs/rfcs/0001-extension-json-schema.md'
       - '.github/workflows/extensions.yml'
   push:
@@ -15,8 +17,10 @@ on:
     paths:
       - 'extensions/**'
       - 'scripts/**'
+      - 'examples/sidecar-scaffold/**'
       - 'README.md'
       - 'docs/extension-entry.md'
+      - 'docs/SIDECAR_CONTRACT.md'
       - 'docs/rfcs/0001-extension-json-schema.md'
       - '.github/workflows/extensions.yml'
 
@@ -40,11 +44,22 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Validate extension entries
         run: node scripts/validate-extensions.mjs
 
       - name: Test extension validator
         run: node scripts/test-extension-validator.mjs
+
+      - name: Test sidecar contract enforcement
+        run: node scripts/test-sidecar-contract.mjs
+
+      - name: Test canonical sidecar scaffold
+        run: python scripts/test-sidecar-scaffold.py
 
       - name: Scan extension safety gates
         run: node scripts/scan-extension-safety.mjs

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Scan extension safety gates
         run: node scripts/scan-extension-safety.mjs
 
+      - name: Check sidecar scaffold is in sync
+        run: node scripts/sync-sidecar-base.mjs --check
+
+      - name: Check sidecar usage (no rogue servers / correct ExecStart)
+        run: node scripts/check-sidecar-usage.mjs
+
       - name: Generate registry
         run: node scripts/generate-registry.mjs --out dist/registry.json
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Extension entries should document:
 - manual verification steps
 - any future CI check that should protect the extension
 
-The long-term goal is for this repository to validate existing extension
-entries as the main WebUI extension contract evolves.
+This repository validates existing extension entries as the main WebUI extension
+contract evolves.
 
 Run the current repo-wide checks locally with:
 
@@ -122,6 +122,7 @@ The one-click **install flow and registry UI shipped in core** (Settings →
 Extensions: browse the registry, review permissions, install/uninstall with
 sha256 verification). Merged entries here are validated + safety-scanned in CI,
 published to the registry, and become one-click-installable from inside WebUI.
-The Tier-A loopback sidecar proxy remains future/demand-driven; sidecar-class
-entries currently reach their local backend directly under the loopback CSP
-allowance and should document their manual install + lifecycle explicitly.
+The consent-gated per-extension loopback proxy is shipped. `token-v1` runtimes use
+that same-origin path and validate core's per-install token; explicitly legacy
+external adapters may still use direct loopback under the core CSP allowance.
+Every sidecar entry must document its install and lifecycle requirements.

--- a/README.md
+++ b/README.md
@@ -98,11 +98,16 @@ Run the current repo-wide checks locally with:
 ```bash
 node scripts/validate-extensions.mjs
 node scripts/test-extension-validator.mjs
+node scripts/test-sidecar-contract.mjs
+python3 scripts/test-sidecar-scaffold.py
 node scripts/scan-extension-safety.mjs
+node scripts/sync-sidecar-base.mjs --check
+node scripts/check-sidecar-usage.mjs
+node scripts/validate-desktop-companion.mjs
 node scripts/generate-registry.mjs --out dist/registry.json
 ```
 
-Pull requests run the same validator and safety scan in CI. Pushes to `main`
+Pull requests run the same validation, contract, and safety checks in CI. Pushes to `main`
 generate the registry and per-extension zip artifacts for GitHub Pages. The
 registry entry includes a `download` URL and artifact-level `sha256` for each
 extension so the WebUI install client fetches and verifies reviewed bytes before

--- a/VISION.md
+++ b/VISION.md
@@ -50,19 +50,15 @@ Extensions grow in capability in stages. Each rung is independently shippable.
 2. **Settings UI** ✅ *shipped* — a Settings → Extensions surface: listing,
    enable/disable, and one-click install/uninstall from the gallery (with sha256
    verification against the registry), plus a diagnostics tab.
-3. **Sidecar metadata + direct loopback** *foundation merged (descriptive metadata); direct loopback shipped* — an extension can
-   *declare* a local helper process (`sidecar: { type, origin, health_path }`) so
-   WebUI can show the dependency and, later, report coarse health. **Today**, an
-   extension's JS can talk to a trusted loopback sidecar **directly** — the core
-   CSP `connect-src` already allows `http://127.0.0.1:*` / `localhost` / `ws://`
-   loopback — so direct browser → sidecar is the *current* sidecar-class pattern.
-4. **Backend routes / same-origin proxy** *planned / future* — a **future, opt-in,
-   per-extension same-origin proxy** (`/extensions/<id>/sidecar/*` → the declared
-   loopback origin). This is *not* required for sidecar extensions to work today
-   (see #3 — direct loopback already works); it's future core work for cases the
-   direct path can't cover (e.g. the sidecar's own CORS, hiding the port, uniform
-   same-origin auth). Repo entries should **not** depend on it yet. In-process
-   server route handlers are a later, separately-gated step beyond that.
+3. **Sidecar metadata + direct loopback** ✅ *shipped* — an extension can declare
+   a local helper process (`sidecar: { type, origin, health_path }`) for health and
+   dependency diagnostics. An explicitly legacy external adapter may still use
+   direct browser → loopback access under core's loopback CSP allowance.
+4. **Same-origin sidecar proxy** ✅ *shipped* — core provides an opt-in,
+   consent-gated per-extension proxy (`/api/extensions/<id>/sidecar/*` → the
+   declared loopback origin). `token-v1` runtimes use this path and authenticate
+   every non-health request with the per-install token injected by core. In-process
+   server route handlers remain a later, separately-gated step beyond the proxy.
 
 ## The registry & install experience (target)
 
@@ -92,14 +88,14 @@ Before real entries accumulate, the library gets a compatibility/test layer:
 - **UI-tweak-class extensions** — sidebar items, composer affordances, panels,
   diagnostics, themes-with-logic. (Several are already in flight.)
 - **Richer / sidecar-class extensions** — anything pairing WebUI assets with a
-  trusted local helper process (the Desktop Companion pet assistant is the first
-  candidate driving the sidecar + proxy work).
-- **Foundation** — the registry generator, the manifest/metadata schema, CI
-  validation, and the Settings → Extensions UI.
+  trusted local helper process. Desktop Companion is the reference external,
+  explicitly legacy sidecar; new `token-v1` runtimes use the consented proxy.
+- **Foundation maintenance** — strengthen the registry, manifest/metadata schema,
+  CI validation, and compatibility with the shipped Settings → Extensions UI.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) and
 [`docs/extension-entry.md`](docs/extension-entry.md) for how to structure an
 entry today. Tracking issues break the roadmap above into concrete pieces.
 
-> Status: foundation phase. Conventions here are a basis for review, not a locked
-> marketplace contract yet.
+> Status: active curated library. Conventions remain reviewable rather than a
+> permanently locked marketplace contract.

--- a/docs/SIDECAR_CONTRACT.md
+++ b/docs/SIDECAR_CONTRACT.md
@@ -78,6 +78,10 @@ runtime that has not migrated must declare `proxy_auth: "legacy"` explicitly;
 the validator reports that status rather than treating it as scaffold-compliant.
 Desktop Companion is the current external/legacy compatibility case.
 
+All runtime kinds use core-compatible endpoint syntax: `origin` is a bare
+loopback HTTP(S) origin with no userinfo, path, query, or fragment, and
+`health_path` is an absolute, segment-normalized path with no query or fragment.
+
 The runtime `manifest.json` repeats `type`, `origin`, `health_path`, and
 `proxy_auth` but omits the library-only `runtime` ownership object. CI requires
 the repeated fields to match `extension.json` exactly.
@@ -126,30 +130,55 @@ conformance.
    loopback probe — acceptable for liveness only.
 3. **Missing token file → 503, wrong token → 401**, both fail closed.
 4. **No secrets in the `.service` file.** The token lives in the state dir; the
-   unit only points at the state dir. `WorkingDirectory` must resolve to
-   `<extension-id>/<runtime.path>`, and `ExecStart` must run only that directory's
-   byte-compared `sidecar.py` as `/usr/bin/python3 -S [-u] sidecar.py`, with no
-   trailing command tokens. The mandatory `-S` prevents `sitecustomize` and `.pth`
-   startup hooks from bypassing the byte-compared modules. The `[Service]`
-   section uses a small directive allowlist; auxiliary `Exec*`, environment files,
-   root/image overrides, and other execution-context directives are forbidden because
-   they could execute outside the authenticated scaffold. Direct shebang execution,
-   arbitrary Python-looking executables, `/usr/bin/env` wrappers, and Quadlet
-   `.container` units are rejected because they cannot prove the interpreter or
-   image entrypoint; model those runtimes as externally maintained instead.
+   unit names only the non-secret state and optional custom extension install
+   directory.
+   `WorkingDirectory` must equal
+   `<HERMES_WEBUI_STATE_DIR>/extensions/<extension-id>/<runtime.path>` by
+   default. For an extension installed elsewhere, the unit declares the exact
+   extension entry directory with the sidecar-only `HERMES_EXT_INSTALL_DIR` and
+   `WorkingDirectory` must equal its `<runtime.path>` child. Do not reuse
+   WebUI's `HERMES_WEBUI_EXTENSION_DIR`: WebUI supports both a single-entry
+   development directory and a gallery root, so that variable is intentionally
+   ambiguous here. Custom directories must be absolute or `%h`-anchored and CI
+   emits an explicit reviewer warning. Reviewers must confirm each one is an
+   operator-controlled installation directory, not a broadly writable or
+   untrusted path.
+   `ExecStart` must run that directory's byte-compared `sidecar.py` as
+   `/usr/bin/python3 -S [-u] sidecar.py`, with no command prefix or trailing
+   tokens. The absolute interpreter path and mandatory `-S` prevent PATH,
+   `sitecustomize`, and `.pth` startup hooks from replacing checked modules. If
+   `Type` is present it must be `simple`, matching the foreground scaffold
+   process. The `[Service]` section uses a small directive allowlist; auxiliary
+   `Exec*`, environment files, root/image overrides, and other execution-context
+   directives are forbidden. Systemd `.service.d/*.conf` drop-ins are also
+   forbidden because they can replace the reviewed launch command. Direct
+   shebang execution, arbitrary Python-looking executables, `/usr/bin/env`
+   wrappers, and Quadlet `.container` units cannot prove the interpreter or image
+   entrypoint and must be modeled as external.
 5. **One required route hook, one optional daemon hook.** `routes_impl.register(app)`
    is required, and `routes_impl.py` must be a regular file that defines exactly
    one top-level synchronous `register(app)` binding callable with that one
-   argument. It must apply at least one reachable `@app.route(...)` decorator (or
-   the equivalent direct decorator application) to a handler. A bare
-   `app.route(...)` call registers nothing and is rejected. Later rebinding is
-   rejected. `routes_impl.start_background(app)` is called only when the module
-   defines it.
-6. **The declared vendored tree is the artifact that executes.** Every component
-   of `runtime.path` must be a real directory, not a symlink. Protected scaffold,
-   entrypoint, config, and route files must be real regular files. Python import
-   collisions next to them (`sidecar_base/`, `routes_impl/`, compiled or bytecode
-   variants) are rejected so another module cannot shadow a byte-compared file.
+   argument. That binding is undecorated and must apply at least one
+   `@app.route(...)` decorator (or the equivalent direct decorator application)
+   in its linear body before any control-flow statement. A bare `app.route(...)`
+   call registers nothing and is rejected. Static checks reject direct,
+   imported, assigned, pattern-capture, evaluated-definition (decorator,
+   default, and annotation), and comprehension-walrus rebinding. Dynamic
+   namespace mutation such as
+   `globals()["register"] = ...` is not generally provable and remains a review
+   responsibility. Control-flow statements in `routes_impl.py`'s own module body
+   are also rejected so that file cannot conditionally stop or replace route
+   registration. Imported helper
+   modules remain ordinary reviewed extension code.
+   `routes_impl.start_background(app)` is called only when the module defines it.
+6. **The reviewed extension tree is the artifact that executes.** Every entry
+   beneath an extension root, including declared assets and every component and
+   nested entry of `runtime.path`, must be a real file or directory, never a
+   symlink. Generated registry artifacts therefore package the same tree that
+   validation inspected. Protected scaffold, entrypoint, config, and route files
+   must be real regular files. Python import collisions next to them
+   (`sidecar_base/`, `routes_impl/`, compiled or bytecode variants) are rejected
+   so another module cannot shadow a byte-compared file.
 
 ## Auth-off posture
 

--- a/docs/SIDECAR_CONTRACT.md
+++ b/docs/SIDECAR_CONTRACT.md
@@ -1,10 +1,13 @@
 # Sidecar contract (proxy → sidecar authentication)
 
-Authoritative spec for **loopback-sidecar extensions** — a stdlib HTTP server on
-`127.0.0.1:<port>` that the WebUI proxies to on the extension's behalf. Read this
-before writing a sidecar; use the reference scaffold in
-[`examples/sidecar-scaffold/`](../examples/sidecar-scaffold/) rather than
-hand-rolling.
+Authoritative spec for **loopback-sidecar extensions** — a local HTTP server on
+`127.0.0.1:<port>`. A `token-v1` adapter reaches it through WebUI's same-origin
+proxy; an explicitly legacy external adapter may still use direct loopback
+access. The wire/authentication contract is language-neutral. A runtime committed
+to this repository must use the canonical Python scaffold in
+[`examples/sidecar-scaffold/`](../examples/sidecar-scaffold/); a runtime owned by
+an external repository may implement the same contract in Node, Rust, or another
+language.
 
 ## Why this exists
 
@@ -26,28 +29,79 @@ key, or just run your sidecar's underlying tool directly. No mechanism available
 here (token, HMAC, nonce, Unix socket with `0600`) changes that. Do not claim
 otherwise in your README.
 
-## The manifest field
+## Manifest and runtime ownership
+
+Every library entry declares whether its sidecar runtime is **vendored** in this
+repository or **external**. Discovery comes from this metadata, never from the
+presence of `sidecar_base.py`.
+
+### Repository-vendored runtime
 
 ```json
 "sidecar": {
   "type": "loopback",
   "origin": "http://127.0.0.1:17790",
   "health_path": "/health",
-  "proxy_auth": "token-v1"
+  "proxy_auth": "token-v1",
+  "runtime": {
+    "kind": "vendored",
+    "path": "sidecar"
+  }
 }
 ```
 
+Vendored runtimes must use `token-v1`. CI requires `sidecar_base.py`,
+`sidecar.py`, `sidecar.json`, and `routes_impl.py`; byte-compares the two
+protected scaffold files; and verifies that `sidecar.json` agrees with
+`extension.json` on id, port, and auth mode. Because the canonical scaffold
+serves plain HTTP on IPv4 loopback with a fixed liveness route, vendored metadata
+must use `http://127.0.0.1:<explicit-port>` and `health_path: "/health"`.
+
+### External runtime
+
+```json
+"sidecar": {
+  "type": "loopback",
+  "origin": "http://127.0.0.1:17787",
+  "health_path": "/health",
+  "proxy_auth": "legacy",
+  "runtime": {
+    "kind": "external",
+    "repository": "https://github.com/example/sidecar-runtime"
+  }
+}
+```
+
+External runtimes do not vendor the Python scaffold. `token-v1` external
+runtimes must implement the language-neutral conformance contract below. A
+runtime that has not migrated must declare `proxy_auth: "legacy"` explicitly;
+the validator reports that status rather than treating it as scaffold-compliant.
+Desktop Companion is the current external/legacy compatibility case.
+
+The runtime `manifest.json` repeats `type`, `origin`, `health_path`, and
+`proxy_auth` but omits the library-only `runtime` ownership object. CI requires
+the repeated fields to match `extension.json` exactly.
+
+### Auth modes
+
 - **`token-v1`** — required for any sidecar that mutates state or exposes
   sensitive reads. WebUI injects `X-Hermes-Sidecar-Token`; the sidecar validates.
-- **absent** — explicit **legacy** mode (no token, unchanged behavior). Only for
-  read-only, non-sensitive sidecars. New sidecars should use `token-v1`.
+- **`legacy`** — no token. Allowed only for an explicitly external runtime that
+  has not migrated yet. New sidecars should use `token-v1`.
 - **unknown value** — fails closed (the sidecar declaration is rejected by core).
+
+Core treats an omitted mode as legacy for backward compatibility. This library
+requires the field explicitly so legacy status cannot be mistaken for token-v1
+conformance.
 
 ## The token
 
 - **Provisioned by core**, minted per-extension at
-  `STATE_DIR/sidecar-auth/<id>.token` (mode `0600`), created eagerly and also on
-  consent. The sidecar never mints it — it only reads it.
+  `STATE_DIR/sidecar-auth/<id>.token` (mode `0600`) when the operator grants
+  sidecar-proxy consent. Proxy resolution reads the current persisted token and
+  calls the same atomic provisioner if the file is missing. If the token cannot
+  be persisted and re-read, consent or resolution fails closed with `503`. The
+  sidecar never mints the token — it only reads it.
 - **Header:** `X-Hermes-Sidecar-Token`, injected by the proxy on every forwarded
   request. Core strips any client-supplied `x-hermes-*` inbound (so the browser
   can't forge it) and strips it from responses (so a sidecar can't echo it back).
@@ -55,7 +109,7 @@ otherwise in your README.
   `HERMES_EXT_SIDECAR_TOKEN_FILE` → `$HERMES_WEBUI_STATE_DIR/sidecar-auth/<id>.token`
   → `$HERMES_HOME/webui/sidecar-auth/<id>.token` → platform default
   (`~/.hermes/webui/...`, `%LOCALAPPDATA%\hermes\webui\...` on Windows).
-- **Rotation:** re-read the token per request (the scaffold does — mtime-checked),
+- **Rotation:** re-read the token per request (the scaffold does),
   so deleting/rotating the file takes effect with no restart, and a stale token
   stops validating immediately.
 
@@ -71,17 +125,41 @@ otherwise in your README.
    health means any website can fingerprint which sidecars you run via a drive-by
    loopback probe — acceptable for liveness only.
 3. **Missing token file → 503, wrong token → 401**, both fail closed.
-4. **No secrets in the `.service`/unit file.** The token lives in the state dir;
-   the unit only points at the state dir. `ExecStart` must run `sidecar.py`.
+4. **No secrets in the `.service` file.** The token lives in the state dir; the
+   unit only points at the state dir. `WorkingDirectory` must resolve to
+   `<extension-id>/<runtime.path>`, and `ExecStart` must run only that directory's
+   byte-compared `sidecar.py` as `/usr/bin/python3 -S [-u] sidecar.py`, with no
+   trailing command tokens. The mandatory `-S` prevents `sitecustomize` and `.pth`
+   startup hooks from bypassing the byte-compared modules. The `[Service]`
+   section uses a small directive allowlist; auxiliary `Exec*`, environment files,
+   root/image overrides, and other execution-context directives are forbidden because
+   they could execute outside the authenticated scaffold. Direct shebang execution,
+   arbitrary Python-looking executables, `/usr/bin/env` wrappers, and Quadlet
+   `.container` units are rejected because they cannot prove the interpreter or
+   image entrypoint; model those runtimes as externally maintained instead.
+5. **One required route hook, one optional daemon hook.** `routes_impl.register(app)`
+   is required, and `routes_impl.py` must be a regular file that defines exactly
+   one top-level synchronous `register(app)` binding callable with that one
+   argument. It must apply at least one reachable `@app.route(...)` decorator (or
+   the equivalent direct decorator application) to a handler. A bare
+   `app.route(...)` call registers nothing and is rejected. Later rebinding is
+   rejected. `routes_impl.start_background(app)` is called only when the module
+   defines it.
+6. **The declared vendored tree is the artifact that executes.** Every component
+   of `runtime.path` must be a real directory, not a symlink. Protected scaffold,
+   entrypoint, config, and route files must be real regular files. Python import
+   collisions next to them (`sidecar_base/`, `routes_impl/`, compiled or bytecode
+   variants) are rejected so another module cannot shadow a byte-compared file.
 
 ## Auth-off posture
 
-WebUI authentication is optional and **off by default**. In that mode the consent
-endpoint itself is unauthenticated, so a `token-v1` sidecar is proxied **only when
-its origin is provably loopback** (`127.0.0.1`/`localhost`/`::1`); a non-loopback
-`token-v1` origin returns `503` until a password/passkey is configured. The
-extensions panel surfaces `auth_required` so the operator is prompted to enable
-authentication before wiring up a sidecar. Enabling auth is one field in
+WebUI authentication is optional and **off by default**, but `token-v1` is
+fail-closed in that posture. Both consent and proxy-target resolution return
+`403` until WebUI authentication is configured, regardless of whether the
+sidecar origin is loopback. This prevents an unauthenticated caller from using
+WebUI as a token-bearing forwarding oracle. The extensions status payload uses
+`posture: "local_unprotected"` to prompt the operator; once authentication is
+enabled it reports `posture: "protected"`. Enabling auth is one field in
 **Settings → Password** (or `HERMES_WEBUI_PASSWORD`).
 
 ## The request/response envelope (do not fight it)
@@ -124,11 +202,16 @@ changes, bump the version and re-sync every vendored copy
 
 ## Checklist for a new sidecar
 
-- [ ] `proxy_auth: "token-v1"` in the manifest (unless genuinely read-only/legacy)
-- [ ] vendor `sidecar_base.py` + `sidecar.py` byte-identical from the reference
+- [ ] declare `sidecar.runtime.kind` as `vendored` or `external`
+- [ ] declare `proxy_auth` explicitly in both metadata and runtime manifest
+- [ ] for vendored: use `token-v1` and vendor `sidecar_base.py` + `sidecar.py`
+      byte-identical from the reference
+- [ ] `runtime.path` contains no symlink and no canonical-module import collision
+- [ ] for external token-v1: implement the same header, health, status, rotation,
+      and fail-closed behavior in the external runtime's language
 - [ ] routes only in `routes_impl.py`; no `HTTPServer`/framework server anywhere else
 - [ ] `sidecar.json` = `{id, port, proxy_auth}`
-- [ ] `.service` `ExecStart` runs `sidecar.py`; no token in the unit
+- [ ] `.service` uses `/usr/bin/python3 -S [-u] sidecar.py`; no token in the unit
 - [ ] long ops use start-job + poll; nothing relies on streaming
 - [ ] README states the same-UID scope honestly and the docker limitation
 - [ ] `node scripts/sync-sidecar-base.mjs --check` and

--- a/docs/SIDECAR_CONTRACT.md
+++ b/docs/SIDECAR_CONTRACT.md
@@ -1,0 +1,135 @@
+# Sidecar contract (proxy → sidecar authentication)
+
+Authoritative spec for **loopback-sidecar extensions** — a stdlib HTTP server on
+`127.0.0.1:<port>` that the WebUI proxies to on the extension's behalf. Read this
+before writing a sidecar; use the reference scaffold in
+[`examples/sidecar-scaffold/`](../examples/sidecar-scaffold/) rather than
+hand-rolling.
+
+## Why this exists
+
+The loopback port is reachable by **any local process**, and the WebUI proxy
+strips every inbound credential (cookies, `Authorization`, CSRF, `x-hermes-*`)
+before forwarding — so a sidecar cannot, on its own, tell a request that came
+through the authenticated WebUI proxy from one a random local process sent
+directly. `proxy_auth: token-v1` closes that: WebUI mints a per-extension secret
+and injects it as a header the sidecar validates.
+
+### Threat model — be honest about scope
+
+The token converts *"anyone who can send a loopback TCP packet"* (other-UID
+users, host containers, sandboxed network-only processes) into *"processes that
+can read the user's WebUI state dir"* — the same protection level WebUI's own
+auth already has. It does **not** defend against arbitrary same-UID code: a
+process running as the same user can read the token file, read WebUI's signing
+key, or just run your sidecar's underlying tool directly. No mechanism available
+here (token, HMAC, nonce, Unix socket with `0600`) changes that. Do not claim
+otherwise in your README.
+
+## The manifest field
+
+```json
+"sidecar": {
+  "type": "loopback",
+  "origin": "http://127.0.0.1:17790",
+  "health_path": "/health",
+  "proxy_auth": "token-v1"
+}
+```
+
+- **`token-v1`** — required for any sidecar that mutates state or exposes
+  sensitive reads. WebUI injects `X-Hermes-Sidecar-Token`; the sidecar validates.
+- **absent** — explicit **legacy** mode (no token, unchanged behavior). Only for
+  read-only, non-sensitive sidecars. New sidecars should use `token-v1`.
+- **unknown value** — fails closed (the sidecar declaration is rejected by core).
+
+## The token
+
+- **Provisioned by core**, minted per-extension at
+  `STATE_DIR/sidecar-auth/<id>.token` (mode `0600`), created eagerly and also on
+  consent. The sidecar never mints it — it only reads it.
+- **Header:** `X-Hermes-Sidecar-Token`, injected by the proxy on every forwarded
+  request. Core strips any client-supplied `x-hermes-*` inbound (so the browser
+  can't forge it) and strips it from responses (so a sidecar can't echo it back).
+- **Resolution order** (the scaffold does this for you):
+  `HERMES_EXT_SIDECAR_TOKEN_FILE` → `$HERMES_WEBUI_STATE_DIR/sidecar-auth/<id>.token`
+  → `$HERMES_HOME/webui/sidecar-auth/<id>.token` → platform default
+  (`~/.hermes/webui/...`, `%LOCALAPPDATA%\hermes\webui\...` on Windows).
+- **Rotation:** re-read the token per request (the scaffold does — mtime-checked),
+  so deleting/rotating the file takes effect with no restart, and a stale token
+  stops validating immediately.
+
+## Enforcement rules (what the scaffold guarantees, and you must not weaken)
+
+1. **Deny-by-default at one chokepoint.** Every route except `/health` requires a
+   valid token. Auth is *inherited* from the dispatch loop, never invoked
+   per-route — a forgotten call cannot open a route.
+2. **`/health` is the only tokenless route.** `GET/HEAD /health` returns liveness
+   only (`{"ok": true}`-class), `Cache-Control: no-store`. WebUI probes it
+   cross-origin, so it also carries `Access-Control-Allow-Origin: *`. Do **not**
+   put stats or any sensitive data on `/health`. Accepted trade-off: `ACAO: *`
+   health means any website can fingerprint which sidecars you run via a drive-by
+   loopback probe — acceptable for liveness only.
+3. **Missing token file → 503, wrong token → 401**, both fail closed.
+4. **No secrets in the `.service`/unit file.** The token lives in the state dir;
+   the unit only points at the state dir. `ExecStart` must run `sidecar.py`.
+
+## Auth-off posture
+
+WebUI authentication is optional and **off by default**. In that mode the consent
+endpoint itself is unauthenticated, so a `token-v1` sidecar is proxied **only when
+its origin is provably loopback** (`127.0.0.1`/`localhost`/`::1`); a non-loopback
+`token-v1` origin returns `503` until a password/passkey is configured. The
+extensions panel surfaces `auth_required` so the operator is prompted to enable
+authentication before wiring up a sidecar. Enabling auth is one field in
+**Settings → Password** (or `HERMES_WEBUI_PASSWORD`).
+
+## The request/response envelope (do not fight it)
+
+The proxy fully **buffers** both directions:
+
+| Limit | Value |
+|---|---|
+| Response body | ≤ 512 KiB |
+| Request body | ≤ the proxy cap (≈20 MiB) |
+| Upstream timeout | ≈ 10 s |
+| Streaming / SSE | **not supported** (buffered) |
+
+For work longer than a few seconds, **do not hold the request open** — it will
+502. Use **start-job + poll**:
+
+```
+POST /api/job        -> {"job_id": "..."}        # returns immediately
+GET  /api/job/{id}   -> {"state": "running"|"done", "result": ...}
+```
+
+(This is exactly what a speed test / image pull / long scan needs, independent of
+auth — the 10 s proxy timeout makes it mandatory.)
+
+## Docker limitation
+
+A bridge-networked WebUI container **cannot reach a host-run sidecar's
+`127.0.0.1:<port>`** — loopback is namespace-local. Sidecars work only where core
+and the sidecar share a network namespace and the state dir (sidecar inside the
+WebUI container / shared `hermes-home` volume). **Sidecars are not supported with
+bridge-networked docker installs.**
+
+## Versioning
+
+`sidecar_base.py` carries `SIDECAR_BASE_VERSION`, echoed in `/health` and error
+bodies so an installed-copy drift (users copy directories by hand; CI can't see
+that) is diagnosable from the extensions panel. When the canonical scaffold
+changes, bump the version and re-sync every vendored copy
+(`node scripts/sync-sidecar-base.mjs --write`); CI's `--check` enforces identity.
+
+## Checklist for a new sidecar
+
+- [ ] `proxy_auth: "token-v1"` in the manifest (unless genuinely read-only/legacy)
+- [ ] vendor `sidecar_base.py` + `sidecar.py` byte-identical from the reference
+- [ ] routes only in `routes_impl.py`; no `HTTPServer`/framework server anywhere else
+- [ ] `sidecar.json` = `{id, port, proxy_auth}`
+- [ ] `.service` `ExecStart` runs `sidecar.py`; no token in the unit
+- [ ] long ops use start-job + poll; nothing relies on streaming
+- [ ] README states the same-UID scope honestly and the docker limitation
+- [ ] `node scripts/sync-sidecar-base.mjs --check` and
+      `node scripts/check-sidecar-usage.mjs` pass

--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -269,8 +269,8 @@ Generate the registry locally with:
 node scripts/generate-registry.mjs --out dist/registry.json
 ```
 
-The generated registry is the gallery/install index consumed by future WebUI
-extension UI work. The first version includes the reviewed entry metadata plus
+The generated registry is the gallery/install index consumed by WebUI's shipped
+Settings → Extensions flow. It includes the reviewed entry metadata plus
 Action-added fields such as `entry_path`, `runtime_manifest_path`,
 `published_at`, `file_count`, and per-file `file_sha256` values.
 

--- a/docs/extension-entry.md
+++ b/docs/extension-entry.md
@@ -131,40 +131,43 @@ where the backend has length limits.
 
 ## Sidecar Metadata
 
-Extensions that depend on a local helper process should declare it in manifest
-metadata once the WebUI-side contract supports that field. This lets WebUI show
-users that an extension has a local dependency and eventually report coarse
-health state without hardcoding extension-specific behavior.
+Extensions that depend on a local helper process declare the proxy contract and
+runtime ownership in `extension.json`. This lets WebUI report health without
+hardcoding extension-specific behavior and lets repository CI decide whether a
+runtime must carry the canonical scaffold.
 
 Example shape:
 
 ```json
 {
-  "extensions": [
-    {
-      "id": "desktop-companion",
-      "name": "Desktop Companion",
-      "scripts": ["assets/companion-adapter.js"],
-      "stylesheets": ["assets/companion-adapter.css"],
-      "sidecar": {
-        "type": "loopback",
-        "origin": "http://127.0.0.1:17787",
-        "health_path": "/health"
-      }
+  "sidecar": {
+    "type": "loopback",
+    "origin": "http://127.0.0.1:17787",
+    "health_path": "/health",
+    "proxy_auth": "legacy",
+    "runtime": {
+      "kind": "external",
+      "repository": "https://github.com/franksong2702/hermes-webui-desktop-companion"
     }
-  ]
+  }
 }
 ```
 
-The `sidecar` object should stay descriptive unless the main WebUI repo defines
-stronger behavior. Declaring a sidecar should not imply install, auto-start,
-proxy, or public network access semantics.
+The `sidecar` object declares both the WebUI proxy contract and who owns the
+runtime. The runtime `manifest.json` repeats `type`, `origin`, `health_path`, and
+`proxy_auth`, but omits the library-only `runtime` object. See
+[`SIDECAR_CONTRACT.md`](SIDECAR_CONTRACT.md) before adding one.
 
 Suggested fields:
 
 - `type`: use `loopback` for a local HTTP service bound to localhost
 - `origin`: the localhost origin the extension expects
 - `health_path`: a read-only path WebUI can use for coarse health checks
+- `proxy_auth`: explicit `token-v1` or `legacy` (new runtimes use `token-v1`)
+- `runtime.kind`: `vendored` for a runtime committed under this entry, or
+  `external` for a separately owned runtime
+- `runtime.path`: required local directory for `vendored`
+- `runtime.repository`: required source URL for `external`
 
 ## README Shape
 

--- a/docs/rfcs/0001-extension-json-schema.md
+++ b/docs/rfcs/0001-extension-json-schema.md
@@ -52,18 +52,24 @@ the table.
   // --- what core surface this entry needs (capability names, not version pins) ---
   // capabilities are CORE-OWNED: the canonical list lives in the core repo, since
   // it defines the actual surface. Only list a capability core has SHIPPED.
-  // `manifest-bundle` and `loopback-sidecar` (direct browser→loopback, shipped today)
-  // are valid now; do NOT list `sidecar-proxy` until core ships the same-origin proxy.
+  // `manifest-bundle` and `loopback-sidecar` are valid core capabilities.
+  // The sidecar auth/proxy posture is declared by `sidecar.proxy_auth`; there is
+  // no separate `sidecar-proxy` capability.
   "capabilities": ["manifest-bundle", "loopback-sidecar"],
 
   // --- optional local helper process. The `sidecar` block is descriptive metadata. ---
-  // Today an extension reaches this directly (browser → loopback, allowed by the
-  // core CSP connect-src). A same-origin proxy to it is FUTURE work (capability
-  // `sidecar-proxy`), not assumable by entries yet.
+  // token-v1 runtimes are reached through core's consent-gated same-origin proxy.
+  // An external runtime may stay explicitly legacy while its browser adapter
+  // still uses direct loopback access, as Desktop Companion currently does.
   "sidecar": {
     "type": "loopback",
     "origin": "http://127.0.0.1:17787",
-    "health_path": "/health"
+    "health_path": "/health",
+    "proxy_auth": "legacy",
+    "runtime": {
+      "kind": "external",
+      "repository": "https://github.com/franksong2702/hermes-webui-desktop-companion"
+    }
   },
 
   // --- install / lifecycle behavior ---
@@ -146,7 +152,10 @@ delivery design:
 - `assets` paths are same-origin / repo-local (no external URLs, no traversal) AND
   the *derived* manifest passes the core loader's hardening rules
 - declared `capabilities` are in the **core-owned** capability list and SHIPPED
-  (e.g. reject `sidecar-proxy` until core ships it)
+  (`proxy_auth` is sidecar metadata, not a separate capability)
+- loopback sidecars explicitly declare proxy auth plus vendored/external runtime
+  ownership; vendored runtimes carry the canonical token-v1 scaffold while
+  external runtimes name their source repository
 - `permissions` block present and honest — cross-checked against a static scan of
   the assets (e.g. `network_external:false` + an external `fetch` → flagged;
   `webui_authenticated_api:false` + calls to authed endpoints → flagged)
@@ -166,7 +175,8 @@ delivery design:
   permissions, compatibility, source repo, screenshots, install/lifecycle notes)
   is much richer than the loader manifest, and hand-writing both would drift.
 - **Capabilities are core-owned; declare only shipped ones.** Desktop Companion
-  declares `manifest-bundle` + `loopback-sidecar` today, NOT `sidecar-proxy`.
+  declares `manifest-bundle` + `loopback-sidecar`; proxy auth lives in its
+  `sidecar` block rather than a separate capability.
 - **Screenshots in-repo for the first pass.** Revisit if repo size becomes an issue.
 - **Updates:** user-facing comparison by `version`; integrity by `sha256`.
 - **Compatibility capability-first**, `min_webui_version` as a fallback hint only.

--- a/docs/rfcs/0001-extension-json-schema.md
+++ b/docs/rfcs/0001-extension-json-schema.md
@@ -1,12 +1,11 @@
 # RFC 0001 — Extension entry metadata (`extension.json`)
 
-**Status:** Draft / for discussion
+**Status:** Implemented; updated to match the shipped registry contract
 **Audience:** extension library maintainers + contributors
 
-This is an **RFC, not a locked contract.** It proposes a concrete shape for
-per-extension metadata so we have something specific to react to. Please leave
-comments on the PR — field names, what's required vs. optional, and the open
-questions at the end are all up for debate before anything is implemented.
+This RFC records the design discussion that produced the current extension
+metadata contract. The implementation now validates both author-maintained files:
+the library-facing `extension.json` and core's minimal runtime `manifest.json`.
 
 ## Why
 
@@ -19,19 +18,18 @@ Two roadmap pieces need a metadata file per extension:
 - **CI validation** (#6) + **safety gates** (#8) — validate entries against a schema
   on every PR.
 
-A single declared file is the natural source of truth for all of these.
+The richer library declaration and the minimal runtime declaration split those
+responsibilities; CI is the source of truth for whether they agree.
 
-## Proposed: author writes `extension.json`, the Action derives the loader manifest
+## Implemented: author maintains both declarations and CI checks agreement
 
-Recommendation (open to debate — see Open Questions): each
-`extensions/<id>/extension.json` is the **one file an author maintains**. The
-registry GitHub Action **derives** the minimal runtime `manifest.json` the core
-loader (`api/extensions.py`) consumes, from the `assets` block below. Rationale:
-single source of truth for authors; the loader contract stays minimal and
-auditable (and core-owned). The alternative — two hand-written files — is also on
-the table.
+Each extension maintains `extension.json` for registry, permissions, lifecycle,
+and compatibility metadata, plus the minimal `manifest.json` consumed by core's
+loader (`api/extensions.py`). CI requires IDs, asset lists, and sidecar wire fields
+to agree exactly. The registry generator packages the reviewed manifest; it does
+not synthesize or replace it.
 
-## Proposed schema
+## Implemented `extension.json` schema
 
 ```jsonc
 {
@@ -124,15 +122,13 @@ the table.
 }
 ```
 
-## Manifest derivation must preserve core hardening (per @santastabber)
+## Manifest consistency preserves core hardening (per @santastabber)
 
-When the Action derives the runtime `manifest.json` from `assets`, the output
-**must satisfy every rule the core loader already enforces** — same-origin asset
-paths only (`/extensions/` or `/static/`), no traversal/encoded dot-segments, the
-URL-count and manifest-size caps, bare paths resolving under `/extensions/`. The
-derivation never relaxes those; if an entry's `assets` can't produce a
-core-valid manifest, the entry fails validation. The generated manifest is held
-to the *same* bar as a hand-written one.
+The checked-in runtime `manifest.json` must satisfy every rule the core loader
+already enforces: same-origin asset paths only (`/extensions/` or `/static/`), no
+traversal or encoded dot-segments, URL-count and manifest-size caps, and bare
+paths resolving under `/extensions/`. CI also compares it with `extension.json`;
+drift in assets or sidecar wire fields fails validation before packaging.
 
 ## Install metadata / lifecycle the schema must support (per @santastabber)
 
@@ -149,8 +145,8 @@ delivery design:
 ## Validation (what CI / safety gates check — #6, #8)
 
 - required fields present; `id` is lowercase-hyphen, unique, matches the directory
-- `assets` paths are same-origin / repo-local (no external URLs, no traversal) AND
-  the *derived* manifest passes the core loader's hardening rules
+- `assets` paths are same-origin / repo-local (no external URLs, no traversal),
+  the checked-in manifest passes core loader hardening, and both declarations agree
 - declared `capabilities` are in the **core-owned** capability list and SHIPPED
   (`proxy_auth` is sidecar metadata, not a separate capability)
 - loopback sidecars explicitly declare proxy auth plus vendored/external runtime
@@ -169,11 +165,10 @@ delivery design:
 
 ## Resolved (maintainer consensus)
 
-- **One file (not two).** Both maintainers favor: authors maintain `extension.json`,
-  CI derives the runtime loader manifest. Frank's rationale from real Desktop
-  Companion code: the author-facing metadata (identity, assets, sidecar,
-  permissions, compatibility, source repo, screenshots, install/lifecycle notes)
-  is much richer than the loader manifest, and hand-writing both would drift.
+- **Two reviewed files with exact drift checks.** Authors maintain rich
+  `extension.json` metadata and core's minimal runtime `manifest.json`. CI compares
+  their identity, assets, and sidecar wire fields, while the registry packages the
+  checked-in manifest unchanged.
 - **Capabilities are core-owned; declare only shipped ones.** Desktop Companion
   declares `manifest-bundle` + `loopback-sidecar`; proxy auth lives in its
   `sidecar` block rather than a separate capability.

--- a/examples/loopback-sidecar/README.md
+++ b/examples/loopback-sidecar/README.md
@@ -7,6 +7,8 @@ It is not a working feature extension. It documents the intended shape for
 extensions such as Desktop Companion, where WebUI loads local JS/CSS assets and
 the desktop or native behavior runs in a separate localhost process.
 
-The `sidecar` metadata is descriptive until the main Hermes WebUI repository
-defines and ships the corresponding manifest contract.
+The manifest contract and consent-gated proxy are shipped. This historical
+Desktop Companion shape is explicitly `legacy` because its externally maintained
+runtime still uses direct loopback. New `token-v1` sidecars use the proxy and must
+follow [`docs/SIDECAR_CONTRACT.md`](../../docs/SIDECAR_CONTRACT.md).
 

--- a/examples/loopback-sidecar/manifest.json
+++ b/examples/loopback-sidecar/manifest.json
@@ -8,7 +8,8 @@
       "sidecar": {
         "type": "loopback",
         "origin": "http://127.0.0.1:17787",
-        "health_path": "/health"
+        "health_path": "/health",
+        "proxy_auth": "legacy"
       }
     }
   ]

--- a/examples/loopback-sidecar/manifest.json
+++ b/examples/loopback-sidecar/manifest.json
@@ -2,9 +2,9 @@
   "extensions": [
     {
       "id": "desktop-companion",
-      "name": "Desktop Companion",
+      "name": "Hermes WebUI Desktop Companion",
       "scripts": ["assets/companion-adapter.js"],
-      "stylesheets": ["assets/companion-adapter.css"],
+      "stylesheets": [],
       "sidecar": {
         "type": "loopback",
         "origin": "http://127.0.0.1:17787",

--- a/examples/sidecar-scaffold/.gitignore
+++ b/examples/sidecar-scaffold/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/examples/sidecar-scaffold/README.md
+++ b/examples/sidecar-scaffold/README.md
@@ -1,0 +1,57 @@
+# Sidecar scaffold (reference)
+
+The **canonical, drop-in scaffold** every loopback-sidecar extension vendors. It
+makes the secure path the only path: the scaffold owns the HTTP dispatch loop and
+validates the WebUI-injected `X-Hermes-Sidecar-Token` **deny-by-default** — you
+cannot write an unauthenticated route by accident. See
+[`docs/SIDECAR_CONTRACT.md`](../../docs/SIDECAR_CONTRACT.md) for the full contract.
+
+## Files
+
+| File | Vendored? | You edit it? |
+|---|---|---|
+| `sidecar_base.py` | byte-identical (CI-checked) | **no** |
+| `sidecar.py` (entrypoint) | byte-identical (CI-checked) | **no** |
+| `sidecar.json` | per-extension config | yes — `{id, port, proxy_auth}` |
+| `routes_impl.py` | per-extension | yes — your routes live here |
+
+`sidecar_base.py` and `sidecar.py` are kept identical across every sidecar
+extension by `scripts/sync-sidecar-base.mjs --check` in CI. To adopt or update:
+
+```bash
+cp examples/sidecar-scaffold/sidecar_base.py extensions/<id>/sidecar/
+cp examples/sidecar-scaffold/sidecar.py       extensions/<id>/sidecar/
+# then write extensions/<id>/sidecar/sidecar.json + routes_impl.py
+node scripts/sync-sidecar-base.mjs --check   # confirm byte-identity
+node scripts/check-sidecar-usage.mjs         # confirm no rogue server
+```
+
+## Writing routes
+
+Only `routes_impl.py` is yours. Everything auth-related is handled for you:
+
+```python
+def register(app):
+    @app.route("GET", "/api/items/{item_id}")   # path params
+    def get_item(req):
+        return app.json({"id": req.params["item_id"]})
+
+    @app.route("POST", "/api/upload")
+    def upload(req):
+        return (200, {"Content-Type": "image/png"}, req.body)   # binary ok
+```
+
+- `req.params` (path), `req.query` / `req.query_one("x")` (query string),
+  `req.body` (raw bytes — multipart etc.), `req.headers`.
+- Return `app.json(obj)`, `app.gzip_json(obj)`, or a raw
+  `(status, headers, bytes)` tuple.
+- Background threads are fine — the scaffold owns the *dispatch loop*, not the
+  *process*. Start daemons in `start_background(app)`, then `app.serve()`.
+- **No streaming/SSE** — the WebUI proxy buffers responses (≤512 KiB, ~10 s). For
+  long work use start-job + poll (see the contract doc).
+
+## Running
+
+The `.service` unit's `ExecStart` must run `sidecar.py` (CI enforces this). The
+token file is provisioned by WebUI; point the sidecar at the same state dir (the
+default resolution matches core, so a standard install needs no extra config).

--- a/examples/sidecar-scaffold/README.md
+++ b/examples/sidecar-scaffold/README.md
@@ -62,6 +62,13 @@ def register(app):
 The `.service` unit's `ExecStart` must use
 `/usr/bin/python3 -S [-u] sidecar.py` (CI enforces this). The pinned interpreter
 and mandatory `-S` keep PATH, `sitecustomize`, and `.pth` startup hooks from
-bypassing the checked scaffold. The token file is provisioned by WebUI; point the
-sidecar at the same state dir (the default resolution matches core, so a standard
-install needs no extra config).
+replacing the checked scaffold. Use one unprefixed `ExecStart`; if `Type` is
+present, it must be `simple`. The token file is provisioned by WebUI. For a custom
+state directory, set `HERMES_WEBUI_STATE_DIR` and place `WorkingDirectory` at its
+matching `extensions/<id>/<runtime.path>` location. If this extension is installed
+outside that default tree, declare the extension's exact entry directory as
+`HERMES_EXT_INSTALL_DIR` and place `WorkingDirectory` at its `<runtime.path>`
+child. This sidecar-only variable is deliberately distinct from WebUI's
+`HERMES_WEBUI_EXTENSION_DIR`, which can mean either one entry or a gallery root.
+Custom directories must be absolute or `%h`-anchored and produce a reviewer
+warning. The defaults already agree.

--- a/examples/sidecar-scaffold/README.md
+++ b/examples/sidecar-scaffold/README.md
@@ -1,6 +1,6 @@
 # Sidecar scaffold (reference)
 
-The **canonical, drop-in scaffold** every loopback-sidecar extension vendors. It
+The **canonical, drop-in scaffold** every repository-vendored loopback sidecar uses. It
 makes the secure path the only path: the scaffold owns the HTTP dispatch loop and
 validates the WebUI-injected `X-Hermes-Sidecar-Token` **deny-by-default** — you
 cannot write an unauthenticated route by accident. See
@@ -15,8 +15,9 @@ cannot write an unauthenticated route by accident. See
 | `sidecar.json` | per-extension config | yes — `{id, port, proxy_auth}` |
 | `routes_impl.py` | per-extension | yes — your routes live here |
 
-`sidecar_base.py` and `sidecar.py` are kept identical across every sidecar
-extension by `scripts/sync-sidecar-base.mjs --check` in CI. To adopt or update:
+`sidecar_base.py` and `sidecar.py` are kept identical across every vendored
+sidecar extension by `scripts/sync-sidecar-base.mjs --check` in CI. To adopt or
+update:
 
 ```bash
 cp examples/sidecar-scaffold/sidecar_base.py extensions/<id>/sidecar/
@@ -25,6 +26,11 @@ cp examples/sidecar-scaffold/sidecar.py       extensions/<id>/sidecar/
 node scripts/sync-sidecar-base.mjs --check   # confirm byte-identity
 node scripts/check-sidecar-usage.mjs         # confirm no rogue server
 ```
+
+External runtimes declare `sidecar.runtime.kind: "external"` plus their source
+repository and implement the language-neutral token-v1 contract in their own
+language. They do not copy this Python scaffold. See the contract's runtime
+ownership section before choosing a mode.
 
 ## Writing routes
 
@@ -46,12 +52,16 @@ def register(app):
 - Return `app.json(obj)`, `app.gzip_json(obj)`, or a raw
   `(status, headers, bytes)` tuple.
 - Background threads are fine — the scaffold owns the *dispatch loop*, not the
-  *process*. Start daemons in `start_background(app)`, then `app.serve()`.
+  *process*. Define the optional `start_background(app)` hook when you need
+  daemons; route-only sidecars can omit it.
 - **No streaming/SSE** — the WebUI proxy buffers responses (≤512 KiB, ~10 s). For
   long work use start-job + poll (see the contract doc).
 
 ## Running
 
-The `.service` unit's `ExecStart` must run `sidecar.py` (CI enforces this). The
-token file is provisioned by WebUI; point the sidecar at the same state dir (the
-default resolution matches core, so a standard install needs no extra config).
+The `.service` unit's `ExecStart` must use
+`/usr/bin/python3 -S [-u] sidecar.py` (CI enforces this). The pinned interpreter
+and mandatory `-S` keep PATH, `sitecustomize`, and `.pth` startup hooks from
+bypassing the checked scaffold. The token file is provisioned by WebUI; point the
+sidecar at the same state dir (the default resolution matches core, so a standard
+install needs no extra config).

--- a/examples/sidecar-scaffold/routes_impl.py
+++ b/examples/sidecar-scaffold/routes_impl.py
@@ -1,0 +1,62 @@
+"""Example route implementations for the sidecar scaffold.
+
+This is the ONLY file an extension author writes. It shows every capability the
+three real PR-#64 sidecars need: JSON, path params, query strings, a binary
+response with a custom content-type, a gzip-JSON response, and a background
+thread. Auth is handled entirely by the scaffold — nothing here touches the
+token; a handler simply cannot be reached without a valid one (except /health,
+which the scaffold owns).
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+# Trivial in-memory state a background daemon updates, to show threads are fine.
+_STATE = {"ticks": 0}
+
+# A 1x1 transparent PNG, to demonstrate a binary response with custom headers.
+_PNG_1x1 = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06"
+    b"\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05"
+    b"\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def register(app) -> None:
+    @app.route("GET", "/api/status")
+    def status(req):
+        # query string reachable via req.query / req.query_one
+        verbose = req.query_one("verbose") == "1"
+        payload = {"ticks": _STATE["ticks"]}
+        if verbose:
+            payload["note"] = "verbose"
+        return app.json(payload)
+
+    @app.route("GET", "/api/items/{item_id}")
+    def get_item(req):
+        # path parameter
+        return app.json({"id": req.params["item_id"]})
+
+    @app.route("GET", "/api/report")
+    def report(req):
+        # gzip-JSON convenience (feeds + sysinfo hand-roll this today)
+        return app.gzip_json({"rows": list(range(100))})
+
+    @app.route("GET", "/api/pixel.png")
+    def pixel(req):
+        # binary response with a custom content-type + hardening header
+        return (200, {"Content-Type": "image/png", "X-Content-Type-Options": "nosniff"}, _PNG_1x1)
+
+    @app.route("POST", "/api/echo")
+    def echo(req):
+        # raw request body (multipart / arbitrary bytes) available as req.body
+        return app.json({"received_bytes": len(req.body)})
+
+
+def start_background(app) -> None:
+    def _tick():
+        while True:
+            _STATE["ticks"] += 1
+            time.sleep(5)
+    threading.Thread(target=_tick, daemon=True).start()

--- a/examples/sidecar-scaffold/sidecar.json
+++ b/examples/sidecar-scaffold/sidecar.json
@@ -1,0 +1,5 @@
+{
+  "id": "sidecar-scaffold-example",
+  "port": 17790,
+  "proxy_auth": "token-v1"
+}

--- a/examples/sidecar-scaffold/sidecar.py
+++ b/examples/sidecar-scaffold/sidecar.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Canonical sidecar ENTRYPOINT — this is the file the systemd/.service ExecStart
+runs, and the file CI byte-compares against the canonical copy. Keep it thin: it
+imports the vendored scaffold, registers this extension's routes, and serves.
+
+Do NOT instantiate your own HTTPServer anywhere in a sidecar extension — the CI
+usage lint (scripts/check-sidecar-usage.mjs) fails the build if you do, because a
+second server would bypass the scaffold's deny-by-default token guard. Put route
+logic in ``routes_impl.py``; keep this entrypoint and ``sidecar_base.py``
+byte-identical to the canonical copies.
+"""
+from __future__ import annotations
+
+from sidecar_base import Sidecar
+import routes_impl
+
+app = Sidecar()          # reads sidecar.json next to this file
+routes_impl.register(app)
+
+if __name__ == "__main__":
+    routes_impl.start_background(app)   # optional daemons (safe: scaffold owns
+                                        # the dispatch loop, not the process)
+    app.serve()

--- a/examples/sidecar-scaffold/sidecar.py
+++ b/examples/sidecar-scaffold/sidecar.py
@@ -3,11 +3,11 @@
 runs, and the file CI byte-compares against the canonical copy. Keep it thin: it
 imports the vendored scaffold, registers this extension's routes, and serves.
 
-Do NOT instantiate your own HTTPServer anywhere in a sidecar extension — the CI
-usage lint (scripts/check-sidecar-usage.mjs) fails the build if you do, because a
-second server would bypass the scaffold's deny-by-default token guard. Put route
-logic in ``routes_impl.py``; keep this entrypoint and ``sidecar_base.py``
-byte-identical to the canonical copies.
+Do NOT instantiate your own HTTPServer anywhere in a repository-vendored sidecar
+extension — the CI usage lint (scripts/check-sidecar-usage.mjs) fails the build if
+you do, because a second server would bypass the scaffold's deny-by-default token
+guard. Put route logic in ``routes_impl.py``; keep this entrypoint and
+``sidecar_base.py`` byte-identical to the canonical copies.
 """
 from __future__ import annotations
 
@@ -18,6 +18,9 @@ app = Sidecar()          # reads sidecar.json next to this file
 routes_impl.register(app)
 
 if __name__ == "__main__":
-    routes_impl.start_background(app)   # optional daemons (safe: scaffold owns
-                                        # the dispatch loop, not the process)
+    start_background = getattr(routes_impl, "start_background", None)
+    if start_background is not None:
+        if not callable(start_background):
+            raise TypeError("routes_impl.start_background must be callable")
+        start_background(app)  # optional daemons; scaffold owns the dispatch loop
     app.serve()

--- a/examples/sidecar-scaffold/sidecar.service
+++ b/examples/sidecar-scaffold/sidecar.service
@@ -3,8 +3,9 @@
 # Copy to ~/.config/systemd/user/<id>-sidecar.service, adjust WorkingDirectory,
 # then: systemctl --user enable --now <id>-sidecar.service
 #
-# ExecStart MUST run sidecar.py (the canonical byte-compared entrypoint) — the
-# CI usage lint rejects any other entrypoint. Do NOT put the token in this file;
+# ExecStart MUST use the pinned interpreter with site startup disabled and run
+# sidecar.py (the canonical byte-compared entrypoint). The CI usage lint rejects
+# any other entrypoint. Do NOT put the token in this file;
 # WebUI provisions it in the state dir and the scaffold resolves it there.
 [Unit]
 Description=Hermes WebUI sidecar (scaffold example)
@@ -14,7 +15,7 @@ After=default.target
 Type=simple
 WorkingDirectory=%h/.hermes/webui/extensions/sidecar-scaffold-example/sidecar
 Environment=HERMES_WEBUI_STATE_DIR=%h/.hermes/webui
-ExecStart=/usr/bin/env python3 sidecar.py
+ExecStart=/usr/bin/python3 -S -u sidecar.py
 Restart=on-failure
 
 [Install]

--- a/examples/sidecar-scaffold/sidecar.service
+++ b/examples/sidecar-scaffold/sidecar.service
@@ -1,12 +1,16 @@
 # Example systemd unit for a scaffold-based sidecar.
 #
-# Copy to ~/.config/systemd/user/<id>-sidecar.service, adjust WorkingDirectory,
+# Copy to ~/.config/systemd/user/<id>-sidecar.service, adjust the state and
+# matching extension WorkingDirectory together,
 # then: systemctl --user enable --now <id>-sidecar.service
 #
 # ExecStart MUST use the pinned interpreter with site startup disabled and run
 # sidecar.py (the canonical byte-compared entrypoint). The CI usage lint rejects
-# any other entrypoint. Do NOT put the token in this file;
+# any other entrypoint or ignore-failure prefix. Do NOT put the token in this file;
 # WebUI provisions it in the state dir and the scaffold resolves it there.
+# If this extension is installed outside WebUI's default state directory,
+# declare its exact entry directory as HERMES_EXT_INSTALL_DIR and update
+# WorkingDirectory to the matching <runtime.path> child.
 [Unit]
 Description=Hermes WebUI sidecar (scaffold example)
 After=default.target
@@ -15,6 +19,8 @@ After=default.target
 Type=simple
 WorkingDirectory=%h/.hermes/webui/extensions/sidecar-scaffold-example/sidecar
 Environment=HERMES_WEBUI_STATE_DIR=%h/.hermes/webui
+# Environment=HERMES_WEBUI_STATE_DIR=%h/.hermes/webui-custom
+# Environment=HERMES_EXT_INSTALL_DIR=%h/.hermes/custom-extensions/<extension-id>
 ExecStart=/usr/bin/python3 -S -u sidecar.py
 Restart=on-failure
 

--- a/examples/sidecar-scaffold/sidecar.service
+++ b/examples/sidecar-scaffold/sidecar.service
@@ -1,0 +1,21 @@
+# Example systemd unit for a scaffold-based sidecar.
+#
+# Copy to ~/.config/systemd/user/<id>-sidecar.service, adjust WorkingDirectory,
+# then: systemctl --user enable --now <id>-sidecar.service
+#
+# ExecStart MUST run sidecar.py (the canonical byte-compared entrypoint) — the
+# CI usage lint rejects any other entrypoint. Do NOT put the token in this file;
+# WebUI provisions it in the state dir and the scaffold resolves it there.
+[Unit]
+Description=Hermes WebUI sidecar (scaffold example)
+After=default.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/.hermes/webui/extensions/sidecar-scaffold-example/sidecar
+Environment=HERMES_WEBUI_STATE_DIR=%h/.hermes/webui
+ExecStart=/usr/bin/env python3 sidecar.py
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/examples/sidecar-scaffold/sidecar_base.py
+++ b/examples/sidecar-scaffold/sidecar_base.py
@@ -1,0 +1,288 @@
+"""Canonical loopback-sidecar scaffold for Hermes WebUI extensions.
+
+    SIDECAR_BASE_VERSION = 1
+
+DO NOT EDIT per-extension. This file is vendored byte-identical into every
+sidecar extension and verified by CI (`scripts/sync-sidecar-base.mjs --check`).
+Per-extension values (id, port, handler module) come from `sidecar.json` at
+runtime — never edit a constant in here. If you need behavior this file does not
+provide, propose a change to the canonical copy, bump SIDECAR_BASE_VERSION, and
+re-sync every extension; do not fork it.
+
+Why the scaffold owns the dispatch loop
+----------------------------------------
+The loopback port is reachable by any local process, and the WebUI proxy strips
+every inbound credential before forwarding, so a sidecar cannot tell a proxied
+request from a direct one. WebUI (token-v1) mints a per-extension secret and
+injects it as ``X-Hermes-Sidecar-Token`` on every proxied request. This scaffold
+validates that token **deny-by-default at the single dispatch chokepoint** — auth
+is inherited, not invoked per route, so a forgotten guard cannot open a route.
+Only ``GET/HEAD /health`` is served without a token (the WebUI diagnostics probe
+hits it cross-origin).
+
+What it protects (be honest): callers that cannot read the user's state dir
+(other-UID users, host containers, sandboxed network-only processes). It does NOT
+defend against arbitrary same-UID code — that can read the token file directly.
+
+Envelope (matches the WebUI proxy — do not fight it)
+----------------------------------------------------
+Requests/responses are fully buffered by the proxy: response body <= 512 KiB,
+request body <= the proxy cap, ~10 s upstream timeout, NO streaming/SSE. For work
+longer than a few seconds use the start-job + poll pattern (see
+docs/SIDECAR_CONTRACT.md), not a long-held request.
+
+Handler contract
+----------------
+Register handlers against method + path (path params with ``{name}``)::
+
+    app = Sidecar()                       # reads sidecar.json next to this file
+
+    @app.route("GET", "/api/items")
+    def list_items(req):
+        return app.json({"items": [...]})          # -> (200, headers, bytes)
+
+    @app.route("GET", "/api/items/{item_id}")
+    def get_item(req):
+        return app.json({"id": req.params["item_id"]})
+
+    @app.route("POST", "/api/upload")
+    def upload(req):
+        data = req.body                             # raw bytes (multipart etc.)
+        return (200, {"Content-Type": "image/png"}, blob)   # binary ok
+
+    # background threads are fine — the scaffold owns the dispatch loop, not the
+    # process. Start threads, then serve.
+    app.serve()
+
+A handler returns either ``app.json(obj)`` / ``app.gzip_json(obj)`` or a raw
+``(status:int, headers:dict, body:bytes)`` tuple.
+"""
+from __future__ import annotations
+
+import gzip
+import hmac
+import json
+import os
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+from urllib.parse import parse_qs, urlsplit
+
+SIDECAR_BASE_VERSION = 1
+
+_TOKEN_HEADER = "X-Hermes-Sidecar-Token"
+_HEALTH_PATHS = {"/health"}
+# Request-body ceiling the scaffold enforces itself (the proxy also caps; this is
+# defense-in-depth so a direct caller can't OOM the sidecar).
+_MAX_REQUEST_BYTES = 20 * 1024 * 1024
+_LOOPBACK_HOST = "127.0.0.1"
+
+
+class Request:
+    __slots__ = ("method", "path", "query", "params", "headers", "body")
+
+    def __init__(self, method, path, query, params, headers, body):
+        self.method = method
+        self.path = path
+        self.query: Dict[str, List[str]] = query
+        self.params: Dict[str, str] = params
+        self.headers = headers
+        self.body: bytes = body
+
+    def query_one(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        vals = self.query.get(name)
+        return vals[0] if vals else default
+
+
+def _compile(path: str) -> Tuple[re.Pattern, List[str]]:
+    """Turn '/api/items/{id}' into a regex + the param names."""
+    names: List[str] = []
+    out = ["^"]
+    for seg in path.split("/"):
+        if not seg:
+            continue
+        out.append("/")
+        m = re.fullmatch(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}", seg)
+        if m:
+            names.append(m.group(1))
+            out.append(r"([^/]+)")
+        else:
+            out.append(re.escape(seg))
+    out.append("/?$")
+    return re.compile("".join(out)), names
+
+
+def _resolve_token_path(ext_id: str) -> Optional[Path]:
+    """Resolve the token file the SAME way core does (§9.2). Explicit override
+    first, then the WebUI state dir, then HERMES_HOME/webui, then the platform
+    default — so a relocated state dir does not silently break auth."""
+    override = os.getenv("HERMES_EXT_SIDECAR_TOKEN_FILE")
+    if override:
+        return Path(override).expanduser()
+    state_dir = os.getenv("HERMES_WEBUI_STATE_DIR")
+    if state_dir:
+        return Path(state_dir).expanduser() / "sidecar-auth" / f"{ext_id}.token"
+    home = os.getenv("HERMES_HOME")
+    if home:
+        return Path(home).expanduser() / "webui" / "sidecar-auth" / f"{ext_id}.token"
+    # Platform default mirrors core api/paths.py.
+    if sys.platform == "win32":
+        base = os.getenv("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(base) / "hermes" / "webui" / "sidecar-auth" / f"{ext_id}.token"
+    return Path.home() / ".hermes" / "webui" / "sidecar-auth" / f"{ext_id}.token"
+
+
+class Sidecar:
+    def __init__(self, config_path: Optional[str] = None):
+        cfg = self._load_config(config_path)
+        self.ext_id: str = cfg["id"]
+        self.port: int = int(cfg["port"])
+        self.proxy_auth: str = cfg.get("proxy_auth", "token-v1")
+        self._token_path = _resolve_token_path(self.ext_id)
+        self._routes: List[Tuple[str, re.Pattern, List[str], Callable]] = []
+
+    @staticmethod
+    def _load_config(config_path: Optional[str]) -> Dict:
+        p = Path(config_path) if config_path else Path(__file__).with_name("sidecar.json")
+        cfg = json.loads(p.read_text(encoding="utf-8"))
+        if not isinstance(cfg, dict) or "id" not in cfg or "port" not in cfg:
+            raise ValueError("sidecar.json must define at least {id, port}")
+        return cfg
+
+    # -- registration -------------------------------------------------------
+    def route(self, method: str, path: str):
+        pattern, names = _compile(path)
+        def deco(fn: Callable) -> Callable:
+            self._routes.append((method.upper(), pattern, names, fn))
+            return fn
+        return deco
+
+    # -- response helpers ---------------------------------------------------
+    @staticmethod
+    def json(obj, status: int = 200) -> Tuple[int, Dict[str, str], bytes]:
+        body = json.dumps(obj).encode("utf-8")
+        return status, {"Content-Type": "application/json"}, body
+
+    @staticmethod
+    def gzip_json(obj, status: int = 200) -> Tuple[int, Dict[str, str], bytes]:
+        body = gzip.compress(json.dumps(obj).encode("utf-8"))
+        return status, {"Content-Type": "application/json", "Content-Encoding": "gzip"}, body
+
+    # -- auth ---------------------------------------------------------------
+    def _current_token(self) -> Optional[str]:
+        if self._token_path is None:
+            return None
+        try:
+            tok = self._token_path.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError):
+            return None
+        return tok or None
+
+    def _authorized(self, headers) -> bool:
+        if self.proxy_auth != "token-v1":
+            return True  # legacy sidecar (declared unauthenticated in its manifest)
+        expected = self._current_token()  # re-read per request: live rotation
+        if not expected:
+            return False  # fail closed when no token on disk
+        presented = headers.get(_TOKEN_HEADER, "")
+        return bool(presented) and hmac.compare_digest(presented, expected)
+
+    # -- serving ------------------------------------------------------------
+    def _dispatch(self, method: str, raw_path: str, headers, read_body: Callable) -> Tuple[int, Dict[str, str], bytes]:
+        parsed = urlsplit(raw_path)
+        path = parsed.path
+        # Health is the ONLY tokenless route (WebUI probes it cross-origin).
+        if path in _HEALTH_PATHS and method in ("GET", "HEAD"):
+            return self.json({"ok": True, "sidecar_base_version": SIDECAR_BASE_VERSION})
+        # Deny-by-default: every non-health route requires the injected token.
+        if not self._authorized(headers):
+            return self.json(
+                {
+                    "error": "sidecar proxy token missing or mismatched",
+                    "hint": "requests must arrive through the authenticated WebUI "
+                            "sidecar proxy; is WebUI running and do core + sidecar "
+                            "agree on the state dir?",
+                    "sidecar_base_version": SIDECAR_BASE_VERSION,
+                },
+                status=401 if self._current_token() else 503,
+            )
+        query = parse_qs(parsed.query)
+        for r_method, pattern, names, fn in self._routes:
+            if r_method != method:
+                continue
+            m = pattern.match(path)
+            if not m:
+                continue
+            params = dict(zip(names, m.groups()))
+            body = read_body()
+            req = Request(method, path, query, params, headers, body)
+            result = fn(req)
+            return self._normalize(result)
+        return self.json({"error": "not found"}, status=404)
+
+    @staticmethod
+    def _normalize(result) -> Tuple[int, Dict[str, str], bytes]:
+        if isinstance(result, tuple) and len(result) == 3:
+            status, headers, body = result
+            if isinstance(body, str):
+                body = body.encode("utf-8")
+            return int(status), dict(headers or {}), body or b""
+        raise TypeError("handler must return app.json(...)/app.gzip_json(...) or (status, headers, bytes)")
+
+    def serve(self) -> None:
+        app = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def _run(self, method: str):
+                def read_body() -> bytes:
+                    try:
+                        n = int(self.headers.get("Content-Length", 0))
+                    except (TypeError, ValueError):
+                        n = 0
+                    if n < 0 or n > _MAX_REQUEST_BYTES:
+                        return b""
+                    return self.rfile.read(n) if n else b""
+                try:
+                    status, headers, body = app._dispatch(method, self.path, self.headers, read_body)
+                except Exception:  # never leak a traceback to the caller
+                    status, headers, body = app.json({"error": "internal error"}, status=500)
+                self.send_response(status)
+                sent_ct = False
+                for k, v in (headers or {}).items():
+                    if k.lower() == "content-type":
+                        sent_ct = True
+                    # never echo the token back, even if a handler set it
+                    if k.lower().startswith("x-hermes-"):
+                        continue
+                    self.send_header(k, v)
+                if not sent_ct:
+                    self.send_header("Content-Type", "application/octet-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                if method != "HEAD":
+                    self.wfile.write(body)
+
+            def do_GET(self):
+                self._run("GET")
+
+            def do_HEAD(self):
+                self._run("HEAD")
+
+            def do_POST(self):
+                self._run("POST")
+
+            def do_PUT(self):
+                self._run("PUT")
+
+            def do_PATCH(self):
+                self._run("PATCH")
+
+            def do_DELETE(self):
+                self._run("DELETE")
+
+            def log_message(self, format, *args):
+                pass  # no request logging (would risk logging headers/token)
+
+        ThreadingHTTPServer((_LOOPBACK_HOST, self.port), Handler).serve_forever()

--- a/examples/sidecar-scaffold/sidecar_base.py
+++ b/examples/sidecar-scaffold/sidecar_base.py
@@ -1,9 +1,10 @@
 """Canonical loopback-sidecar scaffold for Hermes WebUI extensions.
 
-    SIDECAR_BASE_VERSION = 1
+    SIDECAR_BASE_VERSION = 2
 
 DO NOT EDIT per-extension. This file is vendored byte-identical into every
-sidecar extension and verified by CI (`scripts/sync-sidecar-base.mjs --check`).
+repository-vendored sidecar extension and verified by CI
+(`scripts/sync-sidecar-base.mjs --check`).
 Per-extension values (id, port, handler module) come from `sidecar.json` at
 runtime — never edit a constant in here. If you need behavior this file does not
 provide, propose a change to the canonical copy, bump SIDECAR_BASE_VERSION, and
@@ -70,7 +71,7 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, urlsplit
 
-SIDECAR_BASE_VERSION = 1
+SIDECAR_BASE_VERSION = 2
 
 _TOKEN_HEADER = "X-Hermes-Sidecar-Token"
 _HEALTH_PATHS = {"/health"}
@@ -78,6 +79,7 @@ _HEALTH_PATHS = {"/health"}
 # defense-in-depth so a direct caller can't OOM the sidecar).
 _MAX_REQUEST_BYTES = 20 * 1024 * 1024
 _LOOPBACK_HOST = "127.0.0.1"
+_PROXY_AUTH_MODES = {"legacy", "token-v1"}
 
 
 class Request:
@@ -139,7 +141,10 @@ class Sidecar:
         cfg = self._load_config(config_path)
         self.ext_id: str = cfg["id"]
         self.port: int = int(cfg["port"])
-        self.proxy_auth: str = cfg.get("proxy_auth", "token-v1")
+        proxy_auth = cfg.get("proxy_auth", "token-v1")
+        if not isinstance(proxy_auth, str) or proxy_auth not in _PROXY_AUTH_MODES:
+            raise ValueError("sidecar.json proxy_auth must be legacy or token-v1")
+        self.proxy_auth: str = proxy_auth
         self._token_path = _resolve_token_path(self.ext_id)
         self._routes: List[Tuple[str, re.Pattern, List[str], Callable]] = []
 
@@ -181,8 +186,10 @@ class Sidecar:
         return tok or None
 
     def _authorized(self, headers) -> bool:
-        if self.proxy_auth != "token-v1":
+        if self.proxy_auth == "legacy":
             return True  # legacy sidecar (declared unauthenticated in its manifest)
+        if self.proxy_auth != "token-v1":
+            return False  # defense-in-depth if startup validation is ever bypassed
         expected = self._current_token()  # re-read per request: live rotation
         if not expected:
             return False  # fail closed when no token on disk
@@ -195,7 +202,16 @@ class Sidecar:
         path = parsed.path
         # Health is the ONLY tokenless route (WebUI probes it cross-origin).
         if path in _HEALTH_PATHS and method in ("GET", "HEAD"):
-            return self.json({"ok": True, "sidecar_base_version": SIDECAR_BASE_VERSION})
+            status, response_headers, body = self.json(
+                {"ok": True, "sidecar_base_version": SIDECAR_BASE_VERSION}
+            )
+            response_headers.update(
+                {
+                    "Access-Control-Allow-Origin": "*",
+                    "Cache-Control": "no-store",
+                }
+            )
+            return status, response_headers, body
         # Deny-by-default: every non-health route requires the injected token.
         if not self._authorized(headers):
             return self.json(

--- a/extensions/desktop-companion/README.md
+++ b/extensions/desktop-companion/README.md
@@ -247,7 +247,8 @@ Manual verification should confirm:
 
 ## Known Limitations
 
-- No one-click install path is available yet.
+- Gallery installation is available for the WebUI adapter; the external Desktop
+  Companion application and sidecar still require their own installation.
 - WebUI settings do not yet manage sidecar lifecycle.
 - Hermes WebUI core's consent-gated sidecar proxy is shipped, but this external
   runtime remains explicitly `legacy` and its adapter still uses direct loopback.

--- a/extensions/desktop-companion/README.md
+++ b/extensions/desktop-companion/README.md
@@ -45,9 +45,12 @@ This entry declares only capabilities already available to extension entries:
 - `manifest-bundle`
 - `loopback-sidecar`
 
-It does not declare `sidecar-proxy`. Direct browser-to-loopback access is the
-current integration model. A same-origin sidecar proxy can be added later if
-Hermes WebUI core ships that capability.
+Direct browser-to-loopback access is the current integration model. Its sidecar
+runtime is owned by the external source
+repository above and is declared `proxy_auth: "legacy"`; it is not treated as a
+copy of this repository's canonical Python scaffold. Migration to the core
+same-origin proxy requires the external runtime to implement the language-neutral
+`token-v1` contract first.
 
 ## Install From Gallery
 
@@ -246,6 +249,7 @@ Manual verification should confirm:
 
 - No one-click install path is available yet.
 - WebUI settings do not yet manage sidecar lifecycle.
-- Sidecar proxy support is not declared because Hermes WebUI core has not
-  shipped it.
+- Hermes WebUI core's consent-gated sidecar proxy is shipped, but this external
+  runtime remains explicitly `legacy` and its adapter still uses direct loopback.
+  Moving it to the proxy requires the external runtime to adopt `token-v1`.
 - The native host source is linked, not vendored, in this extension entry.

--- a/extensions/desktop-companion/extension.json
+++ b/extensions/desktop-companion/extension.json
@@ -18,7 +18,12 @@
   "sidecar": {
     "type": "loopback",
     "origin": "http://127.0.0.1:17787",
-    "health_path": "/health"
+    "health_path": "/health",
+    "proxy_auth": "legacy",
+    "runtime": {
+      "kind": "external",
+      "repository": "https://github.com/franksong2702/hermes-webui-desktop-companion"
+    }
   },
   "lifecycle": {
     "webui_restart_required": false,

--- a/extensions/desktop-companion/manifest.json
+++ b/extensions/desktop-companion/manifest.json
@@ -11,7 +11,8 @@
       "sidecar": {
         "type": "loopback",
         "origin": "http://127.0.0.1:17787",
-        "health_path": "/health"
+        "health_path": "/health",
+        "proxy_auth": "legacy"
       }
     }
   ]

--- a/extensions/message-pins/README.md
+++ b/extensions/message-pins/README.md
@@ -71,8 +71,7 @@ The runtime `manifest.json` injects:
 }
 ```
 
-Once the in-app extensions gallery is available, this entry can also be browsed
-and installed from Settings -> Extensions.
+This entry can be browsed and installed from Settings -> Extensions.
 
 ## Disable And Uninstall
 

--- a/extensions/message-pins/README.md
+++ b/extensions/message-pins/README.md
@@ -44,7 +44,7 @@ This entry declares only capabilities currently available to extension entries:
 
 - `manifest-bundle`
 
-It does not require `loopback-sidecar` or future sidecar proxy support.
+It does not require `loopback-sidecar` or the sidecar proxy.
 
 ## Install For Local Testing
 

--- a/extensions/mobile-conversations/README.md
+++ b/extensions/mobile-conversations/README.md
@@ -146,7 +146,6 @@ Manual mobile verification should confirm:
 
 ## Known Limitations
 
-- No one-click install path is available yet.
 - The extension relies on current WebUI DOM and browser helper names until a
   formal mobile sidebar extension API exists.
 - The extension is intentionally mobile-only and does not add a desktop control.

--- a/extensions/mobile-conversations/README.md
+++ b/extensions/mobile-conversations/README.md
@@ -39,7 +39,7 @@ This entry declares only capabilities currently available to extension entries:
 
 - `manifest-bundle`
 
-It does not require `loopback-sidecar` or future sidecar proxy support.
+It does not require `loopback-sidecar` or the sidecar proxy.
 
 ## Install For Local Testing
 

--- a/scripts/check-sidecar-usage.mjs
+++ b/scripts/check-sidecar-usage.mjs
@@ -15,6 +15,7 @@ import { checkSidecarUsage } from './sidecar-contract-lib.mjs';
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const result = checkSidecarUsage(REPO);
 for (const failure of result.failures) console.error(failure);
+for (const warning of result.warnings) console.warn(warning);
 
 if (result.failures.length) {
   console.error(`\n${result.failures.length} sidecar usage violation(s).`);

--- a/scripts/check-sidecar-usage.mjs
+++ b/scripts/check-sidecar-usage.mjs
@@ -5,77 +5,19 @@
 // (CI green, port wide open — exactly the failure class this whole boundary
 // exists to prevent). This lint fails the build when a sidecar extension:
 //   (1) instantiates its own HTTP server outside the canonical scaffold, or
-//   (2) ships a .service/.container unit whose ExecStart does not run sidecar.py.
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+//   (2) ships a .service unit whose ExecStart does not use the canonical pinned
+//       interpreter + sidecar.py command, or a .container unit whose image
+//       entrypoint cannot be proven by this lint.
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { checkSidecarUsage } from './sidecar-contract-lib.mjs';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const EXT_ROOT = path.join(REPO, 'extensions');
+const result = checkSidecarUsage(REPO);
+for (const failure of result.failures) console.error(failure);
 
-// Any of these instantiated in a sidecar .py that ISN'T the canonical scaffold
-// means a competing server / bypassed auth.
-const SERVER_PATTERNS = [
-  /\bThreadingHTTPServer\s*\(/,
-  /\bHTTPServer\s*\(/,
-  /\bmake_server\s*\(/,           // wsgiref
-  /\bsocketserver\.\w*Server\s*\(/,
-  /\bapp\.run\s*\(/,               // flask/bottle style
-  /\buvicorn\.run\s*\(/,
-];
-// sidecar_base.py is the ONE place a server may be created.
-const ALLOWED_SERVER_FILE = 'sidecar_base.py';
-
-function walkPy(dir) {
-  const out = [];
-  for (const name of readdirSync(dir)) {
-    const p = path.join(dir, name);
-    const st = statSync(p);
-    if (st.isDirectory()) out.push(...walkPy(p));
-    else if (name.endsWith('.py')) out.push(p);
-  }
-  return out;
-}
-
-let failures = 0;
-const sidecarDirs = existsSync(EXT_ROOT)
-  ? readdirSync(EXT_ROOT)
-      .map((id) => path.join(EXT_ROOT, id, 'sidecar'))
-      .filter((d) => existsSync(path.join(d, 'sidecar_base.py')))
-  : [];
-
-for (const dir of sidecarDirs) {
-  // (1) no rogue servers outside the scaffold
-  for (const py of walkPy(dir)) {
-    if (path.basename(py) === ALLOWED_SERVER_FILE) continue;
-    const src = readFileSync(py, 'utf8');
-    for (const pat of SERVER_PATTERNS) {
-      if (pat.test(src)) {
-        console.error(
-          `ROGUE SERVER  ${path.relative(REPO, py)} matches ${pat} — sidecars must serve ` +
-          `only through the canonical sidecar_base.py (its deny-by-default token guard).`
-        );
-        failures++;
-      }
-    }
-  }
-  // (2) every service/container unit must ExecStart the scaffold entrypoint
-  for (const unit of walkPy(dir).length ? readdirSync(dir) : []) {
-    if (!/\.(service|container)$/.test(unit)) continue;
-    const src = readFileSync(path.join(dir, unit), 'utf8');
-    const exec = (src.match(/ExecStart=.*/) || [''])[0];
-    if (exec && !/sidecar\.py(\s|$)/.test(exec)) {
-      console.error(
-        `BAD ExecStart  ${path.relative(REPO, path.join(dir, unit))} — must run sidecar.py ` +
-        `(the byte-compared canonical entrypoint), got: ${exec}`
-      );
-      failures++;
-    }
-  }
-}
-
-if (failures) {
-  console.error(`\n${failures} sidecar usage violation(s).`);
+if (result.failures.length) {
+  console.error(`\n${result.failures.length} sidecar usage violation(s).`);
   process.exit(1);
 }
-console.log(`sidecar usage OK across ${sidecarDirs.length} sidecar extension(s).`);
+console.log(`sidecar usage OK across ${result.scannedCount} extension entr${result.scannedCount === 1 ? 'y' : 'ies'}.`);

--- a/scripts/check-sidecar-usage.mjs
+++ b/scripts/check-sidecar-usage.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Close the "vendored-but-unused" hole: byte-identity of sidecar_base.py proves
+// the scaffold is INTACT, not that it is USED. An extension could carry a
+// pristine scaffold and still stand up its own unguarded HTTP server next to it
+// (CI green, port wide open — exactly the failure class this whole boundary
+// exists to prevent). This lint fails the build when a sidecar extension:
+//   (1) instantiates its own HTTP server outside the canonical scaffold, or
+//   (2) ships a .service/.container unit whose ExecStart does not run sidecar.py.
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const EXT_ROOT = path.join(REPO, 'extensions');
+
+// Any of these instantiated in a sidecar .py that ISN'T the canonical scaffold
+// means a competing server / bypassed auth.
+const SERVER_PATTERNS = [
+  /\bThreadingHTTPServer\s*\(/,
+  /\bHTTPServer\s*\(/,
+  /\bmake_server\s*\(/,           // wsgiref
+  /\bsocketserver\.\w*Server\s*\(/,
+  /\bapp\.run\s*\(/,               // flask/bottle style
+  /\buvicorn\.run\s*\(/,
+];
+// sidecar_base.py is the ONE place a server may be created.
+const ALLOWED_SERVER_FILE = 'sidecar_base.py';
+
+function walkPy(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...walkPy(p));
+    else if (name.endsWith('.py')) out.push(p);
+  }
+  return out;
+}
+
+let failures = 0;
+const sidecarDirs = existsSync(EXT_ROOT)
+  ? readdirSync(EXT_ROOT)
+      .map((id) => path.join(EXT_ROOT, id, 'sidecar'))
+      .filter((d) => existsSync(path.join(d, 'sidecar_base.py')))
+  : [];
+
+for (const dir of sidecarDirs) {
+  // (1) no rogue servers outside the scaffold
+  for (const py of walkPy(dir)) {
+    if (path.basename(py) === ALLOWED_SERVER_FILE) continue;
+    const src = readFileSync(py, 'utf8');
+    for (const pat of SERVER_PATTERNS) {
+      if (pat.test(src)) {
+        console.error(
+          `ROGUE SERVER  ${path.relative(REPO, py)} matches ${pat} — sidecars must serve ` +
+          `only through the canonical sidecar_base.py (its deny-by-default token guard).`
+        );
+        failures++;
+      }
+    }
+  }
+  // (2) every service/container unit must ExecStart the scaffold entrypoint
+  for (const unit of walkPy(dir).length ? readdirSync(dir) : []) {
+    if (!/\.(service|container)$/.test(unit)) continue;
+    const src = readFileSync(path.join(dir, unit), 'utf8');
+    const exec = (src.match(/ExecStart=.*/) || [''])[0];
+    if (exec && !/sidecar\.py(\s|$)/.test(exec)) {
+      console.error(
+        `BAD ExecStart  ${path.relative(REPO, path.join(dir, unit))} — must run sidecar.py ` +
+        `(the byte-compared canonical entrypoint), got: ${exec}`
+      );
+      failures++;
+    }
+  }
+}
+
+if (failures) {
+  console.error(`\n${failures} sidecar usage violation(s).`);
+  process.exit(1);
+}
+console.log(`sidecar usage OK across ${sidecarDirs.length} sidecar extension(s).`);

--- a/scripts/extension-registry-lib.mjs
+++ b/scripts/extension-registry-lib.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -101,6 +101,15 @@ function isSafeLocalPath(value) {
 
 function localFile(entryRoot, rel) {
   return path.join(entryRoot, rel.split('/').join(path.sep));
+}
+
+function localPathHasSymlink(entryRoot, rel) {
+  let current = entryRoot;
+  for (const segment of rel.split('/')) {
+    current = path.join(current, segment);
+    if (existsSync(current) && lstatSync(current).isSymbolicLink()) return true;
+  }
+  return false;
 }
 
 function collectFiles(dir, prefix = '') {
@@ -308,6 +317,20 @@ function validateRuntimeManifest(entry, assets, errors) {
   if (JSON.stringify(runtimeStylesheets) !== JSON.stringify(assets.stylesheets)) {
     errors.push('manifest stylesheets must match extension.json assets.stylesheets');
   }
+  const hasSidecar = Array.isArray(entry.capabilities) && entry.capabilities.includes('loopback-sidecar');
+  if (!hasSidecar && runtime.sidecar !== undefined) {
+    errors.push('manifest sidecar block requires loopback-sidecar metadata in extension.json');
+  } else if (hasSidecar) {
+    if (!isPlainObject(runtime.sidecar)) {
+      errors.push('manifest sidecar block is required when loopback-sidecar capability is declared');
+    } else if (isPlainObject(entry.sidecar)) {
+      for (const field of ['type', 'origin', 'health_path', 'proxy_auth']) {
+        if (runtime.sidecar[field] !== entry.sidecar[field]) {
+          errors.push(`manifest sidecar.${field} must match extension.json sidecar.${field}`);
+        }
+      }
+    }
+  }
 }
 
 function validatePermissions(entry, scriptText, errors) {
@@ -430,16 +453,23 @@ function validatePostInstall(entry, errors) {
   }
 }
 
-function validateSidecar(entry, errors) {
+function validateSidecar(entry, errors, warnings) {
   const hasCapability = Array.isArray(entry.capabilities) && entry.capabilities.includes('loopback-sidecar');
-  if (!hasCapability) return;
+  if (!hasCapability) {
+    if (entry.sidecar !== undefined) {
+      errors.push('sidecar block requires the loopback-sidecar capability');
+    }
+    return;
+  }
   if (!isPlainObject(entry.sidecar)) {
     errors.push('sidecar block is required when loopback-sidecar capability is declared');
     return;
   }
   if (entry.sidecar.type !== 'loopback') errors.push('sidecar.type must be loopback');
+  let parsedOrigin = null;
   try {
     const origin = new URL(entry.sidecar.origin);
+    parsedOrigin = origin;
     if (!['http:', 'https:'].includes(origin.protocol)) errors.push('sidecar.origin must be http(s)');
     if (!['127.0.0.1', 'localhost', '::1'].includes(origin.hostname)) {
       errors.push('sidecar.origin must be loopback');
@@ -449,6 +479,61 @@ function validateSidecar(entry, errors) {
   }
   if (!isNonEmptyString(entry.sidecar.health_path) || !entry.sidecar.health_path.startsWith('/')) {
     errors.push('sidecar.health_path must be an absolute path');
+  }
+  if (!['legacy', 'token-v1'].includes(entry.sidecar.proxy_auth)) {
+    errors.push('sidecar.proxy_auth must be legacy or token-v1');
+  }
+
+  const runtime = entry.sidecar.runtime;
+  if (!isPlainObject(runtime)) {
+    errors.push('sidecar.runtime is required when loopback-sidecar capability is declared');
+    return;
+  }
+  if (!['vendored', 'external'].includes(runtime.kind)) {
+    errors.push('sidecar.runtime.kind must be vendored or external');
+    return;
+  }
+  if (runtime.kind === 'vendored') {
+    const port = parsedOrigin === null ? NaN : Number(parsedOrigin.port);
+    if (parsedOrigin === null
+        || parsedOrigin.protocol !== 'http:'
+        || parsedOrigin.hostname !== '127.0.0.1'
+        || !parsedOrigin.port
+        || !Number.isInteger(port)
+        || port < 1
+        || port > 65535
+        || parsedOrigin.username
+        || parsedOrigin.password
+        || parsedOrigin.pathname !== '/'
+        || parsedOrigin.search
+        || parsedOrigin.hash) {
+      errors.push('vendored sidecar.origin must use http://127.0.0.1 with an explicit port');
+    }
+    if (entry.sidecar.health_path !== '/health') {
+      errors.push('vendored sidecar.health_path must be /health');
+    }
+    if (!isSafeLocalPath(runtime.path)) {
+      errors.push('sidecar.runtime.path is required for a vendored runtime');
+    } else {
+      const runtimePath = localFile(entry.__root, runtime.path);
+      if (!existsSync(runtimePath)) {
+        errors.push(`vendored sidecar runtime directory missing: ${runtime.path}`);
+      } else if (localPathHasSymlink(entry.__root, runtime.path)) {
+        errors.push(`vendored sidecar runtime path must not contain symlinks: ${runtime.path}`);
+      } else if (!lstatSync(runtimePath).isDirectory()) {
+        errors.push(`vendored sidecar runtime directory missing: ${runtime.path}`);
+      }
+    }
+    if (entry.sidecar.proxy_auth !== 'token-v1') {
+      errors.push('vendored sidecars must use proxy_auth token-v1');
+    }
+  } else {
+    if (!isHttpUrl(runtime.repository)) {
+      errors.push('sidecar.runtime.repository is required for an external runtime');
+    }
+    if (entry.sidecar.proxy_auth === 'legacy') {
+      warnings.push('external sidecar runtime is explicitly legacy (proxy_auth: legacy)');
+    }
   }
 }
 
@@ -474,6 +559,7 @@ function validateCapabilities(entry, errors) {
 
 export function validateEntry(discovered) {
   const errors = [];
+  const warnings = [];
   let entry;
   try {
     entry = readJson(discovered.extensionJsonPath);
@@ -481,6 +567,7 @@ export function validateEntry(discovered) {
     return {
       id: discovered.idFromDir,
       root: discovered.root,
+      warnings,
       errors: [`extension.json is not valid JSON: ${error.message}`]
     };
   }
@@ -501,7 +588,7 @@ export function validateEntry(discovered) {
   validateCapabilities(entry, errors);
   validateLifecycle(entry, errors);
   validatePostInstall(entry, errors);
-  validateSidecar(entry, errors);
+  validateSidecar(entry, errors, warnings);
   validateSettingsSchema(entry, errors);
 
   const scriptText = assets.scripts
@@ -510,7 +597,7 @@ export function validateEntry(discovered) {
   validatePermissions(entry, scriptText, errors);
 
   delete entry.__root;
-  return { id: entry.id || discovered.idFromDir, root: discovered.root, entry, errors };
+  return { id: entry.id || discovered.idFromDir, root: discovered.root, entry, warnings, errors };
 }
 
 export function validateAllEntries() {

--- a/scripts/extension-registry-lib.mjs
+++ b/scripts/extension-registry-lib.mjs
@@ -3,12 +3,14 @@ import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from 'node
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { checkScaffoldSync, checkSidecarUsage, symlinksUnder } from './sidecar-contract-lib.mjs';
 
 export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 export const EXTENSIONS_ROOT = path.join(REPO_ROOT, 'extensions');
 export const DEFAULT_REGISTRY_BASE_URL = 'https://hermes-webui.github.io/hermes-webui-extensions/';
 const ZIP32_MAX = 0xffffffff;
 const ZIP16_MAX = 0xffff;
+const ZIP_UTF8_FLAG = 0x0800;
 
 const VALID_CAPABILITIES = new Set([
   'manifest-bundle',
@@ -43,22 +45,25 @@ export function readJson(filePath) {
   return JSON.parse(readFileSync(filePath, 'utf8'));
 }
 
-export function repoRelative(filePath) {
-  return path.relative(REPO_ROOT, filePath).split(path.sep).join('/');
+export function repoRelative(filePath, repoRoot = REPO_ROOT) {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
 }
 
-export function discoverEntries() {
-  if (!existsSync(EXTENSIONS_ROOT)) return [];
-  return readdirSync(EXTENSIONS_ROOT, { withFileTypes: true })
-    .filter((item) => item.isDirectory())
+export function discoverEntries({ repoRoot = REPO_ROOT } = {}) {
+  const extensionsRoot = path.join(repoRoot, 'extensions');
+  if (!existsSync(extensionsRoot)) return [];
+  return readdirSync(extensionsRoot, { withFileTypes: true })
+    .filter((item) => item.isDirectory() || item.isSymbolicLink())
     .map((item) => {
-      const root = path.join(EXTENSIONS_ROOT, item.name);
+      const root = path.join(extensionsRoot, item.name);
       const extensionJsonPath = path.join(root, 'extension.json');
-      return existsSync(extensionJsonPath)
-        ? { idFromDir: item.name, root, extensionJsonPath }
-        : null;
+      return {
+        idFromDir: item.name,
+        root,
+        extensionJsonPath,
+        rootIsSymlink: item.isSymbolicLink()
+      };
     })
-    .filter(Boolean)
     .sort((a, b) => a.idFromDir.localeCompare(b.idFromDir));
 }
 
@@ -88,6 +93,59 @@ function isHttpUrl(value) {
   }
 }
 
+function fullyDecodePath(value) {
+  let current = value;
+  try {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const decoded = decodeURIComponent(current);
+      if (decoded === current) return decoded;
+      current = decoded;
+    }
+  } catch (_) {
+    return null;
+  }
+  return current;
+}
+
+function isCoreCompatibleSidecarOrigin(value) {
+  if (!isNonEmptyString(value)) return false;
+  const raw = value.trim();
+  if ([...raw].some((char) => ['\0', '\r', '\n', '"', "'", '<', '>', '\\'].includes(char))) {
+    return false;
+  }
+  if (!/^https?:\/\/[^/?#]+$/i.test(raw)) return false;
+  const authority = raw.slice(raw.indexOf('://') + 3);
+  if (!/^(?:127\.0\.0\.1|localhost|\[::1\])(?::\d+)?$/i.test(authority)) return false;
+  try {
+    const origin = new URL(raw);
+    return ['http:', 'https:'].includes(origin.protocol)
+      && ['127.0.0.1', 'localhost', '::1', '[::1]'].includes(origin.hostname.toLowerCase())
+      && !origin.username
+      && !origin.password;
+  } catch (_) {
+    return false;
+  }
+}
+
+function isCoreCompatibleHealthPath(value) {
+  if (!isNonEmptyString(value)) return false;
+  const raw = value.trim();
+  if (!raw.startsWith('/') || raw.startsWith('//')) return false;
+  if ([...raw].some((char) => ['\0', '\r', '\n', '"', "'", '<', '>', '\\'].includes(char))) {
+    return false;
+  }
+  if (raw.includes('?') || raw.includes('#')) return false;
+  const decoded = fullyDecodePath(raw);
+  if (decoded === null || !decoded.startsWith('/') || decoded.startsWith('//')) return false;
+  if ([...decoded].some((char) => ['\0', '\r', '\n', '"', "'", '<', '>', '\\', '?', '#'].includes(char))) {
+    return false;
+  }
+  if (/\s/u.test(decoded)) return false;
+  const segments = decoded.slice(1).split('/');
+  return segments.length > 0
+    && segments.every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+}
+
 function isSafeLocalPath(value) {
   if (!isNonEmptyString(value)) return false;
   if (value.startsWith('/') || value.startsWith('\\')) return false;
@@ -111,6 +169,7 @@ function localPathHasSymlink(entryRoot, rel) {
   }
   return false;
 }
+
 
 function collectFiles(dir, prefix = '') {
   const files = [];
@@ -165,8 +224,8 @@ function writeZipLocalHeader({ name, content }) {
   const { date, time } = dosDateTime();
   const checksum = crc32(content);
   header.writeUInt32LE(0x04034b50, 0);
-  header.writeUInt16LE(10, 4);
-  header.writeUInt16LE(0, 6);
+  header.writeUInt16LE(20, 4);
+  header.writeUInt16LE(ZIP_UTF8_FLAG, 6);
   header.writeUInt16LE(0, 8);
   header.writeUInt16LE(time, 10);
   header.writeUInt16LE(date, 12);
@@ -184,8 +243,8 @@ function writeZipCentralHeader({ name, content, offset, checksum }) {
   const { date, time } = dosDateTime();
   header.writeUInt32LE(0x02014b50, 0);
   header.writeUInt16LE(0x031e, 4);
-  header.writeUInt16LE(10, 6);
-  header.writeUInt16LE(0, 8);
+  header.writeUInt16LE(20, 6);
+  header.writeUInt16LE(ZIP_UTF8_FLAG, 8);
   header.writeUInt16LE(0, 10);
   header.writeUInt16LE(time, 12);
   header.writeUInt16LE(date, 14);
@@ -467,18 +526,13 @@ function validateSidecar(entry, errors, warnings) {
   }
   if (entry.sidecar.type !== 'loopback') errors.push('sidecar.type must be loopback');
   let parsedOrigin = null;
-  try {
-    const origin = new URL(entry.sidecar.origin);
-    parsedOrigin = origin;
-    if (!['http:', 'https:'].includes(origin.protocol)) errors.push('sidecar.origin must be http(s)');
-    if (!['127.0.0.1', 'localhost', '::1'].includes(origin.hostname)) {
-      errors.push('sidecar.origin must be loopback');
-    }
-  } catch (_) {
-    errors.push('sidecar.origin must be a valid URL');
+  if (!isCoreCompatibleSidecarOrigin(entry.sidecar.origin)) {
+    errors.push('sidecar.origin must be a loopback HTTP(S) origin without path, query, fragment, or userinfo');
+  } else {
+    parsedOrigin = new URL(entry.sidecar.origin.trim());
   }
-  if (!isNonEmptyString(entry.sidecar.health_path) || !entry.sidecar.health_path.startsWith('/')) {
-    errors.push('sidecar.health_path must be an absolute path');
+  if (!isCoreCompatibleHealthPath(entry.sidecar.health_path)) {
+    errors.push('sidecar.health_path must be a safe absolute path without query or fragment');
   }
   if (!['legacy', 'token-v1'].includes(entry.sidecar.proxy_auth)) {
     errors.push('sidecar.proxy_auth must be legacy or token-v1');
@@ -522,6 +576,12 @@ function validateSidecar(entry, errors, warnings) {
         errors.push(`vendored sidecar runtime path must not contain symlinks: ${runtime.path}`);
       } else if (!lstatSync(runtimePath).isDirectory()) {
         errors.push(`vendored sidecar runtime directory missing: ${runtime.path}`);
+      } else {
+        for (const symlink of symlinksUnder(runtimePath)) {
+          errors.push(
+            `vendored sidecar runtime tree must not contain symlinks: ${runtime.path}/${symlink}`
+          );
+        }
       }
     }
     if (entry.sidecar.proxy_auth !== 'token-v1') {
@@ -560,6 +620,33 @@ function validateCapabilities(entry, errors) {
 export function validateEntry(discovered) {
   const errors = [];
   const warnings = [];
+  if (discovered.rootIsSymlink) {
+    return {
+      id: discovered.idFromDir,
+      root: discovered.root,
+      warnings,
+      errors: ['extension root must be a real directory, not a symlink']
+    };
+  }
+  let metadataStat;
+  try {
+    metadataStat = lstatSync(discovered.extensionJsonPath);
+  } catch (error) {
+    return {
+      id: discovered.idFromDir,
+      root: discovered.root,
+      warnings,
+      errors: [`extension.json is not a readable regular file: ${error.message}`]
+    };
+  }
+  if (!metadataStat.isFile()) {
+    return {
+      id: discovered.idFromDir,
+      root: discovered.root,
+      warnings,
+      errors: ['extension.json must be a real regular file, not a symlink']
+    };
+  }
   let entry;
   try {
     entry = readJson(discovered.extensionJsonPath);
@@ -569,6 +656,28 @@ export function validateEntry(discovered) {
       root: discovered.root,
       warnings,
       errors: [`extension.json is not valid JSON: ${error.message}`]
+    };
+  }
+  if (!isPlainObject(entry)) {
+    return {
+      id: discovered.idFromDir,
+      root: discovered.root,
+      warnings,
+      errors: ['extension.json must contain a JSON object']
+    };
+  }
+
+  const treeSymlinks = symlinksUnder(discovered.root);
+  for (const symlink of treeSymlinks) {
+    errors.push(`extension tree must not contain symlinks: ${symlink}`);
+  }
+  if (treeSymlinks.length) {
+    return {
+      id: entry.id || discovered.idFromDir,
+      root: discovered.root,
+      entry,
+      warnings,
+      errors
     };
   }
 
@@ -600,8 +709,8 @@ export function validateEntry(discovered) {
   return { id: entry.id || discovered.idFromDir, root: discovered.root, entry, warnings, errors };
 }
 
-export function validateAllEntries() {
-  const discovered = discoverEntries();
+export function validateAllEntries({ repoRoot = REPO_ROOT } = {}) {
+  const discovered = discoverEntries({ repoRoot });
   const seen = new Set();
   const results = discovered.map((item) => {
     const result = validateEntry(item);
@@ -612,14 +721,23 @@ export function validateAllEntries() {
   return { discovered, results };
 }
 
-function assertValidResults() {
-  const { results } = validateAllEntries();
+function assertValidResults(repoRoot = REPO_ROOT) {
+  const { results } = validateAllEntries({ repoRoot });
   const failures = results.filter((result) => result.errors.length);
   if (failures.length) {
     const message = failures
       .map((result) => `${result.id}\n${result.errors.map((error) => `  - ${error}`).join('\n')}`)
       .join('\n');
     throw new Error(`Cannot generate registry from invalid entries:\n${message}`);
+  }
+  const sidecarFailures = [
+    ...checkScaffoldSync(repoRoot).failures,
+    ...checkSidecarUsage(repoRoot).failures
+  ];
+  if (sidecarFailures.length) {
+    throw new Error(
+      `Cannot generate registry from an invalid sidecar contract:\n${sidecarFailures.join('\n')}`
+    );
   }
   return results;
 }
@@ -662,14 +780,15 @@ export function buildExtensionArtifact(result) {
 function buildRegistryFromResults(results, {
   publishedAt,
   artifactBaseUrl = DEFAULT_REGISTRY_BASE_URL,
-  artifactsById = new Map()
+  artifactsById = new Map(),
+  repoRoot = REPO_ROOT
 }) {
   return {
     version: 1,
     generated_at: publishedAt,
     extensions: results
       .map((result) => {
-        const entryDir = repoRelative(result.root);
+        const entryDir = repoRelative(result.root, repoRoot);
         const fileHashes = extensionFiles(result).map((file) => ({
           path: file.path,
           sha256: sha256File(file.absolutePath)
@@ -695,19 +814,28 @@ function buildRegistryFromResults(results, {
   };
 }
 
-export function buildRegistry({ publishedAt = new Date().toISOString() } = {}) {
-  return buildRegistryFromResults(assertValidResults(), { publishedAt });
+export function buildRegistry({
+  publishedAt = new Date().toISOString(),
+  repoRoot = REPO_ROOT
+} = {}) {
+  return buildRegistryFromResults(assertValidResults(repoRoot), { publishedAt, repoRoot });
 }
 
 export function buildRegistryWithArtifacts({
   publishedAt = new Date().toISOString(),
-  artifactBaseUrl = DEFAULT_REGISTRY_BASE_URL
+  artifactBaseUrl = DEFAULT_REGISTRY_BASE_URL,
+  repoRoot = REPO_ROOT
 } = {}) {
-  const results = assertValidResults();
+  const results = assertValidResults(repoRoot);
   const artifacts = results.map((result) => buildExtensionArtifact(result));
   const artifactsById = new Map(artifacts.map((artifact) => [artifact.id, artifact]));
   return {
-    registry: buildRegistryFromResults(results, { publishedAt, artifactBaseUrl, artifactsById }),
+    registry: buildRegistryFromResults(results, {
+      publishedAt,
+      artifactBaseUrl,
+      artifactsById,
+      repoRoot
+    }),
     artifacts
   };
 }

--- a/scripts/sidecar-contract-lib.mjs
+++ b/scripts/sidecar-contract-lib.mjs
@@ -1,0 +1,504 @@
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+export const CANON_FILES = ['sidecar_base.py', 'sidecar.py'];
+const REQUIRED_VENDORED_FILES = [...CANON_FILES, 'sidecar.json', 'routes_impl.py'];
+const NODE_SERVER_PATTERNS = [
+  /\bfrom\s*['"](?:node:)?(?:http|https|http2|net)['"]/,
+  /\bimport\s+(?:[A-Za-z_$][\w$]*|\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]*\b(?:createServer|Server)\b[^}]*\})\s+from\s*['"](?:node:)?(?:http|https|http2|net)['"]/,
+  /\brequire\s*\(\s*['"](?:node:)?(?:http|https|http2|net)['"]\s*\)/,
+  /\bnew\s+(?:[A-Za-z_$][\w$]*\.)?Server\s*\(/,
+  /\b(?:http|https|http2|net)\.createServer\s*\(/,
+  /\bcreateServer\s*\(/,
+  /\b(?:Bun|Deno)\.serve\s*\(/,
+  /\b(?:express|fastify)\s*\([^)]*\)\s*\.listen\s*\(/,
+  /\b[A-Za-z_$][\w$]*\.listen\s*\(/
+];
+
+const SERVER_PATTERNS = new Map([
+  ['.py', [
+    /\bfrom\s+http\.server\s+import\b/,
+    /\bimport\s+http\.server\b/,
+    /\b(?:from\s+socketserver\s+import|import\s+socketserver\b)/,
+    /\bfrom\s+wsgiref\.simple_server\s+import\b/,
+    /\b(?:from\s+flask\s+import|import\s+flask\b)/,
+    /\b(?:from\s+fastapi\s+import|import\s+fastapi\b)/,
+    /\b(?:from\s+aiohttp\s+import\s+web|import\s+aiohttp\.web\b)/,
+    /\bThreadingHTTPServer\s*\(/,
+    /\bHTTPServer\s*\(/,
+    /\bmake_server\s*\(/,
+    /\bsocketserver\.\w*Server\s*\(/,
+    /\bapp\.run\s*\(/,
+    /\buvicorn\.run\s*\(/
+  ]],
+  ['.js', NODE_SERVER_PATTERNS],
+  ['.mjs', NODE_SERVER_PATTERNS],
+  ['.cjs', NODE_SERVER_PATTERNS],
+  ['.ts', NODE_SERVER_PATTERNS],
+  ['.tsx', NODE_SERVER_PATTERNS],
+  ['.rs', [/\bTcpListener::bind\s*\(/, /\bServer::bind\s*\(/]],
+  ['.go', [
+    /\bhttp\.ListenAndServe(?:TLS)?\s*\(/,
+    /\b[A-Za-z_][A-Za-z0-9_]*\.ListenAndServe(?:TLS)?\s*\(/,
+    /\b(?:http|net)\.Serve\s*\(/,
+    /\b[A-Za-z_][A-Za-z0-9_]*\.Serve\s*\(/,
+    /\bnet\.Listen\s*\(/
+  ]],
+  ['.java', [/\bHttpServer\.create\s*\(/, /\bnew\s+ServerSocket\s*\(/]],
+  ['.kt', [/\bHttpServer\.create\s*\(/, /\bServerSocket\s*\(/]],
+  ['.cs', [/\bnew\s+HttpListener\s*\(/]],
+  ['.rb', [/\bTCPServer\.new\s*\(/, /\bWEBrick::HTTPServer\.new\s*\(/]]
+]);
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function hasTopLevelRegister(filePath) {
+  const check = [
+    'import ast, pathlib, sys',
+    'try:',
+    '    tree = ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))',
+    'except (OSError, SyntaxError, UnicodeError):',
+    '    raise SystemExit(1)',
+    'def is_route_factory(expr):',
+    '    return (',
+    '        isinstance(expr, ast.Call)',
+    '        and isinstance(expr.func, ast.Attribute)',
+    '        and expr.func.attr == "route"',
+    '        and isinstance(expr.func.value, ast.Name)',
+    '        and expr.func.value.id == "app"',
+    '    )',
+    'class BindingFinder(ast.NodeVisitor):',
+    '    def __init__(self):',
+    '        self.bindings = []',
+    '    def visit_FunctionDef(self, node):',
+    '        if node.name == "register": self.bindings.append(node)',
+    '    visit_AsyncFunctionDef = visit_FunctionDef',
+    '    def visit_ClassDef(self, node):',
+    '        if node.name == "register": self.bindings.append(node)',
+    '    def visit_Name(self, node):',
+    '        if node.id == "register" and isinstance(node.ctx, (ast.Store, ast.Del)):',
+    '            self.bindings.append(node)',
+    '    def visit_Import(self, node):',
+    '        for alias in node.names:',
+    '            if (alias.asname or alias.name.split(".")[0]) == "register":',
+    '                self.bindings.append(node)',
+    '    def visit_ImportFrom(self, node):',
+    '        for alias in node.names:',
+    '            if (alias.asname or alias.name) == "register":',
+    '                self.bindings.append(node)',
+    '    def visit_ExceptHandler(self, node):',
+    '        if node.name == "register": self.bindings.append(node)',
+    '        self.generic_visit(node)',
+    '    def visit_Lambda(self, node): pass',
+    '    def visit_ListComp(self, node): pass',
+    '    def visit_SetComp(self, node): pass',
+    '    def visit_DictComp(self, node): pass',
+    '    def visit_GeneratorExp(self, node): pass',
+    'if any(isinstance(node, ast.Raise) for node in tree.body):',
+    '    raise SystemExit(1)',
+    'finder = BindingFinder()',
+    'for node in tree.body:',
+    '    finder.visit(node)',
+    'bindings = finder.bindings',
+    'if (len(bindings) != 1 or not isinstance(bindings[0], ast.FunctionDef)',
+    '        or bindings[0] not in tree.body):',
+    '    raise SystemExit(1)',
+    'node = bindings[0]',
+    'positional = [*node.args.posonlyargs, *node.args.args]',
+    'if (len(positional) != 1 or positional[0].arg != "app"',
+    '        or node.args.vararg or node.args.kwarg or node.args.kwonlyargs',
+    '        or node.args.defaults):',
+    '    raise SystemExit(1)',
+    'for statement in node.body:',
+    '    if isinstance(statement, (ast.Raise, ast.Return)):',
+    '        break',
+    '    if isinstance(statement, (ast.If, ast.For, ast.AsyncFor, ast.While,',
+    '                              ast.Try, ast.TryStar, ast.With, ast.AsyncWith,',
+    '                              ast.Match, ast.Assert)):',
+    '        break',
+    '    if isinstance(statement, ast.FunctionDef):',
+    '        if any(is_route_factory(decorator) for decorator in statement.decorator_list):',
+    '            raise SystemExit(0)',
+    '    elif (isinstance(statement, ast.Expr)',
+    '          and isinstance(statement.value, ast.Call)',
+    '          and is_route_factory(statement.value.func)):',
+    '        raise SystemExit(0)',
+    'raise SystemExit(1)'
+  ].join('\n');
+  const result = spawnSync('python3', ['-c', check, filePath], {
+    stdio: 'ignore'
+  });
+  return result.status === 0;
+}
+
+function parseUnitDirectives(source) {
+  const directives = [];
+  let section = '';
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const sectionMatch = /^\[([^\]]+)]$/.exec(line);
+    if (sectionMatch) {
+      section = sectionMatch[1];
+      continue;
+    }
+    const directiveMatch = /^([A-Za-z][A-Za-z0-9]*)\s*=(.*)$/.exec(line);
+    if (directiveMatch) {
+      directives.push({
+        section,
+        name: directiveMatch[1],
+        value: directiveMatch[2].trim(),
+        raw: line
+      });
+    }
+  }
+  return directives;
+}
+
+function walkFiles(dir) {
+  if (!existsSync(dir)) return [];
+  const files = [];
+  for (const item of readdirSync(dir, { withFileTypes: true })) {
+    const target = path.join(dir, item.name);
+    if (item.isDirectory()) files.push(...walkFiles(target));
+    else if (item.isFile()) files.push(target);
+  }
+  return files;
+}
+
+function pathHasSymlink(root, relativePath) {
+  let current = root;
+  for (const segment of relativePath.split('/')) {
+    current = path.join(current, segment);
+    if (existsSync(current) && lstatSync(current).isSymbolicLink()) return true;
+  }
+  return false;
+}
+
+function importShadowCollisions(runtimeDir) {
+  if (!existsSync(runtimeDir) || !lstatSync(runtimeDir).isDirectory()) return [];
+  return readdirSync(runtimeDir, { withFileTypes: true })
+    .filter((item) => ['sidecar_base', 'routes_impl'].some((moduleName) => (
+      item.name !== `${moduleName}.py`
+      && (item.name === moduleName || item.name.startsWith(`${moduleName}.`))
+    )))
+    .map((item) => item.name);
+}
+
+function isSafeRelativePath(value) {
+  if (typeof value !== 'string' || !value || value.includes('\\') || path.isAbsolute(value)) return false;
+  const normalized = path.posix.normalize(value);
+  return normalized === value && normalized !== '.' && normalized !== '..' && !normalized.startsWith('../');
+}
+
+function extensionEntries(repoRoot) {
+  const extensionsRoot = path.join(repoRoot, 'extensions');
+  if (!existsSync(extensionsRoot)) return [];
+  return readdirSync(extensionsRoot, { withFileTypes: true })
+    .filter((item) => item.isDirectory())
+    .map((item) => {
+      const root = path.join(extensionsRoot, item.name);
+      const metadataPath = path.join(root, 'extension.json');
+      let metadata = null;
+      let parseError = null;
+      if (existsSync(metadataPath)) {
+        try {
+          metadata = readJson(metadataPath);
+        } catch (error) {
+          parseError = error.message;
+        }
+      }
+      return { id: item.name, root, metadata, parseError };
+    });
+}
+
+function declaredSidecarEntries(repoRoot) {
+  return extensionEntries(repoRoot).filter((entry) => hasSidecarCapability(entry));
+}
+
+function hasSidecarCapability(entry) {
+  return Array.isArray(entry.metadata?.capabilities)
+    && entry.metadata.capabilities.includes('loopback-sidecar');
+}
+
+function vendoredDir(entry) {
+  if (!hasSidecarCapability(entry)) return null;
+  const runtime = entry.metadata?.sidecar?.runtime;
+  if (runtime?.kind !== 'vendored' || !isSafeRelativePath(runtime.path)) return null;
+  return path.join(entry.root, runtime.path.split('/').join(path.sep));
+}
+
+function relative(repoRoot, filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+function expectedPort(sidecar) {
+  try {
+    const url = new URL(sidecar.origin);
+    if (url.port) return Number(url.port);
+    return url.protocol === 'https:' ? 443 : 80;
+  } catch (_) {
+    return null;
+  }
+}
+
+function vendoredOriginIsCanonical(sidecar) {
+  try {
+    const origin = new URL(sidecar.origin);
+    const port = Number(origin.port);
+    return origin.protocol === 'http:'
+      && origin.hostname === '127.0.0.1'
+      && Boolean(origin.port)
+      && Number.isInteger(port)
+      && port >= 1
+      && port <= 65535
+      && !origin.username
+      && !origin.password
+      && origin.pathname === '/'
+      && !origin.search
+      && !origin.hash;
+  } catch (_) {
+    return false;
+  }
+}
+
+function commandTokens(command) {
+  return (command.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\S+/g) || [])
+    .map((token) => {
+      if ((token.startsWith('"') && token.endsWith('"'))
+          || (token.startsWith("'") && token.endsWith("'"))) {
+        return token.slice(1, -1);
+      }
+      return token;
+    });
+}
+
+function normalizedUnitPath(value) {
+  if (typeof value !== 'string' || !value) return null;
+  let unquoted = value.trim();
+  if ((unquoted.startsWith('"') && unquoted.endsWith('"'))
+      || (unquoted.startsWith("'") && unquoted.endsWith("'"))) {
+    unquoted = unquoted.slice(1, -1);
+  }
+  return path.posix.normalize(unquoted.replaceAll('\\', '/'));
+}
+
+function runsCanonicalEntrypoint(directive, entryId, runtimePath, workingDirectory) {
+  const equals = directive.indexOf('=');
+  if (equals < 0) return false;
+  let command = directive.slice(equals + 1).trim();
+  if (command.startsWith('-')) command = command.slice(1).trim();
+  const tokens = commandTokens(command);
+  if (tokens.length === 0) return false;
+
+  if (tokens[0] !== '/usr/bin/python3') return false;
+  tokens.shift();
+  let sawNoSite = false;
+  let sawUnbuffered = false;
+  while (tokens.length > 0 && tokens[0].startsWith('-')) {
+    if (tokens[0] === '-S' && !sawNoSite) sawNoSite = true;
+    else if (tokens[0] === '-u' && !sawUnbuffered) sawUnbuffered = true;
+    else return false;
+    tokens.shift();
+  }
+  if (!sawNoSite || tokens.length !== 1 || path.basename(tokens[0]) !== 'sidecar.py') return false;
+  const scriptToken = tokens[0];
+
+  const normalizedRuntime = path.posix.normalize(runtimePath);
+  const expectedWorkingSuffix = `/${entryId}/${normalizedRuntime}`;
+  const normalizedWorkingDirectory = normalizedUnitPath(workingDirectory);
+  if (normalizedWorkingDirectory === null
+      || !normalizedWorkingDirectory.endsWith(expectedWorkingSuffix)) {
+    return false;
+  }
+  const normalizedScript = normalizedUnitPath(scriptToken);
+  return normalizedScript === 'sidecar.py'
+    || normalizedScript === `${normalizedWorkingDirectory}/sidecar.py`;
+}
+
+export function checkScaffoldSync(repoRoot, { write = false } = {}) {
+  const canonicalDir = path.join(repoRoot, 'examples', 'sidecar-scaffold');
+  const canonical = new Map();
+  const failures = [];
+  for (const name of CANON_FILES) {
+    const filePath = path.join(canonicalDir, name);
+    if (!existsSync(filePath)) failures.push(`MISSING  ${relative(repoRoot, filePath)} (canonical scaffold file)`);
+    else canonical.set(name, readFileSync(filePath));
+  }
+
+  let vendoredCount = 0;
+  let externalCount = 0;
+  let synced = 0;
+  for (const entry of declaredSidecarEntries(repoRoot)) {
+    const runtime = entry.metadata?.sidecar?.runtime;
+    if (runtime?.kind === 'external') {
+      externalCount += 1;
+      continue;
+    }
+    if (runtime?.kind !== 'vendored') {
+      failures.push(`INVALID  extensions/${entry.id}/extension.json sidecar.runtime.kind must be vendored or external`);
+      continue;
+    }
+    vendoredCount += 1;
+    const dir = vendoredDir(entry);
+    if (!dir) {
+      failures.push(`INVALID  extensions/${entry.id}/extension.json sidecar.runtime.path must be safe and relative`);
+      continue;
+    }
+    if (pathHasSymlink(entry.root, entry.metadata.sidecar.runtime.path)) {
+      failures.push(`INVALID  ${relative(repoRoot, dir)} runtime path must not contain symlinks`);
+      continue;
+    }
+    for (const collision of importShadowCollisions(dir)) {
+      failures.push(
+        `INVALID  ${relative(repoRoot, path.join(dir, collision))} shadows a canonical Python module`
+      );
+    }
+    if (!vendoredOriginIsCanonical(entry.metadata.sidecar)) {
+      failures.push(`INVALID  extensions/${entry.id}/extension.json vendored sidecar.origin must use http://127.0.0.1 with an explicit port`);
+    }
+    if (entry.metadata.sidecar.health_path !== '/health') {
+      failures.push(`INVALID  extensions/${entry.id}/extension.json vendored sidecar.health_path must be /health`);
+    }
+
+    for (const name of REQUIRED_VENDORED_FILES) {
+      const destination = path.join(dir, name);
+      if (existsSync(destination) && !lstatSync(destination).isFile()) {
+        failures.push(`INVALID  ${relative(repoRoot, destination)} must be a regular file`);
+        continue;
+      }
+      if (write && CANON_FILES.includes(name) && canonical.has(name)) {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(destination, canonical.get(name));
+        synced += 1;
+        continue;
+      }
+      if (!existsSync(destination)) {
+        failures.push(`MISSING  ${relative(repoRoot, destination)} (vendored scaffold incomplete)`);
+        continue;
+      }
+      if (CANON_FILES.includes(name) && canonical.has(name)
+          && !readFileSync(destination).equals(canonical.get(name))) {
+        failures.push(`DRIFT    ${relative(repoRoot, destination)} (differs from canonical examples/sidecar-scaffold/${name})`);
+      }
+      if (name === 'routes_impl.py' && !hasTopLevelRegister(destination)) {
+        failures.push(`INVALID  ${relative(repoRoot, destination)} must define top-level synchronous register(app)`);
+      }
+    }
+
+    const configPath = path.join(dir, 'sidecar.json');
+    if (!existsSync(configPath) || !lstatSync(configPath).isFile()) continue;
+    let config;
+    try {
+      config = readJson(configPath);
+    } catch (error) {
+      failures.push(`INVALID  ${relative(repoRoot, configPath)} (${error.message})`);
+      continue;
+    }
+    const sidecar = entry.metadata.sidecar;
+    if (config.id !== entry.metadata.id) {
+      failures.push(`MISMATCH ${relative(repoRoot, configPath)} id must match extension.json id`);
+    }
+    if (config.port !== expectedPort(sidecar)) {
+      failures.push(`MISMATCH ${relative(repoRoot, configPath)} port must match extension.json sidecar.origin`);
+    }
+    if (config.proxy_auth !== sidecar.proxy_auth) {
+      failures.push(`MISMATCH ${relative(repoRoot, configPath)} proxy_auth must match extension.json sidecar.proxy_auth`);
+    }
+  }
+  return { failures, vendoredCount, externalCount, synced };
+}
+
+export function checkSidecarUsage(repoRoot) {
+  const failures = [];
+  const entries = extensionEntries(repoRoot);
+  const canonicalBasePath = path.join(repoRoot, 'examples', 'sidecar-scaffold', 'sidecar_base.py');
+  const canonicalBase = existsSync(canonicalBasePath) ? readFileSync(canonicalBasePath) : null;
+  for (const entry of entries) {
+    const allowedServerFile = vendoredDir(entry)
+      ? path.join(vendoredDir(entry), 'sidecar_base.py')
+      : null;
+    for (const filePath of walkFiles(entry.root)) {
+      const patterns = SERVER_PATTERNS.get(path.extname(filePath).toLowerCase());
+      if (!patterns) continue;
+      const contents = readFileSync(filePath);
+      if (filePath === allowedServerFile) {
+        if (canonicalBase !== null && contents.equals(canonicalBase)) continue;
+        failures.push(
+          `DRIFT    ${relative(repoRoot, filePath)} (server-file exemption requires byte identity with canonical sidecar_base.py)`
+        );
+        continue;
+      }
+      const source = contents.toString('utf8');
+      for (const pattern of patterns) {
+        if (pattern.test(source)) {
+          failures.push(
+            `ROGUE SERVER  ${relative(repoRoot, filePath)} matches ${pattern} — server code must use the canonical vendored scaffold or live in the declared external repository.`
+          );
+        }
+      }
+    }
+
+    const dir = vendoredDir(entry);
+    if (!dir) continue;
+    if (pathHasSymlink(entry.root, entry.metadata.sidecar.runtime.path)) {
+      failures.push(
+        `INVALID RUNTIME  ${relative(repoRoot, dir)} — vendored runtime path must not contain symlinks`
+      );
+      continue;
+    }
+    for (const unitPath of walkFiles(entry.root).filter((filePath) => /\.(service|container)$/.test(filePath))) {
+      if (unitPath.endsWith('.container')) {
+        failures.push(
+          `UNSUPPORTED CONTAINER  ${relative(repoRoot, unitPath)} — vendored Python sidecars must use a validated .service unit or declare an external runtime`
+        );
+        continue;
+      }
+      const source = readFileSync(unitPath, 'utf8');
+      const directive = 'ExecStart';
+      const workingDirectoryDirective = 'WorkingDirectory';
+      const mainSection = 'Service';
+      const unitDirectives = parseUnitDirectives(source);
+      const mainDirectives = unitDirectives.filter((item) => item.section === mainSection);
+      const allowedServiceDirectives = new Set([
+        'Type', 'WorkingDirectory', 'Environment', 'ExecStart', 'Restart', 'RestartSec'
+      ]);
+      for (const item of mainDirectives) {
+        if (!allowedServiceDirectives.has(item.name)
+            || (item.name === 'Environment'
+              && !/^HERMES_WEBUI_STATE_DIR=\S+$/.test(item.value))) {
+          failures.push(
+            `DISALLOWED ${item.name}  ${relative(repoRoot, unitPath)} — service directives are restricted to the canonical launch environment`
+          );
+        }
+      }
+      const execs = mainDirectives
+        .filter((item) => item.name === directive)
+        .map((item) => item.raw);
+      const workingDirectories = mainDirectives
+        .filter((item) => item.name === workingDirectoryDirective);
+      const workingDirectory = workingDirectories.length > 0
+        ? workingDirectories.at(-1).value
+        : null;
+      if (execs.length === 0) {
+        failures.push(`MISSING ${directive}  ${relative(repoRoot, unitPath)} — must use /usr/bin/python3 -S [-u] sidecar.py`);
+        continue;
+      }
+      for (const exec of execs) {
+        if (!runsCanonicalEntrypoint(
+          exec,
+          entry.id,
+          entry.metadata.sidecar.runtime.path,
+          workingDirectory
+        )) {
+          failures.push(
+            `BAD ${directive}  ${relative(repoRoot, unitPath)} — must use /usr/bin/python3 -S [-u] sidecar.py, got: ${exec.trim()}`
+          );
+        }
+      }
+    }
+  }
+  return { failures, scannedCount: entries.length };
+}

--- a/scripts/sidecar-contract-lib.mjs
+++ b/scripts/sidecar-contract-lib.mjs
@@ -70,14 +70,38 @@ function hasTopLevelRegister(filePath) {
     '        and isinstance(expr.func.value, ast.Name)',
     '        and expr.func.value.id == "app"',
     '    )',
+    'class NamedExprFinder(ast.NodeVisitor):',
+    '    def __init__(self):',
+    '        self.bindings = []',
+    '    def visit_NamedExpr(self, node):',
+    '        if isinstance(node.target, ast.Name) and node.target.id == "register":',
+    '            self.bindings.append(node)',
+    '        self.visit(node.value)',
+    '    def visit_Lambda(self, node):',
+    '        for default in [*node.args.defaults, *node.args.kw_defaults]:',
+    '            if default is not None: self.visit(default)',
     'class BindingFinder(ast.NodeVisitor):',
     '    def __init__(self):',
     '        self.bindings = []',
+    '    def scan_namedexpr(self, expressions):',
+    '        finder = NamedExprFinder()',
+    '        for expression in expressions:',
+    '            if expression is not None: finder.visit(expression)',
+    '        self.bindings.extend(finder.bindings)',
+    '    def annotations(self, args):',
+    '        values = [*args.posonlyargs, *args.args, *args.kwonlyargs]',
+    '        values.extend(item for item in [args.vararg, args.kwarg] if item)',
+    '        return [item.annotation for item in values]',
     '    def visit_FunctionDef(self, node):',
     '        if node.name == "register": self.bindings.append(node)',
+    '        self.scan_namedexpr([*node.decorator_list, *node.args.defaults,',
+    '                             *node.args.kw_defaults, *self.annotations(node.args),',
+    '                             node.returns])',
     '    visit_AsyncFunctionDef = visit_FunctionDef',
     '    def visit_ClassDef(self, node):',
     '        if node.name == "register": self.bindings.append(node)',
+    '        self.scan_namedexpr([*node.decorator_list, *node.bases,',
+    '                             *(keyword.value for keyword in node.keywords)])',
     '    def visit_Name(self, node):',
     '        if node.id == "register" and isinstance(node.ctx, (ast.Store, ast.Del)):',
     '            self.bindings.append(node)',
@@ -87,24 +111,43 @@ function hasTopLevelRegister(filePath) {
     '                self.bindings.append(node)',
     '    def visit_ImportFrom(self, node):',
     '        for alias in node.names:',
-    '            if (alias.asname or alias.name) == "register":',
+    '            if alias.name == "*" or (alias.asname or alias.name) == "register":',
     '                self.bindings.append(node)',
     '    def visit_ExceptHandler(self, node):',
     '        if node.name == "register": self.bindings.append(node)',
     '        self.generic_visit(node)',
-    '    def visit_Lambda(self, node): pass',
-    '    def visit_ListComp(self, node): pass',
-    '    def visit_SetComp(self, node): pass',
-    '    def visit_DictComp(self, node): pass',
-    '    def visit_GeneratorExp(self, node): pass',
-    'if any(isinstance(node, ast.Raise) for node in tree.body):',
+    '    def visit_MatchAs(self, node):',
+    '        if node.name == "register": self.bindings.append(node)',
+    '        self.generic_visit(node)',
+    '    def visit_MatchStar(self, node):',
+    '        if node.name == "register": self.bindings.append(node)',
+    '    def visit_MatchMapping(self, node):',
+    '        if node.rest == "register": self.bindings.append(node)',
+    '        self.generic_visit(node)',
+    '    def visit_Lambda(self, node):',
+    '        self.scan_namedexpr([*node.args.defaults, *node.args.kw_defaults])',
+    '    def visit_ListComp(self, node): self.scan_namedexpr([node])',
+    '    def visit_SetComp(self, node): self.scan_namedexpr([node])',
+    '    def visit_DictComp(self, node): self.scan_namedexpr([node])',
+    '    def visit_GeneratorExp(self, node): self.scan_namedexpr([node])',
+    'control_flow = (ast.If, ast.For, ast.AsyncFor, ast.While, ast.Try,',
+    '                ast.With, ast.AsyncWith, ast.Assert)',
+    'optional_control_flow = tuple(',
+    '    item for item in (getattr(ast, "TryStar", None), getattr(ast, "Match", None))',
+    '    if item is not None',
+    ')',
+    'if any(isinstance(node, (ast.Raise,) + control_flow + optional_control_flow)',
+    '       for node in tree.body):',
+    '    raise SystemExit(1)',
+    'if any(isinstance(node, ast.Global) and "register" in node.names',
+    '       for node in ast.walk(tree)):',
     '    raise SystemExit(1)',
     'finder = BindingFinder()',
     'for node in tree.body:',
     '    finder.visit(node)',
     'bindings = finder.bindings',
     'if (len(bindings) != 1 or not isinstance(bindings[0], ast.FunctionDef)',
-    '        or bindings[0] not in tree.body):',
+    '        or bindings[0] not in tree.body or bindings[0].decorator_list):',
     '    raise SystemExit(1)',
     'node = bindings[0]',
     'positional = [*node.args.posonlyargs, *node.args.args]',
@@ -115,9 +158,7 @@ function hasTopLevelRegister(filePath) {
     'for statement in node.body:',
     '    if isinstance(statement, (ast.Raise, ast.Return)):',
     '        break',
-    '    if isinstance(statement, (ast.If, ast.For, ast.AsyncFor, ast.While,',
-    '                              ast.Try, ast.TryStar, ast.With, ast.AsyncWith,',
-    '                              ast.Match, ast.Assert)):',
+    '    if isinstance(statement, control_flow + optional_control_flow):',
     '        break',
     '    if isinstance(statement, ast.FunctionDef):',
     '        if any(is_route_factory(decorator) for decorator in statement.decorator_list):',
@@ -175,6 +216,18 @@ function pathHasSymlink(root, relativePath) {
     if (existsSync(current) && lstatSync(current).isSymbolicLink()) return true;
   }
   return false;
+}
+
+export function symlinksUnder(dir, prefix = '') {
+  if (!existsSync(dir)) return [];
+  const symlinks = [];
+  for (const item of readdirSync(dir, { withFileTypes: true })) {
+    const relativePath = prefix ? `${prefix}/${item.name}` : item.name;
+    const target = path.join(dir, item.name);
+    if (item.isSymbolicLink()) symlinks.push(relativePath);
+    else if (item.isDirectory()) symlinks.push(...symlinksUnder(target, relativePath));
+  }
+  return symlinks;
 }
 
 function importShadowCollisions(runtimeDir) {
@@ -245,23 +298,11 @@ function expectedPort(sidecar) {
 }
 
 function vendoredOriginIsCanonical(sidecar) {
-  try {
-    const origin = new URL(sidecar.origin);
-    const port = Number(origin.port);
-    return origin.protocol === 'http:'
-      && origin.hostname === '127.0.0.1'
-      && Boolean(origin.port)
-      && Number.isInteger(port)
-      && port >= 1
-      && port <= 65535
-      && !origin.username
-      && !origin.password
-      && origin.pathname === '/'
-      && !origin.search
-      && !origin.hash;
-  } catch (_) {
-    return false;
-  }
+  if (typeof sidecar?.origin !== 'string') return false;
+  const match = /^http:\/\/127\.0\.0\.1:([1-9]\d*)$/.exec(sidecar.origin.trim());
+  if (!match) return false;
+  const port = Number(match[1]);
+  return Number.isInteger(port) && port <= 65535;
 }
 
 function commandTokens(command) {
@@ -285,11 +326,15 @@ function normalizedUnitPath(value) {
   return path.posix.normalize(unquoted.replaceAll('\\', '/'));
 }
 
-function runsCanonicalEntrypoint(directive, entryId, runtimePath, workingDirectory) {
+function runsCanonicalEntrypoint(
+  directive,
+  runtimePath,
+  workingDirectory,
+  installDirectory
+) {
   const equals = directive.indexOf('=');
   if (equals < 0) return false;
-  let command = directive.slice(equals + 1).trim();
-  if (command.startsWith('-')) command = command.slice(1).trim();
+  const command = directive.slice(equals + 1).trim();
   const tokens = commandTokens(command);
   if (tokens.length === 0) return false;
 
@@ -307,10 +352,16 @@ function runsCanonicalEntrypoint(directive, entryId, runtimePath, workingDirecto
   const scriptToken = tokens[0];
 
   const normalizedRuntime = path.posix.normalize(runtimePath);
-  const expectedWorkingSuffix = `/${entryId}/${normalizedRuntime}`;
+  const normalizedInstallDirectory = normalizedUnitPath(installDirectory);
   const normalizedWorkingDirectory = normalizedUnitPath(workingDirectory);
-  if (normalizedWorkingDirectory === null
-      || !normalizedWorkingDirectory.endsWith(expectedWorkingSuffix)) {
+  if (normalizedInstallDirectory === null || normalizedWorkingDirectory === null) {
+    return false;
+  }
+  const expectedWorkingDirectory = path.posix.join(
+    normalizedInstallDirectory,
+    normalizedRuntime
+  );
+  if (normalizedWorkingDirectory !== expectedWorkingDirectory) {
     return false;
   }
   const normalizedScript = normalizedUnitPath(scriptToken);
@@ -351,6 +402,11 @@ export function checkScaffoldSync(repoRoot, { write = false } = {}) {
       failures.push(`INVALID  ${relative(repoRoot, dir)} runtime path must not contain symlinks`);
       continue;
     }
+    for (const symlink of symlinksUnder(dir)) {
+      failures.push(
+        `INVALID  ${relative(repoRoot, path.join(dir, symlink))} runtime tree must not contain symlinks`
+      );
+    }
     for (const collision of importShadowCollisions(dir)) {
       failures.push(
         `INVALID  ${relative(repoRoot, path.join(dir, collision))} shadows a canonical Python module`
@@ -365,7 +421,13 @@ export function checkScaffoldSync(repoRoot, { write = false } = {}) {
 
     for (const name of REQUIRED_VENDORED_FILES) {
       const destination = path.join(dir, name);
-      if (existsSync(destination) && !lstatSync(destination).isFile()) {
+      let destinationStat = null;
+      try {
+        destinationStat = lstatSync(destination);
+      } catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+      }
+      if (destinationStat !== null && !destinationStat.isFile()) {
         failures.push(`INVALID  ${relative(repoRoot, destination)} must be a regular file`);
         continue;
       }
@@ -375,7 +437,7 @@ export function checkScaffoldSync(repoRoot, { write = false } = {}) {
         synced += 1;
         continue;
       }
-      if (!existsSync(destination)) {
+      if (destinationStat === null) {
         failures.push(`MISSING  ${relative(repoRoot, destination)} (vendored scaffold incomplete)`);
         continue;
       }
@@ -413,14 +475,16 @@ export function checkScaffoldSync(repoRoot, { write = false } = {}) {
 
 export function checkSidecarUsage(repoRoot) {
   const failures = [];
+  const warnings = [];
   const entries = extensionEntries(repoRoot);
   const canonicalBasePath = path.join(repoRoot, 'examples', 'sidecar-scaffold', 'sidecar_base.py');
   const canonicalBase = existsSync(canonicalBasePath) ? readFileSync(canonicalBasePath) : null;
   for (const entry of entries) {
+    const entryFiles = walkFiles(entry.root);
     const allowedServerFile = vendoredDir(entry)
       ? path.join(vendoredDir(entry), 'sidecar_base.py')
       : null;
-    for (const filePath of walkFiles(entry.root)) {
+    for (const filePath of entryFiles) {
       const patterns = SERVER_PATTERNS.get(path.extname(filePath).toLowerCase());
       if (!patterns) continue;
       const contents = readFileSync(filePath);
@@ -449,7 +513,19 @@ export function checkSidecarUsage(repoRoot) {
       );
       continue;
     }
-    for (const unitPath of walkFiles(entry.root).filter((filePath) => /\.(service|container)$/.test(filePath))) {
+    for (const symlink of symlinksUnder(dir)) {
+      failures.push(
+        `INVALID RUNTIME  ${relative(repoRoot, path.join(dir, symlink))} — runtime tree must not contain symlinks`
+      );
+    }
+    for (const dropInPath of entryFiles.filter((filePath) => (
+      /(?:^|[/\\])[^/\\]+\.service\.d[/\\][^/\\]+\.conf$/.test(filePath)
+    ))) {
+      failures.push(
+        `DISALLOWED DROP-IN  ${relative(repoRoot, dropInPath)} — vendored launch behavior must live in one reviewed .service unit`
+      );
+    }
+    for (const unitPath of entryFiles.filter((filePath) => /\.(service|container)$/.test(filePath))) {
       if (unitPath.endsWith('.container')) {
         failures.push(
           `UNSUPPORTED CONTAINER  ${relative(repoRoot, unitPath)} — vendored Python sidecars must use a validated .service unit or declare an external runtime`
@@ -467,8 +543,9 @@ export function checkSidecarUsage(repoRoot) {
       ]);
       for (const item of mainDirectives) {
         if (!allowedServiceDirectives.has(item.name)
+            || (item.name === 'Type' && item.value !== 'simple')
             || (item.name === 'Environment'
-              && !/^HERMES_WEBUI_STATE_DIR=\S+$/.test(item.value))) {
+              && !/^(?:HERMES_WEBUI_STATE_DIR|HERMES_EXT_INSTALL_DIR)=\S+$/.test(item.value))) {
           failures.push(
             `DISALLOWED ${item.name}  ${relative(repoRoot, unitPath)} — service directives are restricted to the canonical launch environment`
           );
@@ -482,16 +559,53 @@ export function checkSidecarUsage(repoRoot) {
       const workingDirectory = workingDirectories.length > 0
         ? workingDirectories.at(-1).value
         : null;
+      const stateDirectories = mainDirectives
+        .filter((item) => item.name === 'Environment')
+        .map((item) => /^HERMES_WEBUI_STATE_DIR=(\S+)$/.exec(item.value)?.[1])
+        .filter(Boolean);
+      const stateDirectory = stateDirectories.length > 0
+        ? stateDirectories.at(-1)
+        : '%h/.hermes/webui';
+      const installDirectories = mainDirectives
+        .filter((item) => item.name === 'Environment')
+        .map((item) => /^HERMES_EXT_INSTALL_DIR=(\S+)$/.exec(item.value)?.[1])
+        .filter(Boolean);
+      const installDirectory = installDirectories.length > 0
+        ? installDirectories.at(-1)
+        : path.posix.join(stateDirectory, 'extensions', entry.id);
+      for (const [name, value] of [
+        ...(stateDirectories.length > 0 && stateDirectory !== '%h/.hermes/webui'
+          ? [['HERMES_WEBUI_STATE_DIR', stateDirectory]]
+          : []),
+        ...(installDirectories.length > 0
+          ? [['HERMES_EXT_INSTALL_DIR', installDirectory]]
+          : [])
+      ]) {
+        const normalized = normalizedUnitPath(value);
+        if (!(normalized?.startsWith('/') || normalized === '%h' || normalized?.startsWith('%h/'))) {
+          failures.push(
+            `BAD ${name}  ${relative(repoRoot, unitPath)} — custom directories must be absolute or %h-anchored`
+          );
+        } else {
+          warnings.push(
+            `REVIEW ${relative(repoRoot, unitPath)} ${name}=${value} — confirm this is an operator-controlled, non-broadly-writable directory`
+          );
+        }
+      }
       if (execs.length === 0) {
         failures.push(`MISSING ${directive}  ${relative(repoRoot, unitPath)} — must use /usr/bin/python3 -S [-u] sidecar.py`);
+        continue;
+      }
+      if (execs.length > 1) {
+        failures.push(`MULTIPLE ${directive}  ${relative(repoRoot, unitPath)} — exactly one launch command is allowed`);
         continue;
       }
       for (const exec of execs) {
         if (!runsCanonicalEntrypoint(
           exec,
-          entry.id,
           entry.metadata.sidecar.runtime.path,
-          workingDirectory
+          workingDirectory,
+          installDirectory
         )) {
           failures.push(
             `BAD ${directive}  ${relative(repoRoot, unitPath)} — must use /usr/bin/python3 -S [-u] sidecar.py, got: ${exec.trim()}`
@@ -500,5 +614,5 @@ export function checkSidecarUsage(repoRoot) {
       }
     }
   }
-  return { failures, scannedCount: entries.length };
+  return { failures, warnings, scannedCount: entries.length };
 }

--- a/scripts/sync-sidecar-base.mjs
+++ b/scripts/sync-sidecar-base.mjs
@@ -7,59 +7,25 @@
 //   node scripts/sync-sidecar-base.mjs --check   (CI: fail on any drift)
 //   node scripts/sync-sidecar-base.mjs --write    (local: copy canonical -> all)
 //
-// Canonical files: sidecar_base.py and sidecar.py (the entrypoint). A sidecar
-// extension is any extensions/<id>/sidecar/ dir that contains sidecar_base.py.
-import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+// Canonical files: sidecar_base.py and sidecar.py (the entrypoint). Targets are
+// discovered from extension.json sidecar.runtime metadata, never from the files
+// being enforced.
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { checkScaffoldSync } from './sidecar-contract-lib.mjs';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const CANON_DIR = path.join(REPO, 'examples', 'sidecar-scaffold');
-const CANON_FILES = ['sidecar_base.py', 'sidecar.py'];
-
-function findSidecarDirs() {
-  const extRoot = path.join(REPO, 'extensions');
-  if (!existsSync(extRoot)) return [];
-  const dirs = [];
-  for (const id of readdirSync(extRoot)) {
-    const sc = path.join(extRoot, id, 'sidecar');
-    if (existsSync(path.join(sc, 'sidecar_base.py'))) dirs.push(sc);
-  }
-  return dirs;
-}
-
 const mode = process.argv.includes('--write') ? 'write' : 'check';
-const canon = Object.fromEntries(
-  CANON_FILES.map((f) => [f, readFileSync(path.join(CANON_DIR, f))])
+const result = checkScaffoldSync(REPO, { write: mode === 'write' });
+for (const failure of result.failures) console.error(failure);
+
+if (result.failures.length) {
+  console.error(`\n${result.failures.length} sidecar scaffold/manifest violation(s).`);
+  process.exit(1);
+}
+
+if (mode === 'write') console.log(`synced ${result.synced} protected scaffold file(s).`);
+else console.log(
+  `sidecar scaffold in sync across ${result.vendoredCount} vendored sidecar(s); `
+  + `${result.externalCount} external runtime(s) require no Python scaffold.`
 );
-const targets = findSidecarDirs();
-let drift = 0;
-
-for (const dir of targets) {
-  for (const f of CANON_FILES) {
-    const dest = path.join(dir, f);
-    const rel = path.relative(REPO, dest);
-    if (mode === 'write') {
-      writeFileSync(dest, canon[f]);
-      console.log(`synced ${rel}`);
-      continue;
-    }
-    if (!existsSync(dest)) {
-      console.error(`MISSING  ${rel} (vendored scaffold incomplete)`);
-      drift++;
-      continue;
-    }
-    if (!readFileSync(dest).equals(canon[f])) {
-      console.error(`DRIFT    ${rel} (differs from canonical examples/sidecar-scaffold/${f})`);
-      drift++;
-    }
-  }
-}
-
-if (mode === 'check') {
-  if (drift) {
-    console.error(`\n${drift} sidecar scaffold file(s) drifted. Run: node scripts/sync-sidecar-base.mjs --write`);
-    process.exit(1);
-  }
-  console.log(`sidecar scaffold in sync across ${targets.length} sidecar extension(s).`);
-}

--- a/scripts/sync-sidecar-base.mjs
+++ b/scripts/sync-sidecar-base.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Enforce that every vendored copy of the canonical sidecar scaffold is
+// byte-identical to the reference in examples/sidecar-scaffold/. A sidecar's
+// trust boundary is only as good as the scaffold it runs, so drift is a build
+// failure, not a warning.
+//
+//   node scripts/sync-sidecar-base.mjs --check   (CI: fail on any drift)
+//   node scripts/sync-sidecar-base.mjs --write    (local: copy canonical -> all)
+//
+// Canonical files: sidecar_base.py and sidecar.py (the entrypoint). A sidecar
+// extension is any extensions/<id>/sidecar/ dir that contains sidecar_base.py.
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CANON_DIR = path.join(REPO, 'examples', 'sidecar-scaffold');
+const CANON_FILES = ['sidecar_base.py', 'sidecar.py'];
+
+function findSidecarDirs() {
+  const extRoot = path.join(REPO, 'extensions');
+  if (!existsSync(extRoot)) return [];
+  const dirs = [];
+  for (const id of readdirSync(extRoot)) {
+    const sc = path.join(extRoot, id, 'sidecar');
+    if (existsSync(path.join(sc, 'sidecar_base.py'))) dirs.push(sc);
+  }
+  return dirs;
+}
+
+const mode = process.argv.includes('--write') ? 'write' : 'check';
+const canon = Object.fromEntries(
+  CANON_FILES.map((f) => [f, readFileSync(path.join(CANON_DIR, f))])
+);
+const targets = findSidecarDirs();
+let drift = 0;
+
+for (const dir of targets) {
+  for (const f of CANON_FILES) {
+    const dest = path.join(dir, f);
+    const rel = path.relative(REPO, dest);
+    if (mode === 'write') {
+      writeFileSync(dest, canon[f]);
+      console.log(`synced ${rel}`);
+      continue;
+    }
+    if (!existsSync(dest)) {
+      console.error(`MISSING  ${rel} (vendored scaffold incomplete)`);
+      drift++;
+      continue;
+    }
+    if (!readFileSync(dest).equals(canon[f])) {
+      console.error(`DRIFT    ${rel} (differs from canonical examples/sidecar-scaffold/${f})`);
+      drift++;
+    }
+  }
+}
+
+if (mode === 'check') {
+  if (drift) {
+    console.error(`\n${drift} sidecar scaffold file(s) drifted. Run: node scripts/sync-sidecar-base.mjs --write`);
+    process.exit(1);
+  }
+  console.log(`sidecar scaffold in sync across ${targets.length} sidecar extension(s).`);
+}

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -27,23 +27,13 @@ function mergeDeep(base, overrides) {
   return out;
 }
 
-function validationErrors(scriptText, extensionOverrides = {}) {
+function validationResult(scriptText, extensionOverrides = {}, runtimeOverrides = {}, setup = null) {
   const id = `validator-case-${Math.random().toString(36).slice(2, 8)}`;
   const root = path.join(tmpRoot, id);
   const asset = 'assets/adapter.js';
   mkdirSync(path.join(root, 'assets'), { recursive: true });
   writeFileSync(path.join(root, 'README.md'), '# Validator fixture\n', { encoding: 'utf8', flag: 'w' });
   writeFileSync(path.join(root, 'assets/adapter.js'), scriptText, { encoding: 'utf8', flag: 'w' });
-  writeJson(path.join(root, 'manifest.json'), {
-    extensions: [
-      {
-        id,
-        name: 'Validator Fixture',
-        scripts: [asset],
-        stylesheets: []
-      }
-    ]
-  });
   const extensionJson = mergeDeep({
     id,
     name: 'Validator Fixture',
@@ -85,12 +75,26 @@ function validationErrors(scriptText, extensionOverrides = {}) {
       network_external: false
     }
   }, extensionOverrides);
+  const runtime = mergeDeep({
+    id,
+    name: 'Validator Fixture',
+    scripts: [asset],
+    stylesheets: [],
+    ...(extensionJson.sidecar ? { sidecar: structuredClone(extensionJson.sidecar) } : {})
+  }, runtimeOverrides);
+  if (runtime.sidecar) delete runtime.sidecar.runtime;
+  writeJson(path.join(root, 'manifest.json'), { extensions: [runtime] });
   writeJson(path.join(root, 'extension.json'), extensionJson);
+  if (setup) setup({ id, root, extensionJson, runtime });
   return validateEntry({
     idFromDir: id,
     root,
     extensionJsonPath: path.join(root, 'extension.json')
-  }).errors;
+  });
+}
+
+function validationErrors(scriptText, extensionOverrides = {}, runtimeOverrides = {}, setup = null) {
+  return validationResult(scriptText, extensionOverrides, runtimeOverrides, setup).errors;
 }
 
 try {
@@ -131,6 +135,164 @@ try {
     ]
   });
   assert(errors.includes('settings_schema requires permissions.storage.owned to be true'));
+
+  errors = validationErrors('', {
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'token-v1', runtime: { kind: 'vendored', path: 'sidecar' }
+    }
+  });
+  assert(errors.includes('sidecar block requires the loopback-sidecar capability'));
+
+  errors = validationErrors('', {}, {
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'legacy'
+    }
+  });
+  assert(errors.includes('manifest sidecar block requires loopback-sidecar metadata in extension.json'));
+
+  const externalLegacy = validationResult('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback',
+      origin: 'http://127.0.0.1:17787',
+      health_path: '/health',
+      proxy_auth: 'legacy',
+      runtime: {
+        kind: 'external',
+        repository: 'https://github.com/example/sidecar'
+      }
+    },
+    lifecycle: { sidecar_start_required: true },
+    permissions: { loopback_sidecar: true }
+  });
+  assert.deepEqual(externalLegacy.errors, []);
+  assert(externalLegacy.warnings.includes('external sidecar runtime is explicitly legacy (proxy_auth: legacy)'));
+
+  const externalToken = validationResult('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback',
+      origin: 'http://127.0.0.1:17788',
+      health_path: '/health',
+      proxy_auth: 'token-v1',
+      runtime: {
+        kind: 'external',
+        repository: 'https://github.com/example/node-sidecar'
+      }
+    },
+    permissions: { loopback_sidecar: true }
+  });
+  assert.deepEqual(externalToken.errors, []);
+  assert.deepEqual(externalToken.warnings, []);
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'token-vI',
+      runtime: { kind: 'external', repository: 'https://github.com/example/sidecar' }
+    },
+    permissions: { loopback_sidecar: true }
+  });
+  assert(errors.includes('sidecar.proxy_auth must be legacy or token-v1'));
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'legacy'
+    },
+    permissions: { loopback_sidecar: true }
+  });
+  assert(errors.includes('sidecar.runtime is required when loopback-sidecar capability is declared'));
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'legacy', runtime: { kind: 'external' }
+    },
+    permissions: { loopback_sidecar: true }
+  });
+  assert(errors.includes('sidecar.runtime.repository is required for an external runtime'));
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'token-v1', runtime: { kind: 'vendored' }
+    },
+    permissions: { loopback_sidecar: true }
+  });
+  assert(errors.includes('sidecar.runtime.path is required for a vendored runtime'));
+
+  const realRuntime = path.join(tmpRoot, 'real-vendored-runtime');
+  mkdirSync(realRuntime);
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17790', health_path: '/health',
+      proxy_auth: 'token-v1', runtime: { kind: 'vendored', path: 'sidecar' }
+    },
+    permissions: { loopback_sidecar: true }
+  }, {}, ({ root }) => symlinkSync(realRuntime, path.join(root, 'sidecar'), 'dir'));
+  assert(errors.includes('vendored sidecar runtime path must not contain symlinks: sidecar'));
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'https://127.0.0.1:17790', health_path: '/health',
+      proxy_auth: 'token-v1', runtime: { kind: 'vendored', path: 'sidecar' }
+    }
+  });
+  assert(errors.includes('vendored sidecar.origin must use http://127.0.0.1 with an explicit port'));
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://localhost:17790', health_path: '/health',
+      proxy_auth: 'token-v1', runtime: { kind: 'vendored', path: 'sidecar' }
+    }
+  });
+  assert(errors.includes('vendored sidecar.origin must use http://127.0.0.1 with an explicit port'));
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17790', health_path: '/ready',
+      proxy_auth: 'token-v1', runtime: { kind: 'vendored', path: 'sidecar' }
+    }
+  });
+  assert(errors.includes('vendored sidecar.health_path must be /health'));
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'token-v1',
+      runtime: { kind: 'external', repository: 'https://github.com/example/sidecar' }
+    },
+    permissions: { loopback_sidecar: true }
+  }, {
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'legacy'
+    }
+  });
+  assert(errors.includes('manifest sidecar.proxy_auth must match extension.json sidecar.proxy_auth'));
+
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17787', health_path: '/health',
+      proxy_auth: 'legacy',
+      runtime: { kind: 'external', repository: 'https://github.com/example/sidecar' }
+    },
+    permissions: { loopback_sidecar: true }
+  }, { sidecar: null });
+  assert(errors.includes('manifest sidecar block is required when loopback-sidecar capability is declared'));
 
   const first = buildRegistryWithArtifacts({
     publishedAt: '2026-01-01T00:00:00.000Z',

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import {
+  cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { buildRegistryWithArtifacts, validateEntry } from './extension-registry-lib.mjs';
+import {
+  buildExtensionArtifact, buildRegistryWithArtifacts, validateAllEntries, validateEntry
+} from './extension-registry-lib.mjs';
 
 const tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'hermes-extension-validator-'));
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
@@ -98,8 +102,70 @@ function validationErrors(scriptText, extensionOverrides = {}, runtimeOverrides 
 }
 
 try {
+  const linkedRootRepo = path.join(tmpRoot, 'linked-root-repo');
+  const linkedRootTarget = path.join(tmpRoot, 'linked-root-target');
+  mkdirSync(path.join(linkedRootRepo, 'extensions'), { recursive: true });
+  mkdirSync(linkedRootTarget, { recursive: true });
+  writeFileSync(path.join(linkedRootTarget, 'extension.json'), '{ deliberately invalid json', 'utf8');
+  symlinkSync(linkedRootTarget, path.join(linkedRootRepo, 'extensions', 'linked-entry'), 'dir');
+  const linkedRootResults = validateAllEntries({ repoRoot: linkedRootRepo }).results;
+  assert.equal(linkedRootResults.length, 1,
+    'discovery must report, not silently omit, a symlinked extension root');
+  assert.deepEqual(linkedRootResults[0].errors,
+    ['extension root must be a real directory, not a symlink']);
+
+  const nullMetadataRepo = path.join(tmpRoot, 'null-metadata-repo');
+  const nullMetadataRoot = path.join(nullMetadataRepo, 'extensions', 'null-entry');
+  mkdirSync(nullMetadataRoot, { recursive: true });
+  writeFileSync(path.join(nullMetadataRoot, 'extension.json'), 'null\n', 'utf8');
+  const nullResults = validateAllEntries({ repoRoot: nullMetadataRepo }).results;
+  assert.equal(nullResults.length, 1);
+  assert.deepEqual(nullResults[0].errors, ['extension.json must contain a JSON object']);
+
+  const danglingMetadataRepo = path.join(tmpRoot, 'dangling-metadata-repo');
+  const danglingMetadataRoot = path.join(danglingMetadataRepo, 'extensions', 'dangling-entry');
+  mkdirSync(danglingMetadataRoot, { recursive: true });
+  symlinkSync('missing-extension.json', path.join(danglingMetadataRoot, 'extension.json'), 'file');
+  const danglingResults = validateAllEntries({ repoRoot: danglingMetadataRepo }).results;
+  assert.equal(danglingResults.length, 1,
+    'discovery must not omit an extension whose metadata path is a dangling symlink');
+  assert(danglingResults[0].errors.includes('extension.json must be a real regular file, not a symlink'));
+
   let errors = validationErrors("fetch('/api/sessions/123');\n");
   assert(errors.includes('permissions.webui_api.read must include sessions'));
+
+  const linkedAssetTarget = path.join(tmpRoot, 'linked-asset-target.js');
+  writeFileSync(linkedAssetTarget, 'this is deliberately invalid JavaScript {{\n', 'utf8');
+  errors = validationErrors('', {}, {}, ({ root }) => {
+    const asset = path.join(root, 'assets', 'adapter.js');
+    rmSync(asset);
+    symlinkSync(linkedAssetTarget, asset, 'file');
+  });
+  assert(errors.includes('extension tree must not contain symlinks: assets/adapter.js'),
+    'validation must reject declared assets that artifact collection would omit');
+  assert(!errors.some((error) => error.startsWith('JavaScript syntax check failed')),
+    'validation must fail before reading or parsing a symlink target outside the extension tree');
+
+  const unicodeAsset = 'assets/café.js';
+  const unicodeResult = validationResult('', {
+    assets: { scripts: [unicodeAsset], stylesheets: [] }
+  }, {
+    scripts: [unicodeAsset], stylesheets: []
+  }, ({ root }) => {
+    writeFileSync(path.join(root, unicodeAsset), 'console.log("unicode asset");\n', 'utf8');
+  });
+  assert.deepEqual(unicodeResult.errors, []);
+  const unicodeArtifact = buildExtensionArtifact(unicodeResult);
+  const unicodeZip = path.join(tmpRoot, 'unicode-artifact.zip');
+  writeFileSync(unicodeZip, unicodeArtifact.buffer);
+  const listed = spawnSync('python3', [
+    '-c',
+    'import json,sys,zipfile; print(json.dumps(zipfile.ZipFile(sys.argv[1]).namelist(), ensure_ascii=False))',
+    unicodeZip
+  ], { encoding: 'utf8' });
+  assert.equal(listed.status, 0, listed.stderr);
+  assert(JSON.parse(listed.stdout).includes(`${unicodeResult.id}/${unicodeAsset}`),
+    'ZIP artifacts must mark UTF-8 member names so consumers decode them losslessly');
 
   errors = validationErrors("fetch('/api/session/draft');\n");
   assert(errors.includes('permissions.webui_api.write must include session/draft'));
@@ -187,6 +253,51 @@ try {
   assert.deepEqual(externalToken.errors, []);
   assert.deepEqual(externalToken.warnings, []);
 
+  for (const origin of [
+    'http://127.0.0.1:17788/admin',
+    'http://127.0.0.1:17788?mode=debug',
+    'http://user@127.0.0.1:17788',
+    'http://2130706433:17788',
+    'http://0x7f000001:17788',
+    'http://%31%32%37.0.0.1:17788'
+  ]) {
+    errors = validationErrors('', {
+      capabilities: ['manifest-bundle', 'loopback-sidecar'],
+      sidecar: {
+        type: 'loopback',
+        origin,
+        health_path: '/health',
+        proxy_auth: 'legacy',
+        runtime: { kind: 'external', repository: 'https://github.com/example/sidecar' }
+      },
+      lifecycle: { sidecar_start_required: true },
+      permissions: { loopback_sidecar: true }
+    });
+    assert(
+      errors.includes('sidecar.origin must be a loopback HTTP(S) origin without path, query, fragment, or userinfo'),
+      `core-incompatible sidecar origin must fail validation: ${origin}`
+    );
+  }
+
+  for (const healthPath of ['/health?token=abc', '/health%3Ftoken=abc', '//health', '/health/../admin']) {
+    errors = validationErrors('', {
+      capabilities: ['manifest-bundle', 'loopback-sidecar'],
+      sidecar: {
+        type: 'loopback',
+        origin: 'http://127.0.0.1:17788',
+        health_path: healthPath,
+        proxy_auth: 'legacy',
+        runtime: { kind: 'external', repository: 'https://github.com/example/sidecar' }
+      },
+      lifecycle: { sidecar_start_required: true },
+      permissions: { loopback_sidecar: true }
+    });
+    assert(
+      errors.includes('sidecar.health_path must be a safe absolute path without query or fragment'),
+      `core-incompatible sidecar health path must fail validation: ${healthPath}`
+    );
+  }
+
   errors = validationErrors('', {
     capabilities: ['manifest-bundle', 'loopback-sidecar'],
     sidecar: {
@@ -238,7 +349,23 @@ try {
     },
     permissions: { loopback_sidecar: true }
   }, {}, ({ root }) => symlinkSync(realRuntime, path.join(root, 'sidecar'), 'dir'));
-  assert(errors.includes('vendored sidecar runtime path must not contain symlinks: sidecar'));
+  assert(errors.includes('extension tree must not contain symlinks: sidecar'));
+
+  const externalRuntimeFile = path.join(tmpRoot, 'external-runtime-helper.py');
+  writeFileSync(externalRuntimeFile, '# outside packaged runtime\n', 'utf8');
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17790', health_path: '/health',
+      proxy_auth: 'token-v1', runtime: { kind: 'vendored', path: 'sidecar' }
+    },
+    permissions: { loopback_sidecar: true }
+  }, {}, ({ root }) => {
+    const runtime = path.join(root, 'sidecar');
+    mkdirSync(runtime);
+    symlinkSync(externalRuntimeFile, path.join(runtime, 'linked-helper.py'), 'file');
+  });
+  assert(errors.includes('extension tree must not contain symlinks: sidecar/linked-helper.py'));
 
   errors = validationErrors('', {
     capabilities: ['manifest-bundle', 'loopback-sidecar'],
@@ -334,6 +461,53 @@ try {
   const mobileArtifact = first.artifacts.find((item) => item.id === 'mobile-conversations');
   assert(mobileArtifact.buffer.includes(Buffer.from('mobile-conversations/assets/mobile-conversations.js')));
 
+  const invalidRepo = path.join(tmpRoot, 'empty-vendored-repo');
+  const invalidEntryRoot = path.join(invalidRepo, 'extensions', 'broken-sidecar');
+  const repoRoot = path.resolve(scriptsDir, '..');
+  cpSync(
+    path.join(repoRoot, 'examples', 'sidecar-scaffold'),
+    path.join(invalidRepo, 'examples', 'sidecar-scaffold'),
+    { recursive: true }
+  );
+  cpSync(
+    path.join(repoRoot, 'extensions', 'assistant-avatar'),
+    invalidEntryRoot,
+    { recursive: true }
+  );
+  const invalidEntry = JSON.parse(readFileSync(path.join(invalidEntryRoot, 'extension.json'), 'utf8'));
+  invalidEntry.id = 'broken-sidecar';
+  invalidEntry.name = 'Broken Sidecar';
+  invalidEntry.capabilities = [...new Set([...invalidEntry.capabilities, 'loopback-sidecar'])];
+  invalidEntry.lifecycle.sidecar_start_required = true;
+  invalidEntry.permissions.loopback_sidecar = true;
+  invalidEntry.sidecar = {
+    type: 'loopback',
+    origin: 'http://127.0.0.1:17791',
+    health_path: '/health',
+    proxy_auth: 'token-v1',
+    runtime: { kind: 'vendored', path: 'sidecar' }
+  };
+  writeJson(path.join(invalidEntryRoot, 'extension.json'), invalidEntry);
+  const invalidManifest = JSON.parse(readFileSync(path.join(invalidEntryRoot, 'manifest.json'), 'utf8'));
+  invalidManifest.extensions[0].id = invalidEntry.id;
+  invalidManifest.extensions[0].name = invalidEntry.name;
+  invalidManifest.extensions[0].sidecar = {
+    type: invalidEntry.sidecar.type,
+    origin: invalidEntry.sidecar.origin,
+    health_path: invalidEntry.sidecar.health_path,
+    proxy_auth: invalidEntry.sidecar.proxy_auth
+  };
+  writeJson(path.join(invalidEntryRoot, 'manifest.json'), invalidManifest);
+  mkdirSync(path.join(invalidEntryRoot, 'sidecar'));
+  assert.throws(
+    () => buildRegistryWithArtifacts({
+      repoRoot: invalidRepo,
+      publishedAt: '2026-01-01T00:00:00.000Z'
+    }),
+    /vendored scaffold incomplete/,
+    'registry generation must reject a declared vendored runtime without its scaffold'
+  );
+
   const validateFromScripts = spawnSync(process.execPath, ['validate-extensions.mjs'], {
     cwd: scriptsDir,
     encoding: 'utf8',
@@ -349,8 +523,6 @@ try {
   });
   assert.equal(safetyScanFromScripts.status, 0, safetyScanFromScripts.stderr || safetyScanFromScripts.stdout);
   assert.match(safetyScanFromScripts.stdout, /safety scan passed for \d+ extension entr(?:y|ies)/);
-
-  const repoRoot = path.resolve(scriptsDir, '..');
 
   // Regression: an entry that writes localStorage and declares storage.owned === true
   // (the boolean form core REQUIRES to enable settings_schema) must PASS the safety scan.

--- a/scripts/test-sidecar-contract.mjs
+++ b/scripts/test-sidecar-contract.mjs
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  checkScaffoldSync,
+  checkSidecarUsage
+} from './sidecar-contract-lib.mjs';
+
+const root = mkdtempSync(path.join(os.tmpdir(), 'hermes-sidecar-contract-'));
+const canonical = path.join(root, 'examples', 'sidecar-scaffold');
+const extensions = path.join(root, 'extensions');
+
+function writeJson(filePath, value) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeEntry(id, sidecar) {
+  const entryRoot = path.join(extensions, id);
+  mkdirSync(entryRoot, { recursive: true });
+  writeJson(path.join(entryRoot, 'extension.json'), {
+    id,
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar
+  });
+  return entryRoot;
+}
+
+try {
+  mkdirSync(canonical, { recursive: true });
+  writeFileSync(path.join(canonical, 'sidecar_base.py'), '# canonical base\n', 'utf8');
+  writeFileSync(path.join(canonical, 'sidecar.py'), '# canonical entrypoint\n', 'utf8');
+
+  const externalRoot = writeEntry('external-sidecar', {
+    type: 'loopback',
+    origin: 'http://127.0.0.1:17787',
+    health_path: '/health',
+    proxy_auth: 'legacy',
+    runtime: {
+      kind: 'external',
+      repository: 'https://github.com/example/external-sidecar'
+    }
+  });
+  writeEntry('external-token-sidecar', {
+    type: 'loopback',
+    origin: 'http://127.0.0.1:17788',
+    health_path: '/health',
+    proxy_auth: 'token-v1',
+    runtime: {
+      kind: 'external',
+      repository: 'https://github.com/example/node-sidecar'
+    }
+  });
+
+  let result = checkScaffoldSync(root);
+  assert.deepEqual(result.failures, [], 'external runtime must not be forced to vendor the Python scaffold');
+  assert.equal(result.vendoredCount, 0);
+  assert.equal(result.externalCount, 2);
+
+  const rogueDir = path.join(externalRoot, 'nested', 'runtime');
+  mkdirSync(rogueDir, { recursive: true });
+  const roguePy = path.join(rogueDir, 'rogue.py');
+  writeFileSync(roguePy, 'from http.server import ThreadingHTTPServer\nThreadingHTTPServer(("127.0.0.1", 1), object)\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('nested/runtime/rogue.py')),
+    'a rogue server anywhere under an extension entry must be discovered without sidecar_base.py');
+  rmSync(roguePy);
+
+  const rogueJs = path.join(rogueDir, 'rogue.mjs');
+  writeFileSync(rogueJs, 'http.createServer(handler).listen(17787);\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('nested/runtime/rogue.mjs')),
+    'external runtimes must be scanned without assuming Python');
+  rmSync(rogueJs);
+
+  const aliasedNode = path.join(rogueDir, 'aliased.mjs');
+  writeFileSync(aliasedNode,
+    'import {\n  createServer as serve\n} from "node:http";\nserve(handler).listen(17787);\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('nested/runtime/aliased.mjs')),
+    'aliased Node server constructors must not escape the source scan');
+  writeFileSync(aliasedNode,
+    'import { Server } from "node:http";\nnew Server(handler).listen(17787);\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('nested/runtime/aliased.mjs')),
+    'named Node Server constructors must not escape the source scan');
+  writeFileSync(aliasedNode,
+    'import http, { createServer as serve } from "node:http";\nserve(handler).listen(17787);\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('nested/runtime/aliased.mjs')),
+    'mixed Node server imports must not escape the source scan');
+  rmSync(aliasedNode);
+
+  const aliasedPython = path.join(rogueDir, 'aliased.py');
+  writeFileSync(aliasedPython,
+    'from http.server import (\n    ThreadingHTTPServer as S,\n)\nS(("127.0.0.1", 17787), object)\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('nested/runtime/aliased.py')),
+    'aliased Python server constructors must not escape the source scan');
+  rmSync(aliasedPython);
+
+  const rogueGo = path.join(rogueDir, 'rogue.go');
+  writeFileSync(rogueGo,
+    'package main\nimport "net/http"\nfunc main() { server := &http.Server{}; server.ListenAndServe() }\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('nested/runtime/rogue.go')),
+    'standard Go http.Server method forms must not escape the source scan');
+  rmSync(rogueGo);
+  assert.deepEqual(checkSidecarUsage(root).failures, []);
+
+  const hiddenRoot = path.join(extensions, 'hidden-sidecar');
+  mkdirSync(path.join(hiddenRoot, 'sidecar'), { recursive: true });
+  writeJson(path.join(hiddenRoot, 'extension.json'), {
+    id: 'hidden-sidecar',
+    capabilities: ['manifest-bundle'],
+    sidecar: {
+      type: 'loopback', origin: 'http://127.0.0.1:17789', health_path: '/health',
+      proxy_auth: 'token-v1', runtime: { kind: 'vendored', path: 'sidecar' }
+    }
+  });
+  writeFileSync(path.join(hiddenRoot, 'sidecar', 'sidecar_base.py'),
+    'from http.server import ThreadingHTTPServer\nThreadingHTTPServer(("127.0.0.1", 1), object)\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('hidden-sidecar/sidecar/sidecar_base.py')),
+    'runtime metadata without the loopback-sidecar capability must not gain a scanner exemption');
+  rmSync(hiddenRoot, { recursive: true, force: true });
+
+  const vendoredRoot = writeEntry('vendored-sidecar', {
+    type: 'loopback',
+    origin: 'http://127.0.0.1:17790',
+    health_path: '/health',
+    proxy_auth: 'token-v1',
+    runtime: {
+      kind: 'vendored',
+      path: 'sidecar'
+    }
+  });
+  const sidecarDir = path.join(vendoredRoot, 'sidecar');
+  mkdirSync(sidecarDir, { recursive: true });
+
+  result = checkScaffoldSync(root);
+  assert(result.failures.some((failure) => failure.includes('sidecar_base.py')));
+  assert(result.failures.some((failure) => failure.includes('sidecar.py')));
+  assert(result.failures.some((failure) => failure.includes('sidecar.json')));
+  assert(result.failures.some((failure) => failure.includes('routes_impl.py')));
+
+  writeFileSync(path.join(sidecarDir, 'sidecar_base.py'), '# canonical base\n', 'utf8');
+  writeFileSync(path.join(sidecarDir, 'sidecar.py'), '# canonical entrypoint\n', 'utf8');
+  const routesImpl = path.join(sidecarDir, 'routes_impl.py');
+  mkdirSync(routesImpl);
+  writeFileSync(path.join(routesImpl, 'placeholder.txt'), 'not a Python module\n', 'utf8');
+  writeJson(path.join(sidecarDir, 'sidecar.json'), {
+    id: 'vendored-sidecar',
+    port: 17790,
+    proxy_auth: 'token-v1'
+  });
+
+  result = checkScaffoldSync(root);
+  assert(result.failures.some((failure) => failure.includes('routes_impl.py must be a regular file')),
+    'a directory must not satisfy the required routes_impl.py contract');
+  rmSync(routesImpl, { recursive: true, force: true });
+  for (const invalidRoutes of [
+    '# no route hook\n',
+    'DOC = """\ndef register(app):\n    pass\n"""\n',
+    'if False:\n    def register(app):\n        pass\n',
+    'async def register(app):\n    pass\n',
+    'def register(app):\n    pass\n',
+    'def register(app):\n    ...\n',
+    'def register(app):\n    """placeholder"""\n',
+    'def register(app, required):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n',
+    'def register(app):\n    app.route("GET", "/test")\n',
+    'def register(app):\n    False and app.route("GET", "/test")\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nregister = None\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nregister, other = None, None\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nfrom replacement import register\n',
+    'def register(app):\n    @app.route("GET", "/one")\n    def one(req):\n        return app.json({"ok": True})\ndef register(app):\n    @app.route("GET", "/two")\n    def two(req):\n        return app.json({"ok": True})\n',
+    'raise RuntimeError("unreachable")\ndef register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nraise RuntimeError("module import fails")\n',
+    'def register(app):\n    if True:\n        return\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n'
+  ]) {
+    writeFileSync(routesImpl, invalidRoutes, 'utf8');
+    result = checkScaffoldSync(root);
+    assert(result.failures.some((failure) => failure.includes('must define top-level synchronous register(app)')),
+      'routes_impl.py must provide a usable top-level synchronous register hook');
+  }
+  writeFileSync(routesImpl,
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n',
+    'utf8');
+
+  result = checkScaffoldSync(root);
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.vendoredCount, 1);
+  assert.equal(result.externalCount, 2);
+
+  writeFileSync(routesImpl,
+    'def handler(req):\n    return {"ok": True}\ndef register(app):\n    app.route("GET", "/test")(handler)\n',
+    'utf8');
+  assert.deepEqual(checkScaffoldSync(root).failures, [],
+    'an equivalent direct decorator application must register a route');
+  writeFileSync(routesImpl,
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n',
+    'utf8');
+
+  for (const collision of ['sidecar_base', 'routes_impl.cpython-312-x86_64-linux-gnu.so', 'sidecar_base.pyc']) {
+    const collisionPath = path.join(sidecarDir, collision);
+    if (collision === 'sidecar_base') {
+      mkdirSync(collisionPath);
+      writeFileSync(path.join(collisionPath, '__init__.py'), '# import shadow\n', 'utf8');
+    } else {
+      writeFileSync(collisionPath, 'compiled import shadow\n', 'utf8');
+    }
+    result = checkScaffoldSync(root);
+    assert(result.failures.some((failure) => failure.includes('shadows a canonical Python module')),
+      `package/compiled collision must not shadow the byte-compared scaffold: ${collision}`);
+    rmSync(collisionPath, { recursive: true, force: true });
+  }
+
+  const vendoredMetadataPath = path.join(vendoredRoot, 'extension.json');
+  const vendoredMetadata = JSON.parse(readFileSync(vendoredMetadataPath, 'utf8'));
+  const linkedRuntime = path.join(vendoredRoot, 'linked-sidecar');
+  symlinkSync(sidecarDir, linkedRuntime, 'dir');
+  vendoredMetadata.sidecar.runtime.path = 'linked-sidecar';
+  writeJson(vendoredMetadataPath, vendoredMetadata);
+  result = checkScaffoldSync(root);
+  assert(result.failures.some((failure) => failure.includes('runtime path must not contain symlinks')),
+    'vendored runtime directories must be real artifact-contained directories');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('runtime path must not contain symlinks')),
+    'the standalone usage gate must reject symlinked vendored runtimes too');
+  vendoredMetadata.sidecar.runtime.path = 'sidecar';
+  writeJson(vendoredMetadataPath, vendoredMetadata);
+  rmSync(linkedRuntime);
+  vendoredMetadata.sidecar.health_path = '/ready';
+  writeJson(vendoredMetadataPath, vendoredMetadata);
+  result = checkScaffoldSync(root);
+  assert(result.failures.some((failure) => failure.includes('health_path must be /health')));
+  vendoredMetadata.sidecar.health_path = '/health';
+  writeJson(vendoredMetadataPath, vendoredMetadata);
+
+  writeJson(path.join(sidecarDir, 'sidecar.json'), {
+    id: 'vendored-sidecar',
+    port: 17790,
+    proxy_auth: 'legacy'
+  });
+  result = checkScaffoldSync(root);
+  assert(result.failures.some((failure) => failure.includes('proxy_auth must match extension.json')));
+
+  writeJson(path.join(sidecarDir, 'sidecar.json'), {
+    id: 'vendored-sidecar',
+    port: 17790,
+    proxy_auth: 'token-v1'
+  });
+  writeFileSync(path.join(sidecarDir, 'sidecar_base.py'), '# drifted base\n', 'utf8');
+  result = checkScaffoldSync(root);
+  assert(result.failures.some((failure) => failure.startsWith('DRIFT')));
+
+  writeFileSync(path.join(sidecarDir, 'sidecar_base.py'), '# canonical base\n', 'utf8');
+  writeFileSync(path.join(sidecarDir, 'sidecar_base.py'), '# harmless but noncanonical\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('DRIFT')),
+    'the usage gate must not exempt a noncanonical sidecar_base.py by pathname alone');
+  writeFileSync(path.join(sidecarDir, 'sidecar_base.py'), '# canonical base\n', 'utf8');
+
+  const unitDir = path.join(vendoredRoot, 'packaging');
+  const unitPath = path.join(unitDir, 'sidecar.service');
+  mkdirSync(unitDir, { recursive: true });
+  writeFileSync(unitPath, '[Service]\nType=simple\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('MISSING ExecStart')),
+    'vendored service units without ExecStart must fail even outside runtime.path');
+  writeFileSync(unitPath, '[Service]\nExecStart=/usr/bin/python3 -S rogue.py sidecar.py\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'mentioning sidecar.py as an argument to another script must not pass');
+  writeFileSync(unitPath, '[Service]\nExecStart=/usr/bin/python3 -S sidecar.py\n', 'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'a basename-only entrypoint without canonical WorkingDirectory must not pass');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'systemd must not search PATH for a bare direct sidecar.py executable');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=%h/.hermes/webui/extensions/vendored-sidecar/sidecar/sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'direct shebang execution must not reintroduce unverified PATH and site startup');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S /tmp/other/sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'an unrelated absolute sidecar.py must not pass');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/env PATH=/tmp python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'an env wrapper must not redirect the Python interpreter through attacker-controlled PATH');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/tmp/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'a Python-looking executable outside the canonical interpreter path must not pass');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S -mrogue sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'attached Python -m module execution must not masquerade as sidecar.py');
+  for (const deceptiveFlags of [
+    '-V sidecar.py',
+    '-Bcprint(1) sidecar.py',
+    '-- -u sidecar.py',
+    '-- -- sidecar.py'
+  ]) {
+    writeFileSync(unitPath,
+      `[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S ${deceptiveFlags}\n`,
+      'utf8');
+    result = checkSidecarUsage(root);
+    assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+      `Python flags must not bypass the canonical entrypoint check: ${deceptiveFlags}`);
+  }
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S sidecar.py ; /usr/bin/python3 -m http.server 17790\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'tokens after sidecar.py must not bypass complete entrypoint validation');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStartPre=/usr/bin/python3 -S /tmp/evil.py\nExecStart=/usr/bin/python3 -S -u sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('DISALLOWED ExecStartPre')),
+    'auxiliary systemd Exec directives must not run outside the canonical entrypoint');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=/tmp/untrusted\nExecStart=/usr/bin/python3 -S sidecar.py\n[Unit]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'directives outside [Service] must not mask the working directory systemd executes');
+  writeFileSync(unitPath,
+    '[Service]\nworkingdirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'case-insensitive directive matching must not validate options systemd ignores');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nRootDirectory=/tmp/untrusted\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('DISALLOWED RootDirectory')),
+    'execution-context-changing service directives must fail closed');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nEnvironment=PATH=/tmp\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('DISALLOWED Environment')),
+    'service environment must not redirect interpreter or import resolution');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -u sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'the canonical service must disable site startup with -S');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S -u sidecar.py\n',
+    'utf8');
+  const containerPath = path.join(unitDir, 'sidecar.container');
+  writeFileSync(containerPath,
+    '[Container]\nWorkingDir=/opt/extensions/vendored-sidecar/sidecar\nExec=python3 sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('UNSUPPORTED CONTAINER')),
+    'vendored Python sidecars must not rely on an unverified container entrypoint');
+  rmSync(containerPath);
+  assert.deepEqual(checkSidecarUsage(root).failures, []);
+
+  console.log('sidecar contract self-tests passed');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/scripts/test-sidecar-contract.mjs
+++ b/scripts/test-sidecar-contract.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   checkScaffoldSync,
   checkSidecarUsage
@@ -11,6 +12,7 @@ import {
 const root = mkdtempSync(path.join(os.tmpdir(), 'hermes-sidecar-contract-'));
 const canonical = path.join(root, 'examples', 'sidecar-scaffold');
 const extensions = path.join(root, 'extensions');
+const sourceRepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 function writeJson(filePath, value) {
   mkdirSync(path.dirname(filePath), { recursive: true });
@@ -176,9 +178,19 @@ try {
     'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nregister = None\n',
     'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nregister, other = None, None\n',
     'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nfrom replacement import register\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nfrom replacement import *\n',
+    'def replacement(fn):\n    return lambda app: None\n@replacement\ndef register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nmatch 1:\n    case register:\n        pass\n',
     'def register(app):\n    @app.route("GET", "/one")\n    def one(req):\n        return app.json({"ok": True})\ndef register(app):\n    @app.route("GET", "/two")\n    def two(req):\n        return app.json({"ok": True})\n',
     'raise RuntimeError("unreachable")\ndef register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n',
     'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nraise RuntimeError("module import fails")\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nif True:\n    raise RuntimeError("module import fails")\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\ndef replacement(fn):\n    return fn\n@(register := replacement)\ndef helper():\n    pass\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n_ = [item for item in [1] if (register := None)]\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\nhelper = lambda value=(register := (lambda app: None)): value\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\ndef helper(value: (register := (lambda app: None)) = None):\n    pass\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\ndef helper() -> (register := (lambda app: None)):\n    pass\n',
+    'def register(app):\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\ndef sneak():\n    global register\n    register = lambda app: None\nsneak()\n',
     'def register(app):\n    if True:\n        return\n    @app.route("GET", "/test")\n    def test(req):\n        return app.json({"ok": True})\n'
   ]) {
     writeFileSync(routesImpl, invalidRoutes, 'utf8');
@@ -194,6 +206,18 @@ try {
   assert.deepEqual(result.failures, []);
   assert.equal(result.vendoredCount, 1);
   assert.equal(result.externalCount, 2);
+
+  const canonicalEntrypoint = path.join(sidecarDir, 'sidecar.py');
+  const danglingTarget = path.join(root, 'outside-created-by-sync.py');
+  rmSync(canonicalEntrypoint);
+  symlinkSync(danglingTarget, canonicalEntrypoint, 'file');
+  result = checkScaffoldSync(root, { write: true });
+  assert(result.failures.some((failure) => failure.includes('sidecar.py must be a regular file')),
+    'scaffold sync must reject a dangling symlink in a protected-file position');
+  assert.equal(existsSync(danglingTarget), false,
+    'scaffold sync must not follow a dangling protected-file symlink outside the runtime');
+  rmSync(canonicalEntrypoint);
+  writeFileSync(canonicalEntrypoint, '# canonical entrypoint\n', 'utf8');
 
   writeFileSync(routesImpl,
     'def handler(req):\n    return {"ok": True}\ndef register(app):\n    app.route("GET", "/test")(handler)\n',
@@ -218,6 +242,18 @@ try {
     rmSync(collisionPath, { recursive: true, force: true });
   }
 
+  const externalHelper = path.join(root, 'external-helper.py');
+  const linkedHelper = path.join(sidecarDir, 'linked-helper.py');
+  writeFileSync(externalHelper, 'print("outside artifact")\n', 'utf8');
+  symlinkSync(externalHelper, linkedHelper, 'file');
+  result = checkScaffoldSync(root);
+  assert(result.failures.some((failure) => failure.includes('runtime tree must not contain symlinks')),
+    'files inside a vendored runtime must not redirect outside the packaged artifact');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.includes('runtime tree must not contain symlinks')),
+    'the usage gate must reject nested runtime symlinks too');
+  rmSync(linkedHelper);
+
   const vendoredMetadataPath = path.join(vendoredRoot, 'extension.json');
   const vendoredMetadata = JSON.parse(readFileSync(vendoredMetadataPath, 'utf8'));
   const linkedRuntime = path.join(vendoredRoot, 'linked-sidecar');
@@ -238,6 +274,14 @@ try {
   result = checkScaffoldSync(root);
   assert(result.failures.some((failure) => failure.includes('health_path must be /health')));
   vendoredMetadata.sidecar.health_path = '/health';
+  writeJson(vendoredMetadataPath, vendoredMetadata);
+
+  vendoredMetadata.sidecar.origin = 'http://0x7f.0.0.1:17790';
+  writeJson(vendoredMetadataPath, vendoredMetadata);
+  result = checkScaffoldSync(root);
+  assert(result.failures.some((failure) => failure.includes('vendored sidecar.origin must use http://127.0.0.1')),
+    'the standalone contract gate must reject URL-normalized IPv4 spellings too');
+  vendoredMetadata.sidecar.origin = 'http://127.0.0.1:17790';
   writeJson(vendoredMetadataPath, vendoredMetadata);
 
   writeJson(path.join(sidecarDir, 'sidecar.json'), {
@@ -279,6 +323,12 @@ try {
   result = checkSidecarUsage(root);
   assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
     'a basename-only entrypoint without canonical WorkingDirectory must not pass');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=/tmp/untrusted/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'a directory with only the expected suffix must not replace the installed extension tree');
   writeFileSync(unitPath,
     '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=sidecar.py\n',
     'utf8');
@@ -371,6 +421,24 @@ try {
   assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
     'the canonical service must disable site startup with -S');
   writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=-/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD ExecStart')),
+    'the ignore-failure command prefix must not hide a failed sidecar process');
+  writeFileSync(unitPath,
+    '[Service]\nType=forking\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('DISALLOWED Type')),
+    'service types that do not match the foreground scaffold process must fail');
+  writeFileSync(unitPath,
+    '[Service]\nType=simple\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S sidecar.py\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('MULTIPLE ExecStart')),
+    'a vendored service must have exactly one canonical launch command');
+  writeFileSync(unitPath,
     '[Service]\nWorkingDirectory=%h/.hermes/webui/extensions/vendored-sidecar/sidecar\nExecStart=/usr/bin/python3 -S -u sidecar.py\n',
     'utf8');
   const containerPath = path.join(unitDir, 'sidecar.container');
@@ -381,7 +449,46 @@ try {
   assert(result.failures.some((failure) => failure.startsWith('UNSUPPORTED CONTAINER')),
     'vendored Python sidecars must not rely on an unverified container entrypoint');
   rmSync(containerPath);
-  assert.deepEqual(checkSidecarUsage(root).failures, []);
+  result = checkSidecarUsage(root);
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.warnings, [], 'the default installation layout must not produce review noise');
+  const dropInDir = path.join(unitDir, 'sidecar.service.d');
+  mkdirSync(dropInDir);
+  writeFileSync(path.join(dropInDir, 'override.conf'),
+    '[Service]\nExecStart=\nExecStart=/usr/bin/python3 -S rogue.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('DISALLOWED DROP-IN')),
+    'systemd drop-ins must not replace a reviewed vendored launch command');
+  rmSync(dropInDir, { recursive: true });
+  writeFileSync(unitPath,
+    '[Service]\nType=simple\nWorkingDirectory=/srv/hermes/extensions/vendored-sidecar/sidecar\nEnvironment=HERMES_WEBUI_STATE_DIR=/srv/hermes\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert.deepEqual(result.failures, [],
+    'a custom state directory must be accepted when WorkingDirectory points at its installed artifact');
+  assert(result.warnings.some((warning) => warning.includes('HERMES_WEBUI_STATE_DIR=/srv/hermes')),
+    'a custom state directory must produce an explicit reviewer warning');
+  writeFileSync(unitPath,
+    '[Service]\nType=simple\nWorkingDirectory=/opt/hermes-extensions/vendored-sidecar/sidecar\nEnvironment=HERMES_WEBUI_STATE_DIR=/srv/hermes\nEnvironment=HERMES_EXT_INSTALL_DIR=/opt/hermes-extensions/vendored-sidecar\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert.deepEqual(result.failures, [],
+    'a declared custom extension install directory must override the state-directory default');
+  assert(result.warnings.some((warning) => warning.includes('HERMES_EXT_INSTALL_DIR=/opt/hermes-extensions/vendored-sidecar')),
+    'a custom extension install directory must produce an explicit reviewer warning');
+  writeFileSync(unitPath,
+    '[Service]\nWorkingDirectory=/tmp/vendored-sidecar/sidecar\nEnvironment=HERMES_EXT_INSTALL_DIR=relative/path\nExecStart=/usr/bin/python3 -S sidecar.py\n',
+    'utf8');
+  result = checkSidecarUsage(root);
+  assert(result.failures.some((failure) => failure.startsWith('BAD HERMES_EXT_INSTALL_DIR')),
+    'a custom install directory must be absolute or anchored to the service user home');
+
+  const workflow = readFileSync(path.join(sourceRepoRoot, '.github', 'workflows', 'extensions.yml'), 'utf8');
+  assert.match(workflow, /examples\/loopback-sidecar\/\*\*/,
+    'the Extensions workflow must run for loopback example changes');
+  assert.match(workflow, /node scripts\/validate-desktop-companion\.mjs/,
+    'the Extensions workflow must enforce Desktop Companion external legacy metadata');
 
   console.log('sidecar contract self-tests passed');
 } finally {

--- a/scripts/test-sidecar-scaffold.py
+++ b/scripts/test-sidecar-scaffold.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the canonical Python sidecar scaffold."""
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCAFFOLD = ROOT / "examples" / "sidecar-scaffold"
+sys.dont_write_bytecode = True
+
+
+def _load_sidecar_base():
+    spec = importlib.util.spec_from_file_location("hermes_sidecar_base", SCAFFOLD / "sidecar_base.py")
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load sidecar_base.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class SidecarScaffoldTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base = _load_sidecar_base()
+
+    def test_unknown_proxy_auth_values_fail_closed_at_startup(self):
+        with tempfile.TemporaryDirectory(prefix="hermes-sidecar-config-") as temp:
+            config = Path(temp) / "sidecar.json"
+            for invalid in ("token-vI", "", None, 7):
+                config.write_text(
+                    json.dumps({"id": "test-sidecar", "port": 17790, "proxy_auth": invalid}),
+                    encoding="utf-8",
+                )
+                with self.subTest(proxy_auth=invalid):
+                    with self.assertRaisesRegex(ValueError, "proxy_auth"):
+                        self.base.Sidecar(str(config))
+
+    def test_start_background_hook_is_optional(self):
+        with tempfile.TemporaryDirectory(prefix="hermes-sidecar-optional-hook-") as temp:
+            temp_path = Path(temp)
+            for name in ("sidecar_base.py", "sidecar.py"):
+                shutil.copy2(SCAFFOLD / name, temp_path / name)
+            (temp_path / "routes_impl.py").write_text(
+                "def register(app):\n    return None\n",
+                encoding="utf-8",
+            )
+
+            port = _free_port()
+            token_file = temp_path / "test-sidecar.token"
+            token_file.write_text("optional-hook-token-0123456789", encoding="utf-8")
+            (temp_path / "sidecar.json").write_text(
+                json.dumps({"id": "test-sidecar", "port": port, "proxy_auth": "token-v1"}),
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["HERMES_EXT_SIDECAR_TOKEN_FILE"] = str(token_file)
+            proc = subprocess.Popen(
+                [sys.executable, "sidecar.py"],
+                cwd=temp_path,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                for _ in range(80):
+                    try:
+                        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=0.25)
+                        conn.request("GET", "/health")
+                        response = conn.getresponse()
+                        response.read()
+                        conn.close()
+                        if response.status == 200:
+                            break
+                    except OSError:
+                        time.sleep(0.05)
+                else:
+                    stdout, stderr = proc.communicate(timeout=1)
+                    self.fail(f"sidecar without optional hook did not start\nstdout={stdout}\nstderr={stderr}")
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=3)
+                if proc.stdout is not None:
+                    proc.stdout.close()
+                if proc.stderr is not None:
+                    proc.stderr.close()
+
+    def test_health_is_cross_origin_readable_and_auth_remains_fail_closed(self):
+        with tempfile.TemporaryDirectory(prefix="hermes-sidecar-live-") as temp:
+            temp_path = Path(temp)
+            for name in ("sidecar_base.py", "sidecar.py", "routes_impl.py"):
+                shutil.copy2(SCAFFOLD / name, temp_path / name)
+
+            port = _free_port()
+            token = "contract-test-token-0123456789"
+            token_file = temp_path / "test-sidecar.token"
+            token_file.write_text(token, encoding="utf-8")
+            (temp_path / "sidecar.json").write_text(
+                json.dumps({"id": "test-sidecar", "port": port, "proxy_auth": "token-v1"}),
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["HERMES_EXT_SIDECAR_TOKEN_FILE"] = str(token_file)
+            proc = subprocess.Popen(
+                [sys.executable, "sidecar.py"],
+                cwd=temp_path,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                for _ in range(80):
+                    try:
+                        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=0.25)
+                        conn.request("GET", "/health", headers={"Origin": "https://example.test"})
+                        response = conn.getresponse()
+                        body = response.read()
+                        conn.close()
+                        if response.status == 200:
+                            break
+                    except OSError:
+                        time.sleep(0.05)
+                else:
+                    stdout, stderr = proc.communicate(timeout=1)
+                    self.fail(f"sidecar did not start\nstdout={stdout}\nstderr={stderr}")
+
+                self.assertEqual(response.getheader("Access-Control-Allow-Origin"), "*")
+                self.assertEqual(response.getheader("Cache-Control"), "no-store")
+                self.assertEqual(json.loads(body)["ok"], True)
+
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/api/status")
+                unauthorized = conn.getresponse()
+                unauthorized.read()
+                conn.close()
+                self.assertEqual(unauthorized.status, 401)
+
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request(
+                    "GET",
+                    "/api/status",
+                    headers={"X-Hermes-Sidecar-Token": "wrong-token"},
+                )
+                wrong_token = conn.getresponse()
+                wrong_token.read()
+                conn.close()
+                self.assertEqual(wrong_token.status, 401)
+
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/api/status", headers={"X-Hermes-Sidecar-Token": token})
+                authorized = conn.getresponse()
+                authorized.read()
+                conn.close()
+                self.assertEqual(authorized.status, 200)
+
+                rotated_token = "rotated-contract-token-987654321"
+                token_file.write_text(rotated_token, encoding="utf-8")
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/api/status", headers={"X-Hermes-Sidecar-Token": token})
+                stale = conn.getresponse()
+                stale.read()
+                conn.close()
+                self.assertEqual(stale.status, 401)
+
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request(
+                    "GET",
+                    "/api/status",
+                    headers={"X-Hermes-Sidecar-Token": rotated_token},
+                )
+                rotated = conn.getresponse()
+                rotated.read()
+                conn.close()
+                self.assertEqual(rotated.status, 200)
+
+                token_file.unlink()
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+                conn.request("GET", "/api/status", headers={"X-Hermes-Sidecar-Token": token})
+                unavailable = conn.getresponse()
+                unavailable.read()
+                conn.close()
+                self.assertEqual(unavailable.status, 503)
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=3)
+                if proc.stdout is not None:
+                    proc.stdout.close()
+                if proc.stderr is not None:
+                    proc.stderr.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-desktop-companion.mjs
+++ b/scripts/validate-desktop-companion.mjs
@@ -29,6 +29,12 @@ assert.deepEqual(entry.capabilities, ['manifest-bundle', 'loopback-sidecar']);
 assert.ok(!entry.capabilities.includes('sidecar-proxy'));
 assert.deepEqual(entry.assets.stylesheets, []);
 assert.deepEqual(runtime.stylesheets, []);
+assert.equal(entry.sidecar.proxy_auth, 'legacy');
+assert.deepEqual(entry.sidecar.runtime, {
+  kind: 'external',
+  repository: 'https://github.com/franksong2702/hermes-webui-desktop-companion'
+});
+assert.equal(runtime.sidecar.proxy_auth, entry.sidecar.proxy_auth);
 assertIncludesAll(
   entry.permissions.webui_api.read,
   ['sessions', 'session', 'approval/pending', 'clarify/pending'],

--- a/scripts/validate-desktop-companion.mjs
+++ b/scripts/validate-desktop-companion.mjs
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import { readFileSync, statSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = path.resolve('extensions/desktop-companion');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const root = path.join(repoRoot, 'extensions', 'desktop-companion');
 
 function readJson(rel) {
   return JSON.parse(readFileSync(path.join(root, rel), 'utf8'));
@@ -35,6 +37,20 @@ assert.deepEqual(entry.sidecar.runtime, {
   repository: 'https://github.com/franksong2702/hermes-webui-desktop-companion'
 });
 assert.equal(runtime.sidecar.proxy_auth, entry.sidecar.proxy_auth);
+const exampleManifest = JSON.parse(
+  readFileSync(path.join(repoRoot, 'examples', 'loopback-sidecar', 'manifest.json'), 'utf8')
+);
+assert.deepEqual(
+  exampleManifest.extensions,
+  [{
+    id: runtime.id,
+    name: runtime.name,
+    scripts: runtime.scripts,
+    stylesheets: runtime.stylesheets,
+    sidecar: runtime.sidecar
+  }],
+  'the loopback-sidecar example must match Desktop Companion’s shipped external legacy manifest'
+);
 assertIncludesAll(
   entry.permissions.webui_api.read,
   ['sessions', 'session', 'approval/pending', 'clarify/pending'],

--- a/scripts/validate-extensions.mjs
+++ b/scripts/validate-extensions.mjs
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
-import { validateAllEntries } from './extension-registry-lib.mjs';
+import { REPO_ROOT, validateAllEntries } from './extension-registry-lib.mjs';
+import { checkScaffoldSync, checkSidecarUsage } from './sidecar-contract-lib.mjs';
 
 const { results } = validateAllEntries();
 const failures = results.filter((result) => result.errors.length);
+const sidecarUsage = checkSidecarUsage(REPO_ROOT);
+const sidecarFailures = [
+  ...checkScaffoldSync(REPO_ROOT).failures,
+  ...sidecarUsage.failures
+];
 
 for (const result of results) {
   if (!result.errors.length) {
@@ -16,8 +22,18 @@ for (const result of results) {
   }
 }
 
-if (failures.length) {
-  console.error(`\n${failures.length} extension entr${failures.length === 1 ? 'y' : 'ies'} failed validation.`);
+for (const warning of sidecarUsage.warnings) console.warn(`warning: ${warning}`);
+
+if (sidecarFailures.length) {
+  console.error('fail sidecar contract');
+  for (const error of sidecarFailures) console.error(`  - ${error}`);
+}
+
+if (failures.length || sidecarFailures.length) {
+  console.error(
+    `\n${failures.length} extension entr${failures.length === 1 ? 'y' : 'ies'} and `
+    + `${sidecarFailures.length} sidecar contract check${sidecarFailures.length === 1 ? '' : 's'} failed validation.`
+  );
   process.exit(1);
 }
 

--- a/scripts/validate-extensions.mjs
+++ b/scripts/validate-extensions.mjs
@@ -7,6 +7,7 @@ const failures = results.filter((result) => result.errors.length);
 for (const result of results) {
   if (!result.errors.length) {
     console.log(`ok ${result.id}`);
+    for (const warning of result.warnings || []) console.warn(`  warning: ${warning}`);
     continue;
   }
   console.error(`fail ${result.id}`);


### PR DESCRIPTION
## What this does

Adds the canonical sidecar scaffold and repository contract for `loopback-sidecar` extensions. It is the library-side companion to the proxy-to-sidecar `token-v1` boundary in **nesquena/hermes-webui#6331**.

Core owns consent, per-extension token provisioning, proxy target validation, and `X-Hermes-Sidecar-Token` injection. This PR owns the language-neutral metadata contract, the optional Python reference scaffold, repository validation, tests, examples, and CI enforcement.

## Runtime ownership model

Sidecar discovery is manifest-driven and distinguishes two valid cases:

1. **Repository-vendored runtimes**
   - Declare `sidecar.runtime.kind: "vendored"` and a safe relative runtime path.
   - Use `proxy_auth: "token-v1"`.
   - Vendor byte-identical canonical `sidecar_base.py` and `sidecar.py` files.
   - Keep extension routes in a regular `routes_impl.py` file with exactly one valid `register(app)` hook.
   - Launch through exactly one validated `/usr/bin/python3` command with `-S`,
     optional `-u`, and `sidecar.py` from the declared/default extension entry.

2. **External runtimes**
   - Declare `sidecar.runtime.kind: "external"` and the runtime repository.
   - May use any language, framework, or layout.
   - Implement the language-neutral token/header/health/rotation contract when using `token-v1`.
   - Remain explicitly reported as `legacy` until migrated.

Every runtime kind uses core-compatible endpoint syntax: a bare loopback origin
and a normalized absolute health path, both without a query or fragment.

Desktop Companion is modeled as the existing external compatibility case. Its Node/Tauri runtime remains external and explicitly legacy; this PR does not force it into the Python scaffold.

## Canonical scaffold

`examples/sidecar-scaffold/sidecar_base.py` owns dispatch and validates authentication at one chokepoint. Only `GET/HEAD /health` is tokenless. It returns direct-browser-readable CORS and `Cache-Control: no-store` headers. Every other route fails closed for missing, wrong, stale, or unavailable token material. Tokens are read per request so rotation takes effect without restarting the sidecar.

The scaffold supports path parameters, query strings, raw and multipart bodies, JSON and binary responses, custom headers, gzip JSON, and an optional background hook. `sidecar.py` remains a thin canonical entrypoint, `sidecar.json` holds per-entry identity/port/auth settings, and `routes_impl.py` contains extension-owned behavior.

## Enforcement

The shared contract library now drives synchronization, validation, usage checks, and adversarial tests:

- Metadata defines the target set. Omitting the protected scaffold cannot make a vendored sidecar disappear.
- Unknown authentication modes fail closed, and `extension.json`, runtime `manifest.json`, and `sidecar.json` must agree.
- Protected scaffold/config/route paths must be real regular files.
- Symlinks anywhere beneath an extension root are rejected before their targets
  are read, including declared assets and every component or nested entry of
  `runtime.path`, so validation and artifact collection inspect the same tree.
- Symlinked extension roots, directories with missing or dangling metadata, and
  non-object JSON metadata are surfaced as structured validation failures rather
  than being silently omitted or raising an unstructured exception.
- Python package, extension-module, and bytecode names that could shadow protected modules are rejected.
- Vendored services must use one unprefixed command with the pinned interpreter
  and `-S`. The working directory must match the default state-tree installation
  or an exact extension entry declared with `HERMES_EXT_INSTALL_DIR`. Custom
  paths must be absolute or `%h`-anchored and emit an explicit reviewer warning.
  WebUI's ambiguous `HERMES_WEBUI_EXTENSION_DIR` is deliberately not reused.
  PATH wrappers, arbitrary Python-looking
  executables, direct shebang execution, Python command/module flags, trailing
  commands, duplicate launch commands, non-foreground service types, auxiliary
  `Exec*`, `.service.d` drop-ins, unsafe execution-context directives, and
  unverifiable Quadlet entrypoints are rejected.
- The route hook is checked with Python AST. Bare decorator-factory calls,
  unreachable or conditional registration, malformed signatures, decorators on
  `register`, duplicate/direct/wildcard/pattern rebindings, rebinding through
  evaluated definition expressions or module-level comprehensions, statically
  visible `global register` declarations, module-level control flow, and
  unconditional module raises fail. The docs state the static check's unavoidable
  limit for dynamic namespace mutation.
- Server source is scanned across every extension entry, including malformed or incomplete declarations, for unguarded listener construction in the supported source languages.
- Canonical server-file exemptions require byte identity in the same usage check.

## Tests and CI

The workflow runs:

- entry validation and validator self-tests;
- adversarial sidecar-contract tests;
- real-socket Python scaffold tests covering health CORS/cache headers, missing/wrong/rotated/deleted tokens, optional background behavior, and unknown auth modes;
- extension safety scanning;
- canonical scaffold synchronization checks;
- sidecar listener/service usage checks;
- Desktop Companion and loopback-example agreement checks;
- registry generation and JSON validation.

Generated ZIP artifacts set the standard UTF-8 filename flag in both local and
central headers, with a cross-runtime regression test for non-ASCII asset names.

Focused fixtures also pin origin/health-path parity with core, including
rejection of numeric, hexadecimal, and percent-encoded loopback spellings that
JavaScript's URL parser would otherwise normalize into acceptance.

The protected scaffold directory, loopback example, and contract documentation
are included in CI path filters. Registry generation independently reruns the
sidecar contract checks before packaging any artifact.

## Verification

The complete workflow-equivalent sequence passes locally on exact commit `a0fb6175b44dc61a439ecffe70d2573b7209c71e` across all 14 extension entries, including registry artifact generation and parsing, Desktop Companion validation, Node syntax checks, and `git diff --check`.

## Sequencing

Core PR **nesquena/hermes-webui#6331** supplies the token-v1 proxy enforcement. This PR defines and enforces the matching library contract. Neither PR is merged by this update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
