### PR TITLE
Harden Profile Avatars upload and storage invariants

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Test canonical sidecar scaffold
         run: python scripts/test-sidecar-scaffold.py
 
+      - name: Test Profile Avatars
+        run: python scripts/test-profile-avatars.py
+
       - name: Scan extension safety gates
         run: node scripts/scan-extension-safety.mjs
 

--- a/extensions/profile-avatars/README.md
+++ b/extensions/profile-avatars/README.md
@@ -19,8 +19,8 @@ load** into a shared in-memory object URL. Nothing is written to
   to the title, so with "Show N from other profiles" you can see at a glance
   which agent each chat belongs to. Re-renders live when you switch profiles.
 - **Manager modal** — a button at the top of the **Profiles** tab opens an upload / replace / remove
-  panel for every profile. PNG / JPEG / WebP, up to 512 KiB, magic-byte sniffed
-  server-side.
+  panel for every profile. PNG / JPEG / WebP, up to 512 KiB and 4096px / 16
+  megapixels, decoded before upload and structurally validated server-side.
 - **Colored-initial fallback** — profiles without an image get a deterministic
   colored initial bubble.
 
@@ -136,8 +136,11 @@ where core and the sidecar share a network namespace and the state dir.
 - Reads `GET /api/profiles` and `GET /api/sessions?all_profiles=1` (same-origin,
   session-authenticated) to know the roster and which profile owns each session.
 - Talks to its loopback sidecar only through the WebUI's consented proxy path.
-- Uploads go to the sidecar; images never leave the machine. The sidecar
-  validates type by magic bytes and caps size at 512 KiB (matching the core sidecar-proxy response cap).
+- Uploads go to the sidecar; images never leave the machine. The browser first
+  decodes each file, then the sidecar validates the raster structure, dimensions,
+  type, and 512 KiB limit (matching the core sidecar-proxy response cap).
+- Avatar rows use the same profile-ID grammar as core and are capped at 128.
+  `avatars.db` and its SQLite artifacts are forced to owner-only (`0600`) mode.
 - No localStorage, no cookies read, no external network access, no native host.
 
 ## Manual verification
@@ -153,10 +156,10 @@ where core and the sidecar share a network namespace and the state dir.
 5. Remove the avatar → everything reverts to the colored initial / native glyph.
 6. Upload a >512 KiB file or a non-image → rejected with a message, nothing applied.
 
-## Future CI checks
+## Automated verification
 
-- `node --check assets/avatars.js`
-- JSON validity of `extension.json` / `manifest.json`
-- `python3 -m py_compile sidecar/*.py`
-- Sidecar contract test: `POST` a 1×1 PNG → `GET` returns it with `ETag`;
-  `GET /health` returns `{"ok": true}`.
+- `python3 scripts/test-profile-avatars.py` covers raster structure/dimensions,
+  profile grammar, storage bounds/modes, multipart parsing, consent-aware manager
+  refresh, upload decoding, and generated-initial contrast.
+- Repository CI also runs extension metadata, JavaScript syntax, sidecar contract,
+  scaffold-sync, and safety checks on every change.

--- a/extensions/profile-avatars/assets/avatars.js
+++ b/extensions/profile-avatars/assets/avatars.js
@@ -543,6 +543,8 @@
         var dimensions = { width: bitmap.width, height: bitmap.height };
         if (typeof bitmap.close === 'function') bitmap.close();
         return dimensions;
+      }).catch(function () {
+        throw new Error('The selected file is not a decodable image.');
       });
     }
     return new Promise(function (resolve, reject) {

--- a/extensions/profile-avatars/assets/avatars.js
+++ b/extensions/profile-avatars/assets/avatars.js
@@ -65,7 +65,8 @@
   function _hashColor(name) {
     var h = 0;
     for (var i = 0; i < name.length; i++) h = ((h << 5) - h + name.charCodeAt(i)) | 0;
-    return 'hsl(' + (Math.abs(h) % 360) + ', 55%, 45%)';
+    // White initials stay above WCAG AA contrast at every generated hue.
+    return 'hsl(' + (Math.abs(h) % 360) + ', 55%, 30%)';
   }
   function _initial(name) {
     if (!name) return '?';
@@ -536,6 +537,40 @@
       wrap.appendChild(row);
     });
   }
+  function _decodeAvatarDimensions(file) {
+    if (typeof window.createImageBitmap === 'function') {
+      return window.createImageBitmap(file).then(function (bitmap) {
+        var dimensions = { width: bitmap.width, height: bitmap.height };
+        if (typeof bitmap.close === 'function') bitmap.close();
+        return dimensions;
+      });
+    }
+    return new Promise(function (resolve, reject) {
+      var objectUrl = URL.createObjectURL(file);
+      var image = new Image();
+      image.onload = function () {
+        var dimensions = { width: image.naturalWidth, height: image.naturalHeight };
+        URL.revokeObjectURL(objectUrl);
+        resolve(dimensions);
+      };
+      image.onerror = function () {
+        URL.revokeObjectURL(objectUrl);
+        reject(new Error('The selected file is not a decodable image.'));
+      };
+      image.src = objectUrl;
+    });
+  }
+  function _validateAvatarFile(file) {
+    return _decodeAvatarDimensions(file).then(function (dimensions) {
+      var width = Number(dimensions.width) || 0;
+      var height = Number(dimensions.height) || 0;
+      if (!width || !height) throw new Error('The selected image has invalid dimensions.');
+      if (width > 4096 || height > 4096 || width * height > 16 * 1024 * 1024) {
+        throw new Error('Image dimensions are too large (max 4096px / 16 megapixels).');
+      }
+      return dimensions;
+    });
+  }
   function _pickAndUpload(name) {
     var inp = document.createElement('input');
     inp.type = 'file'; inp.accept = 'image/png,image/jpeg,image/webp';
@@ -546,7 +581,9 @@
       // 512 KiB matches the core sidecar-proxy's hard response cap — anything
       // larger uploads "ok" then 502s on read, so reject it up front.
       if (f.size > 512 * 1024) { _showAvatarError('Image too large (max 512 KiB). Resize to 256–512px first.'); return; }
-      upload(name, f).catch(function (e) { _showAvatarError(e.message); });
+      _validateAvatarFile(f)
+        .then(function () { return upload(name, f); })
+        .catch(function (e) { _showAvatarError(e.message); });
     };
     inp.click();
   }
@@ -592,7 +629,16 @@
     ov.style.display = 'flex';
     var close = document.getElementById('paAvatarClose');
     if (close) close.focus();
-    (_loaded ? Promise.resolve() : refresh()).then(_renderManagerList);
+    // Always refresh on open: profile create/delete rebuilds the core panel but
+    // emits no stable lifecycle event for extensions to consume.
+    sidecarConsented().then(function (ok) {
+      if (!ok) {
+        _renderManagerList();
+        _showAvatarError('Enable WebUI authentication and approve this sidecar in Settings → Extensions.');
+        return;
+      }
+      return refresh().then(_renderManagerList);
+    });
   }
   function _closeManager() {
     var ov = document.getElementById('paAvatarManager');

--- a/extensions/profile-avatars/assets/avatars.js
+++ b/extensions/profile-avatars/assets/avatars.js
@@ -34,6 +34,11 @@
   function _canonicalLookupName(name) {
     return (typeof name === 'string' && name.trim()) ? _canonicalProfileName(name) : name;
   }
+  function _entryForName(name) {
+    var lookupName = _canonicalLookupName(name);
+    if (typeof lookupName !== 'string' || !lookupName.trim()) return null;
+    return _byProfile[lookupName] || null;
+  }
   // Refresh the root + active identity from the roster: the root is the
   // is_default entry; the active profile is resolved from is_active (falling
   // back to data.active) and canonicalized so it matches a _byProfile key.
@@ -87,6 +92,7 @@
       color: _hashColor(disp),
       is_default: !!opts.is_default,
       label: disp,
+      storageName: opts.storageName || name,
     };
   }
 
@@ -163,10 +169,12 @@
       for (var k in _byProfile) delete _byProfile[k];
       for (var i = 0; i < profiles.length; i++) {
         var p = profiles[i];
-        var raw = amap[p.name] && amap[p.name].url;
+        var storageName = p.is_default ? 'default' : p.name;
+        var avatar = amap[storageName] || (storageName !== p.name ? amap[p.name] : null);
+        var raw = avatar && avatar.url;
         var url = raw ? (BASE + raw) : null;
-        if (p.is_default) _record(p.name, url, { is_default: true, label: window._botName || 'Hermes' });
-        else _record(p.name, url);
+        if (p.is_default) _record(p.name, url, { is_default: true, label: window._botName || 'Hermes', storageName: storageName });
+        else _record(p.name, url, { storageName: storageName });
       }
       _pruneBlobCache();
       _loaded = true;
@@ -188,20 +196,21 @@
   }
 
   function active() { return _activeName; }
-  function entry(name) { return _byProfile[_canonicalLookupName(name)] || null; }
+  function entry(name) { return _entryForName(name); }
   function list() {
     return Object.keys(_byProfile).map(function (n) { return Object.assign({ name: n }, _byProfile[n] || {}); });
   }
 
   function renderInto(el, name, opts) {
     if (!el) return;
-    name = _canonicalLookupName(name);
+    var resolved = _entryForName(name);
+    name = resolved ? _canonicalLookupName(name) : name;
     var o = opts || {};
     var shape = o.shape === 'square' ? 'pa-avatar--square' : 'pa-avatar--circle';
     el.classList.add('pa-avatar', shape);
     if (o.size) el.classList.add('pa-avatar--' + o.size);
     el.innerHTML = '';
-    var e = name ? _byProfile[name] : null;
+    var e = resolved;
     if (e && e.blob) {
       var img = document.createElement('img');
       img.src = e.blob; img.alt = name; img.decoding = 'async';
@@ -341,11 +350,25 @@
     }, 500);
   }
 
+  function _deleteStoredAvatar(name) {
+    return fetch(BASE + '/api/avatars/' + encodeURIComponent(name), {
+      method: 'DELETE', credentials: 'same-origin',
+    }).then(function (r) {
+      if (!r.ok) return r.json().catch(function () { return {}; }).then(function (jj) {
+        throw new Error(jj.error || ('Delete failed (HTTP ' + r.status + ')'));
+      });
+      return r.json().catch(function () { return {}; });
+    });
+  }
+
   function upload(name, blob) {
-    name = _canonicalLookupName(name);
+    var current = _entryForName(name);
+    if (!current) return Promise.reject(new Error('Unknown profile'));
+    var displayName = _canonicalLookupName(name);
+    var storageName = current.storageName || displayName;
     var fd = new FormData();
     fd.append('avatar', blob, blob.name || 'avatar');
-    return fetch(BASE + '/api/avatars/' + encodeURIComponent(name), {
+    return fetch(BASE + '/api/avatars/' + encodeURIComponent(storageName), {
       method: 'POST', body: fd, credentials: 'same-origin',
     }).then(function (r) {
       if (!r.ok) return r.json().catch(function () { return {}; }).then(function (jj) {
@@ -353,24 +376,30 @@
       });
       return r.json();
     }).then(function (jj) {
-      var raw = jj.url || ('/api/avatars/' + name + '?v=' + Math.floor(Date.now() / 1000));
-      _record(name, BASE + raw, _byProfile[name] || {});
-      _pruneBlobCache();
-      return _prefetchImages().then(function () { _broadcast(); return jj; });
+      var cleanup = displayName !== storageName ? _deleteStoredAvatar(displayName) : Promise.resolve();
+      return cleanup.then(function () {
+        var raw = jj.url || ('/api/avatars/' + storageName + '?v=' + Math.floor(Date.now() / 1000));
+        _record(displayName, BASE + raw, {
+          is_default: current.is_default,
+          label: current.label,
+          storageName: storageName,
+        });
+        _pruneBlobCache();
+        return _prefetchImages().then(function () { _broadcast(); return jj; });
+      });
     });
   }
   function remove(name) {
-    name = _canonicalLookupName(name);
-    return fetch(BASE + '/api/avatars/' + encodeURIComponent(name), {
-      method: 'DELETE', credentials: 'same-origin',
-    }).then(function (r) {
-      if (!r.ok) return r.json().catch(function () { return {}; }).then(function (jj) {
-        throw new Error(jj.error || ('Delete failed (HTTP ' + r.status + ')'));
-      });
-      if (_byProfile[name]) { _byProfile[name].url = null; _byProfile[name].blob = null; }
+    var current = _entryForName(name);
+    if (!current) return Promise.reject(new Error('Unknown profile'));
+    var displayName = _canonicalLookupName(name);
+    var targets = [current.storageName || displayName];
+    if (displayName !== targets[0]) targets.push(displayName);
+    return Promise.all(targets.map(_deleteStoredAvatar)).then(function (results) {
+      if (_byProfile[displayName]) { _byProfile[displayName].url = null; _byProfile[displayName].blob = null; }
       _pruneBlobCache();
       _broadcast();
-      return r.json();
+      return results[0];
     });
   }
 
@@ -426,10 +455,9 @@
   }
 
   function _setActive(name) {
-    if (!name) return;
-    name = _canonicalLookupName(name);
-    _activeName = name;
-    document.querySelectorAll('[data-avatar-active]').forEach(function (el) { renderInto(el, name); });
+    var current = _entryForName(name);
+    _activeName = current ? _canonicalLookupName(name) : null;
+    document.querySelectorAll('[data-avatar-active]').forEach(function (el) { renderInto(el, _activeName); });
     _renderBadges();
     _decorateSessionRows();
   }

--- a/extensions/profile-avatars/assets/avatars.js
+++ b/extensions/profile-avatars/assets/avatars.js
@@ -31,6 +31,9 @@
     if (n === 'default' || n === _rootProfileName) return _rootProfileName;
     return n;
   }
+  function _canonicalLookupName(name) {
+    return (typeof name === 'string' && name.trim()) ? _canonicalProfileName(name) : name;
+  }
   // Refresh the root + active identity from the roster: the root is the
   // is_default entry; the active profile is resolved from is_active (falling
   // back to data.active) and canonicalized so it matches a _byProfile key.
@@ -185,13 +188,14 @@
   }
 
   function active() { return _activeName; }
-  function entry(name) { return _byProfile[name] || null; }
+  function entry(name) { return _byProfile[_canonicalLookupName(name)] || null; }
   function list() {
     return Object.keys(_byProfile).map(function (n) { return Object.assign({ name: n }, _byProfile[n] || {}); });
   }
 
   function renderInto(el, name, opts) {
     if (!el) return;
+    name = _canonicalLookupName(name);
     var o = opts || {};
     var shape = o.shape === 'square' ? 'pa-avatar--square' : 'pa-avatar--circle';
     el.classList.add('pa-avatar', shape);
@@ -338,6 +342,7 @@
   }
 
   function upload(name, blob) {
+    name = _canonicalLookupName(name);
     var fd = new FormData();
     fd.append('avatar', blob, blob.name || 'avatar');
     return fetch(BASE + '/api/avatars/' + encodeURIComponent(name), {
@@ -355,6 +360,7 @@
     });
   }
   function remove(name) {
+    name = _canonicalLookupName(name);
     return fetch(BASE + '/api/avatars/' + encodeURIComponent(name), {
       method: 'DELETE', credentials: 'same-origin',
     }).then(function (r) {
@@ -421,6 +427,7 @@
 
   function _setActive(name) {
     if (!name) return;
+    name = _canonicalLookupName(name);
     _activeName = name;
     document.querySelectorAll('[data-avatar-active]').forEach(function (el) { renderInto(el, name); });
     _renderBadges();

--- a/extensions/profile-avatars/extension.json
+++ b/extensions/profile-avatars/extension.json
@@ -2,7 +2,7 @@
   "id": "profile-avatars",
   "name": "Profile Avatars",
   "description": "Per-profile avatar images everywhere: profile chips, transcript assistant badges, and the session list (including other-profile chats). Server-stored via a loopback sidecar, so avatars sync across devices with zero localStorage.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "asorourx",
   "assets": {
     "scripts": [

--- a/extensions/profile-avatars/sidecar/avatars.py
+++ b/extensions/profile-avatars/sidecar/avatars.py
@@ -19,6 +19,7 @@ import os
 import re as _re
 import sqlite3
 import time
+import zlib
 from pathlib import Path
 from typing import Optional
 
@@ -35,12 +36,39 @@ _AVATARS_DB = STATE_DIR / "avatars.db"
 ALLOWED_MIMES = {"image/png", "image/jpeg", "image/webp"}
 # 512 KiB matches the core sidecar-proxy's hard response cap.
 MAX_BYTES = 512 * 1024
+MAX_AVATARS = 128
+MAX_DIMENSION = 4096
+MAX_PIXELS = 16 * 1024 * 1024
+_PROFILE_RE = _re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+class InvalidImageError(ValueError):
+    """The upload is not a structurally valid, reasonably sized raster image."""
+
+
+class AvatarLimitError(ValueError):
+    """The bounded avatar store has no room for another profile row."""
+
+
+def _harden_db_files() -> None:
+    """Keep the avatar database and transient SQLite files owner-only."""
+    for path in STATE_DIR.glob(f"{_AVATARS_DB.name}*"):
+        try:
+            if path.is_file() and not path.is_symlink():
+                path.chmod(0o600)
+        except OSError:
+            # A journal can disappear between glob/stat; SQLite remains the
+            # authority for whether the operation itself succeeded.
+            pass
 
 
 def _ensure_db() -> None:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
+    if _AVATARS_DB.is_symlink():
+        raise RuntimeError("avatars database must not be a symlink")
     conn = sqlite3.connect(_AVATARS_DB)
     try:
+        _AVATARS_DB.chmod(0o600)
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS avatars (
@@ -55,6 +83,7 @@ def _ensure_db() -> None:
         conn.commit()
     finally:
         conn.close()
+        _harden_db_files()
 
 
 def _open() -> sqlite3.Connection:
@@ -65,9 +94,7 @@ def _open() -> sqlite3.Connection:
 # -- validation ------------------------------------------------------------
 
 def valid_profile(name: str) -> bool:
-    if not name or len(name) > 128:
-        return False
-    return all(c.isalnum() or c in "-_." for c in name)
+    return bool(isinstance(name, str) and _PROFILE_RE.fullmatch(name))
 
 
 def detect_mime(blob: bytes) -> str:
@@ -78,6 +105,148 @@ def detect_mime(blob: bytes) -> str:
     if len(blob) >= 12 and blob[:4] == b"RIFF" and blob[8:12] == b"WEBP":
         return "image/webp"
     return "application/octet-stream"
+
+
+def _checked_dimensions(width: int, height: int) -> tuple[int, int]:
+    if width <= 0 or height <= 0:
+        raise InvalidImageError("image dimensions must be positive")
+    if width > MAX_DIMENSION or height > MAX_DIMENSION or width * height > MAX_PIXELS:
+        raise InvalidImageError(
+            f"image dimensions exceed {MAX_DIMENSION}px / {MAX_PIXELS} pixels"
+        )
+    return width, height
+
+
+def _png_dimensions(blob: bytes) -> tuple[int, int]:
+    if len(blob) < 45 or blob[:8] != b"\x89PNG\r\n\x1a\n":
+        raise InvalidImageError("malformed PNG")
+    pos = 8
+    width = height = None
+    saw_idat = False
+    saw_iend = False
+    while pos + 12 <= len(blob):
+        length = int.from_bytes(blob[pos:pos + 4], "big")
+        kind = blob[pos + 4:pos + 8]
+        end = pos + 12 + length
+        if end > len(blob):
+            raise InvalidImageError("truncated PNG chunk")
+        data_end = pos + 8 + length
+        expected_crc = int.from_bytes(blob[data_end:data_end + 4], "big")
+        actual_crc = zlib.crc32(blob[pos + 4:data_end]) & 0xFFFFFFFF
+        if expected_crc != actual_crc:
+            raise InvalidImageError("PNG chunk checksum mismatch")
+        if pos == 8:
+            if kind != b"IHDR" or length != 13:
+                raise InvalidImageError("PNG must start with IHDR")
+            width = int.from_bytes(blob[pos + 8:pos + 12], "big")
+            height = int.from_bytes(blob[pos + 12:pos + 16], "big")
+        if kind == b"IDAT":
+            saw_idat = True
+        if kind == b"IEND":
+            if length != 0:
+                raise InvalidImageError("invalid PNG IEND")
+            saw_iend = True
+            break
+        pos = end
+    if width is None or height is None or not saw_idat or not saw_iend:
+        raise InvalidImageError("incomplete PNG")
+    return _checked_dimensions(width, height)
+
+
+_JPEG_SOF = {
+    0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
+    0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF,
+}
+
+
+def _jpeg_dimensions(blob: bytes) -> tuple[int, int]:
+    if len(blob) < 12 or not blob.startswith(b"\xff\xd8") or not blob.endswith(b"\xff\xd9"):
+        raise InvalidImageError("malformed JPEG")
+    pos = 2
+    dimensions = None
+    saw_scan = False
+    while pos < len(blob) - 2:
+        if blob[pos] != 0xFF:
+            raise InvalidImageError("invalid JPEG marker")
+        while pos < len(blob) and blob[pos] == 0xFF:
+            pos += 1
+        if pos >= len(blob):
+            break
+        marker = blob[pos]
+        pos += 1
+        if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+            continue
+        if pos + 2 > len(blob):
+            raise InvalidImageError("truncated JPEG segment")
+        seg_len = int.from_bytes(blob[pos:pos + 2], "big")
+        if seg_len < 2 or pos + seg_len > len(blob):
+            raise InvalidImageError("invalid JPEG segment length")
+        if marker == 0xDA:
+            if dimensions is None or pos + seg_len >= len(blob) - 2:
+                raise InvalidImageError("invalid JPEG scan")
+            saw_scan = True
+            break
+        if marker in _JPEG_SOF:
+            if seg_len < 7:
+                raise InvalidImageError("invalid JPEG frame header")
+            height = int.from_bytes(blob[pos + 3:pos + 5], "big")
+            width = int.from_bytes(blob[pos + 5:pos + 7], "big")
+            dimensions = _checked_dimensions(width, height)
+        pos += seg_len
+    if dimensions is None or not saw_scan:
+        raise InvalidImageError("JPEG has no complete frame")
+    return dimensions
+
+
+def _webp_dimensions(blob: bytes) -> tuple[int, int]:
+    if len(blob) < 20 or blob[:4] != b"RIFF" or blob[8:12] != b"WEBP":
+        raise InvalidImageError("malformed WebP")
+    declared_end = int.from_bytes(blob[4:8], "little") + 8
+    if declared_end > len(blob) or declared_end < 20:
+        raise InvalidImageError("truncated WebP")
+    pos = 12
+    canvas = None
+    while pos + 8 <= declared_end:
+        kind = blob[pos:pos + 4]
+        length = int.from_bytes(blob[pos + 4:pos + 8], "little")
+        data = pos + 8
+        end = data + length
+        if end > declared_end:
+            raise InvalidImageError("truncated WebP chunk")
+        if kind == b"VP8X" and length >= 10:
+            width = int.from_bytes(blob[data + 4:data + 7], "little") + 1
+            height = int.from_bytes(blob[data + 7:data + 10], "little") + 1
+            canvas = _checked_dimensions(width, height)
+        if kind == b"VP8L" and length >= 5 and blob[data] == 0x2F:
+            bits = int.from_bytes(blob[data + 1:data + 5], "little")
+            width = (bits & 0x3FFF) + 1
+            height = ((bits >> 14) & 0x3FFF) + 1
+            frame = _checked_dimensions(width, height)
+            if canvas and (frame[0] > canvas[0] or frame[1] > canvas[1]):
+                raise InvalidImageError("WebP frame exceeds canvas")
+            return canvas or frame
+        if kind == b"VP8 " and length >= 10 and blob[data + 3:data + 6] == b"\x9d\x01\x2a":
+            width = int.from_bytes(blob[data + 6:data + 8], "little") & 0x3FFF
+            height = int.from_bytes(blob[data + 8:data + 10], "little") & 0x3FFF
+            frame = _checked_dimensions(width, height)
+            if canvas and (frame[0] > canvas[0] or frame[1] > canvas[1]):
+                raise InvalidImageError("WebP frame exceeds canvas")
+            return canvas or frame
+        pos = end + (length & 1)
+    raise InvalidImageError("WebP has no supported image frame")
+
+
+def validate_image(blob: bytes, mime: str) -> tuple[int, int]:
+    """Validate image structure and return bounded decoded dimensions."""
+    if not blob or len(blob) > MAX_BYTES:
+        raise InvalidImageError("avatar payload size is invalid")
+    if detect_mime(blob) != mime or mime not in ALLOWED_MIMES:
+        raise InvalidImageError("avatar MIME does not match its bytes")
+    if mime == "image/png":
+        return _png_dimensions(blob)
+    if mime == "image/jpeg":
+        return _jpeg_dimensions(blob)
+    return _webp_dimensions(blob)
 
 
 # -- reads -----------------------------------------------------------------
@@ -119,7 +288,10 @@ def list_avatars() -> dict:
     except Exception:
         return {}
     try:
-        rows = conn.execute("SELECT profile, updated_at, etag FROM avatars").fetchall()
+        rows = conn.execute(
+            "SELECT profile, updated_at, etag FROM avatars ORDER BY profile LIMIT ?",
+            (MAX_AVATARS,),
+        ).fetchall()
     finally:
         conn.close()
     return {
@@ -165,10 +337,23 @@ def get_avatar_row(profile: str):
 
 def store_avatar(profile: str, mime: str, blob: bytes) -> dict:
     """Insert/replace the avatar row and return the response metadata dict."""
+    if not valid_profile(profile):
+        raise ValueError("invalid profile name")
+    width, height = validate_image(blob, mime)
     etag = '"' + hashlib.sha256(blob).hexdigest()[:32] + '"'
     now = time.time()
     conn = _open()
     try:
+        # Serialize the count-and-insert decision so two concurrent first
+        # uploads cannot both pass at MAX_AVATARS - 1.
+        conn.execute("BEGIN IMMEDIATE")
+        exists = conn.execute(
+            "SELECT 1 FROM avatars WHERE profile = ?", (profile,)
+        ).fetchone()
+        if not exists:
+            count = conn.execute("SELECT COUNT(*) FROM avatars").fetchone()[0]
+            if count >= MAX_AVATARS:
+                raise AvatarLimitError(f"avatar store is limited to {MAX_AVATARS} profiles")
         conn.execute(
             "INSERT OR REPLACE INTO avatars (profile, mime, bytes, etag, updated_at) VALUES (?, ?, ?, ?, ?)",
             (profile, mime, blob, etag, now),
@@ -176,10 +361,13 @@ def store_avatar(profile: str, mime: str, blob: bytes) -> dict:
         conn.commit()
     finally:
         conn.close()
+        _harden_db_files()
     return {
         "profile": profile,
         "mime": mime,
         "size": len(blob),
+        "width": width,
+        "height": height,
         "updated_at": now,
         "url": avatar_url_for(profile),
     }
@@ -193,6 +381,7 @@ def delete_avatar(profile: str) -> bool:
         return bool(cur.rowcount)
     finally:
         conn.close()
+        _harden_db_files()
 
 
 def rename_avatar(old_profile: str, new_profile: str) -> bool:
@@ -201,7 +390,7 @@ def rename_avatar(old_profile: str, new_profile: str) -> bool:
     No-op if old has no avatar. If new already has a row it is replaced. Returns
     True if a row was moved.
     """
-    if not old_profile or not new_profile or old_profile == new_profile:
+    if not valid_profile(old_profile) or not valid_profile(new_profile) or old_profile == new_profile:
         return False
     try:
         conn = _open()
@@ -217,6 +406,7 @@ def rename_avatar(old_profile: str, new_profile: str) -> bool:
         return True
     finally:
         conn.close()
+        _harden_db_files()
 
 
 # -- multipart -------------------------------------------------------------
@@ -227,10 +417,6 @@ def parse_multipart(body: bytes, content_type: str) -> tuple:
     Returns (fields, files) where files[name] = (filename, raw_bytes)."""
     if "\r" in content_type or "\n" in content_type:
         raise ValueError("Invalid Content-Type")
-    m = _re.search(r"boundary=([^;\s]+)", content_type)
-    if not m or not m.group(1).strip('"'):
-        raise ValueError("No boundary in Content-Type")
-
     try:
         envelope = (
             b"Content-Type: "
@@ -242,7 +428,7 @@ def parse_multipart(body: bytes, content_type: str) -> tuple:
         raise ValueError("Invalid Content-Type") from exc
 
     message = _ep.BytesParser(policy=_policy.default).parsebytes(envelope)
-    if not message.is_multipart():
+    if not message.get_boundary() or not message.is_multipart():
         raise ValueError("Malformed multipart body")
 
     fields, files = {}, {}

--- a/extensions/profile-avatars/sidecar/routes_impl.py
+++ b/extensions/profile-avatars/sidecar/routes_impl.py
@@ -87,7 +87,12 @@ def register(app) -> None:
                 {"error": "unsupported image type — allowed: PNG, JPEG, WebP (magic bytes)"},
                 status=415,
             )
-        return app.json(avatars.store_avatar(profile, mime, blob))
+        try:
+            return app.json(avatars.store_avatar(profile, mime, blob))
+        except avatars.InvalidImageError as exc:
+            return app.json({"error": f"invalid image: {exc}"}, status=415)
+        except avatars.AvatarLimitError as exc:
+            return app.json({"error": str(exc)}, status=409)
 
     @app.route("DELETE", "/api/avatars/{profile}")
     def delete(req):

--- a/scripts/test-profile-avatars.py
+++ b/scripts/test-profile-avatars.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Regression tests for the Profile Avatars extension."""
+from __future__ import annotations
+
+import colorsys
+import concurrent.futures
+import importlib.util
+import os
+import struct
+import sys
+import tempfile
+import threading
+import unittest
+import zlib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIDECAR_DIR = REPO_ROOT / "extensions" / "profile-avatars" / "sidecar"
+AVATARS_PATH = SIDECAR_DIR / "avatars.py"
+_SPEC = importlib.util.spec_from_file_location("profile_avatars_storage", AVATARS_PATH)
+if _SPEC is None or _SPEC.loader is None:
+    raise RuntimeError(f"cannot load {AVATARS_PATH}")
+avatars = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = avatars
+_SPEC.loader.exec_module(avatars)
+
+
+def _png_chunk(kind: bytes, payload: bytes) -> bytes:
+    checksum = zlib.crc32(kind + payload) & 0xFFFFFFFF
+    return len(payload).to_bytes(4, "big") + kind + payload + checksum.to_bytes(4, "big")
+
+
+def png(width: int = 1, height: int = 1) -> bytes:
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    # One real RGBA scanline is enough for the normal 1x1 storage tests. Large
+    # dimensions are rejected from IHDR before pixel data is decoded.
+    raw = b"\x00" + b"\x00\x00\x00\xff" * (width if height == 1 and width <= 8 else 1)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", ihdr)
+        + _png_chunk(b"IDAT", zlib.compress(raw))
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+def jpeg(width: int = 1, height: int = 1, include_scan: bool = True) -> bytes:
+    sof_data = bytes([8]) + height.to_bytes(2, "big") + width.to_bytes(2, "big") + bytes([
+        3, 1, 0x11, 0, 2, 0x11, 0, 3, 0x11, 0,
+    ])
+    out = b"\xff\xd8\xff\xc0" + (len(sof_data) + 2).to_bytes(2, "big") + sof_data
+    if include_scan:
+        sos_data = bytes([3, 1, 0, 2, 0, 3, 0, 0, 63, 0])
+        out += b"\xff\xda" + (len(sos_data) + 2).to_bytes(2, "big") + sos_data + b"\x00"
+    return out + b"\xff\xd9"
+
+
+def webp_lossless(width: int = 1, height: int = 1) -> bytes:
+    bits = (width - 1) | ((height - 1) << 14)
+    payload = b"\x2f" + bits.to_bytes(4, "little")
+    chunk = b"VP8L" + len(payload).to_bytes(4, "little") + payload + b"\x00"
+    riff_payload = b"WEBP" + chunk
+    return b"RIFF" + len(riff_payload).to_bytes(4, "little") + riff_payload
+
+
+class AvatarValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.old_state = getattr(avatars, "STATE_DIR")
+        self.old_db = getattr(avatars, "_AVATARS_DB")
+        self.old_limit = getattr(avatars, "MAX_AVATARS")
+        setattr(avatars, "STATE_DIR", Path(self.temp.name))
+        setattr(avatars, "_AVATARS_DB", Path(self.temp.name) / "avatars.db")
+        setattr(avatars, "MAX_AVATARS", 128)
+
+    def tearDown(self) -> None:
+        setattr(avatars, "STATE_DIR", self.old_state)
+        setattr(avatars, "_AVATARS_DB", self.old_db)
+        setattr(avatars, "MAX_AVATARS", self.old_limit)
+        self.temp.cleanup()
+
+    def test_profile_names_match_core_ids(self) -> None:
+        for name in ("default", "webui", "agent-2", "agent_two", "a" * 64):
+            self.assertTrue(avatars.valid_profile(name), name)
+        for name in ("", "Agent", ".hidden", "with.dot", "two words", "é", "a" * 65):
+            self.assertFalse(avatars.valid_profile(name), name)
+
+    def test_valid_raster_dimensions(self) -> None:
+        self.assertEqual(avatars.validate_image(png(2, 1), "image/png"), (2, 1))
+        self.assertEqual(avatars.validate_image(jpeg(3, 2), "image/jpeg"), (3, 2))
+        self.assertEqual(avatars.validate_image(webp_lossless(4, 3), "image/webp"), (4, 3))
+
+    def test_malformed_and_excessive_images_are_rejected(self) -> None:
+        broken_crc = bytearray(png())
+        broken_crc[-1] ^= 1
+        cases = [
+            (b"\x89PNG\r\n\x1a\n", "image/png"),
+            (bytes(broken_crc), "image/png"),
+            (png(4097, 1), "image/png"),
+            (jpeg(include_scan=False), "image/jpeg"),
+            (b"RIFF\x0c\x00\x00\x00WEBPVP8X\x00\x00\x00\x00", "image/webp"),
+        ]
+        for blob, mime in cases:
+            with self.subTest(mime=mime, size=len(blob)):
+                with self.assertRaises(avatars.InvalidImageError):
+                    avatars.validate_image(blob, mime)
+
+    def test_store_is_bounded_and_replacement_remains_allowed(self) -> None:
+        setattr(avatars, "MAX_AVATARS", 2)
+        avatars.store_avatar("one", "image/png", png())
+        avatars.store_avatar("two", "image/png", png())
+        with self.assertRaises(avatars.AvatarLimitError):
+            avatars.store_avatar("three", "image/png", png())
+        # Existing rows may still be replaced at the cap.
+        avatars.store_avatar("one", "image/png", png(2, 1))
+        self.assertEqual(set(avatars.list_avatars()), {"one", "two"})
+
+    def test_concurrent_first_uploads_cannot_exceed_row_cap(self) -> None:
+        setattr(avatars, "MAX_AVATARS", 1)
+        barrier = threading.Barrier(2)
+
+        def attempt(name: str) -> str:
+            barrier.wait()
+            try:
+                avatars.store_avatar(name, "image/png", png())
+                return "stored"
+            except avatars.AvatarLimitError:
+                return "limited"
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(attempt, ("one", "two")))
+        self.assertCountEqual(results, ["stored", "limited"])
+        self.assertEqual(len(avatars.list_avatars()), 1)
+
+    def test_database_is_owner_only_even_under_permissive_umask(self) -> None:
+        old_umask = os.umask(0)
+        try:
+            avatars.store_avatar("default", "image/png", png())
+        finally:
+            os.umask(old_umask)
+        self.assertEqual(avatars._AVATARS_DB.stat().st_mode & 0o777, 0o600)
+
+    def test_database_symlink_is_refused(self) -> None:
+        target = avatars.STATE_DIR / "target.db"
+        target.write_bytes(b"not sqlite")
+        avatars._AVATARS_DB.symlink_to(target)
+        with self.assertRaisesRegex(RuntimeError, "must not be a symlink"):
+            avatars._ensure_db()
+
+    def test_quoted_multipart_boundary_and_embedded_boundary_bytes(self) -> None:
+        boundary = "avatar boundary"
+        payload = png() + b"--avatar boundary-not-a-delimiter"
+        body = (
+            b"--avatar boundary\r\n"
+            b"Content-Disposition: form-data; name=\"avatar\"; filename=\"a.png\"\r\n"
+            b"Content-Type: image/png\r\n\r\n"
+            + payload
+            + b"\r\n--avatar boundary--\r\n"
+        )
+        fields, files = avatars.parse_multipart(
+            body, 'multipart/form-data; boundary="avatar boundary"'
+        )
+        self.assertEqual(fields, {})
+        self.assertEqual(files["avatar"], ("a.png", payload))
+
+
+class FrontendContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = (
+            REPO_ROOT / "extensions" / "profile-avatars" / "assets" / "avatars.js"
+        ).read_text(encoding="utf-8")
+
+    def test_manager_rechecks_consent_and_refreshes_on_every_open(self) -> None:
+        block = self.source.split("function openManager()", 1)[1].split(
+            "function _closeManager()", 1
+        )[0]
+        self.assertIn("sidecarConsented()", block)
+        self.assertIn("return refresh().then(_renderManagerList)", block)
+        self.assertNotIn("_loaded ?", block)
+
+    def test_upload_decodes_before_posting(self) -> None:
+        pick = self.source.split("function _pickAndUpload", 1)[1].split(
+            "function _buildManager", 1
+        )[0]
+        self.assertIn("_validateAvatarFile(f)", pick)
+        self.assertLess(pick.index("_validateAvatarFile(f)"), pick.index("upload(name, f)"))
+
+    def test_generated_initial_colors_meet_white_text_contrast(self) -> None:
+        self.assertIn("55%, 30%", self.source)
+        worst = 100.0
+        for hue in range(360):
+            red, green, blue = colorsys.hls_to_rgb(hue / 360, 0.30, 0.55)
+            channels = []
+            for value in (red, green, blue):
+                channels.append(
+                    value / 12.92 if value <= 0.04045
+                    else ((value + 0.055) / 1.055) ** 2.4
+                )
+            luminance = 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+            worst = min(worst, 1.05 / (luminance + 0.05))
+        self.assertGreaterEqual(worst, 4.5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test-profile-avatars.py
+++ b/scripts/test-profile-avatars.py
@@ -185,6 +185,13 @@ class FrontendContractTests(unittest.TestCase):
         self.assertIn("_validateAvatarFile(f)", pick)
         self.assertLess(pick.index("_validateAvatarFile(f)"), pick.index("upload(name, f)"))
 
+    def test_decode_failures_use_a_stable_user_facing_message(self) -> None:
+        block = self.source.split("function _decodeAvatarDimensions", 1)[1].split(
+            "function _validateAvatarFile", 1
+        )[0]
+        message = "The selected file is not a decodable image."
+        self.assertEqual(block.count(message), 2)
+
     def test_generated_initial_colors_meet_white_text_contrast(self) -> None:
         self.assertIn("55%, 30%", self.source)
         worst = 100.0

--- a/scripts/test-profile-avatars.py
+++ b/scripts/test-profile-avatars.py
@@ -200,6 +200,7 @@ import vm from 'node:vm';
 
 const source = fs.readFileSync(process.argv[1], 'utf8');
 const calls = [];
+const avatars = new Map([['default', { url: '/api/avatars/default?v=old' }]]);
 function makeElement() {
   let html = '';
   return {
@@ -215,7 +216,12 @@ function makeElement() {
 const document = {
   readyState: 'loading', body: makeElement(),
   addEventListener() {}, querySelectorAll() { return []; },
-  getElementById() { return null; }, createElement() { return makeElement(); },
+  getElementById() { return null; },
+  createElement(tagName) {
+    const element = makeElement();
+    element.tagName = String(tagName || '').toUpperCase();
+    return element;
+  },
 };
 async function fetch(url, options = {}) {
   calls.push({ url, method: options.method || 'GET' });
@@ -226,15 +232,20 @@ async function fetch(url, options = {}) {
     }) };
   }
   if (url.endsWith('/api/avatars') && !options.method) {
-    return { ok: true, json: async () => ({ avatars: {} }) };
+    return { ok: true, json: async () => ({ avatars: Object.fromEntries(avatars) }) };
   }
   if (options.method === 'POST') {
-    return { ok: true, json: async () => ({ url: '/api/avatars/renamed-root?v=1' }) };
+    const profile = decodeURIComponent(url.split('/').pop());
+    const value = { url: `/api/avatars/${encodeURIComponent(profile)}?v=new` };
+    avatars.set(profile, value);
+    return { ok: true, json: async () => value };
   }
   if (options.method === 'DELETE') {
-    return { ok: true, json: async () => ({ deleted: true }) };
+    const profile = decodeURIComponent(url.split('/').pop());
+    const deleted = avatars.delete(profile);
+    return { ok: true, json: async () => ({ deleted }) };
   }
-  if (url.includes('/api/avatars/renamed-root')) {
+  if (url.includes('/api/avatars/')) {
     return { ok: true, blob: async () => ({}) };
   }
   throw new Error('unexpected fetch: ' + url);
@@ -256,23 +267,47 @@ const api = sandbox.ProfileAvatars;
 await api.refresh();
 const root = api.entry('renamed-root');
 if (!root || api.entry('default') !== root) throw new Error('entry(default) did not resolve renamed root');
+if (root.blob !== 'blob:avatar') throw new Error('avatar stored under default did not survive root rename');
 
 const target = makeElement();
 api.renderInto(target, 'default');
-if (!target.children[0] || target.children[0].textContent !== 'H') {
-  throw new Error('renderInto(default) did not render renamed-root fallback');
+if (!target.children[0] || target.children[0].tagName !== 'IMG') {
+  throw new Error('renderInto(default) did not render the persisted root avatar');
 }
 
 api._setActive('default');
 if (api.active() !== 'renamed-root') throw new Error('_setActive(default) kept the alias');
 
 await api.upload('default', { name: 'avatar.png' });
-await api.remove('default');
-if (!calls.some((call) => call.method === 'POST' && call.url.endsWith('/api/avatars/renamed-root'))) {
-  throw new Error('upload(default) used a non-canonical sidecar key');
+if (!calls.some((call) => call.method === 'POST' && call.url.endsWith('/api/avatars/default'))) {
+  throw new Error('upload(default) did not use stable root storage');
 }
-if (!calls.some((call) => call.method === 'DELETE' && call.url.endsWith('/api/avatars/renamed-root'))) {
-  throw new Error('remove(default) used a non-canonical sidecar key');
+if (!avatars.has('default') || avatars.has('renamed-root')) {
+  throw new Error('upload(default) created a second display-name row');
+}
+
+await api.remove('default');
+if (avatars.has('default') || avatars.has('renamed-root')) {
+  throw new Error('remove(default) left a root alias row behind');
+}
+
+for (const bad of ['', '   ', 'missing-profile']) {
+  if (api.entry(bad) !== null) throw new Error('entry mapped invalid name: ' + JSON.stringify(bad));
+  const invalidTarget = makeElement();
+  api.renderInto(invalidTarget, bad);
+  if (invalidTarget.children[0]?.tagName === 'IMG') throw new Error('renderInto mapped invalid name');
+  const before = calls.length;
+  await api.upload(bad, { name: 'avatar.png' }).then(
+    () => { throw new Error('upload accepted invalid name'); },
+    () => {},
+  );
+  await api.remove(bad).then(
+    () => { throw new Error('remove accepted invalid name'); },
+    () => {},
+  );
+  if (calls.length !== before) throw new Error('invalid name reached the sidecar');
+  api._setActive(bad);
+  if (api.active() !== null) throw new Error('_setActive mapped invalid name');
 }
 """
         completed = subprocess.run(

--- a/scripts/test-profile-avatars.py
+++ b/scripts/test-profile-avatars.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import importlib.util
 import os
 import struct
+import subprocess
 import sys
 import tempfile
 import threading
@@ -191,6 +192,96 @@ class FrontendContractTests(unittest.TestCase):
         )[0]
         message = "The selected file is not a decodable image."
         self.assertEqual(block.count(message), 2)
+
+    def test_renamed_root_alias_is_canonical_across_public_frontend_api(self) -> None:
+        harness = r"""
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const source = fs.readFileSync(process.argv[1], 'utf8');
+const calls = [];
+function makeElement() {
+  let html = '';
+  return {
+    children: [], dataset: {}, style: {}, title: '', textContent: '',
+    classList: { add() {}, remove() {}, contains() { return false; } },
+    appendChild(child) { this.children.push(child); return child; },
+    querySelector() { return null; },
+    setAttribute() {}, getAttribute() { return null; },
+    get innerHTML() { return html; },
+    set innerHTML(value) { html = value; this.children = []; },
+  };
+}
+const document = {
+  readyState: 'loading', body: makeElement(),
+  addEventListener() {}, querySelectorAll() { return []; },
+  getElementById() { return null; }, createElement() { return makeElement(); },
+};
+async function fetch(url, options = {}) {
+  calls.push({ url, method: options.method || 'GET' });
+  if (url === '/api/profiles') {
+    return { ok: true, json: async () => ({
+      active: 'default',
+      profiles: [{ name: 'renamed-root', is_default: true, is_active: true }],
+    }) };
+  }
+  if (url.endsWith('/api/avatars') && !options.method) {
+    return { ok: true, json: async () => ({ avatars: {} }) };
+  }
+  if (options.method === 'POST') {
+    return { ok: true, json: async () => ({ url: '/api/avatars/renamed-root?v=1' }) };
+  }
+  if (options.method === 'DELETE') {
+    return { ok: true, json: async () => ({ deleted: true }) };
+  }
+  if (url.includes('/api/avatars/renamed-root')) {
+    return { ok: true, blob: async () => ({}) };
+  }
+  throw new Error('unexpected fetch: ' + url);
+}
+class FormData { append() {} }
+class Element {}
+const sandbox = {
+  document, fetch, FormData, Element,
+  URL: { createObjectURL() { return 'blob:avatar'; }, revokeObjectURL() {} },
+  setTimeout, clearTimeout, console,
+};
+sandbox.window = sandbox;
+sandbox.window.addEventListener = () => {};
+sandbox.window._botName = 'Hermes';
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: 'avatars.js' });
+
+const api = sandbox.ProfileAvatars;
+await api.refresh();
+const root = api.entry('renamed-root');
+if (!root || api.entry('default') !== root) throw new Error('entry(default) did not resolve renamed root');
+
+const target = makeElement();
+api.renderInto(target, 'default');
+if (!target.children[0] || target.children[0].textContent !== 'H') {
+  throw new Error('renderInto(default) did not render renamed-root fallback');
+}
+
+api._setActive('default');
+if (api.active() !== 'renamed-root') throw new Error('_setActive(default) kept the alias');
+
+await api.upload('default', { name: 'avatar.png' });
+await api.remove('default');
+if (!calls.some((call) => call.method === 'POST' && call.url.endsWith('/api/avatars/renamed-root'))) {
+  throw new Error('upload(default) used a non-canonical sidecar key');
+}
+if (!calls.some((call) => call.method === 'DELETE' && call.url.endsWith('/api/avatars/renamed-root'))) {
+  throw new Error('remove(default) used a non-canonical sidecar key');
+}
+"""
+        completed = subprocess.run(
+            ["node", "--input-type=module", "-e", harness, str(AVATARS_PATH.parent.parent / "assets" / "avatars.js")],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
 
     def test_generated_initial_colors_meet_white_text_contrast(self) -> None:
         self.assertIn("55%, 30%", self.source)


### PR DESCRIPTION
## Summary

Follow-up hardening for Profile Avatars after the late independent review of #66 and the lifecycle correction in #69.

- validate PNG/JPEG/WebP structure and dimensions server-side, with matching browser decode checks;
- enforce core-compatible profile IDs, a transaction-safe 128-row cap, symlink refusal, and owner-only SQLite modes;
- refresh the profile roster and recheck sidecar consent every time the manager opens;
- normalize image decode errors and raise generated-initial contrast to WCAG AA across all hues;
- accept legal quoted multipart boundaries;
- add a standard-library regression suite to repository CI.

Profile Avatars remains authored and credited to @asorourx (`extension.json` author is unchanged). This PR corrects hardening gaps discovered after #66 was merged; #69 remains the preceding lifecycle fix.

## Verification

- `python3 scripts/test-profile-avatars.py` (12 tests)
- complete local `.github/workflows/extensions.yml` command sequence
- `node --check extensions/profile-avatars/assets/avatars.js`
- previous #69 lifecycle/dialog harnesses plus new decode/manager runtime harness
- threat scan + no-network/no-secrets sandbox run
- token-v1 sidecar E2E: fail-closed auth, upload, byte-identical read, ETag/304, malformed/dimension/profile rejection, live token rotation, delete, DB mode
- Fable UX gate: one decode-message finding fixed with mutation-proven regression; final rerun pending
- Codex exact-head gate pending
