### PR TITLE
fix: stop Message Pins observer layout loop

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Test extension validator
         run: node scripts/test-extension-validator.mjs
 
+      - name: Test Message Pins observer sync
+        run: node scripts/test-message-pins-sync.mjs
+
       - name: Test sidecar contract enforcement
         run: node scripts/test-sidecar-contract.mjs
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Run the current repo-wide checks locally with:
 ```bash
 node scripts/validate-extensions.mjs
 node scripts/test-extension-validator.mjs
+node scripts/test-message-pins-sync.mjs
 node scripts/test-sidecar-contract.mjs
 python3 scripts/test-sidecar-scaffold.py
 node scripts/scan-extension-safety.mjs

--- a/extensions/message-pins/assets/message-pins.js
+++ b/extensions/message-pins/assets/message-pins.js
@@ -25,6 +25,8 @@
   let popover = null;
   let toastTimer = null;
   let lastSessionId = null;
+  let pendingRows = new Set();
+  let pendingSessionCheck = false;
 
   // ── small DOM helpers ────────────────────────────────────────────────────
   function $(id) { return document.getElementById(id); }
@@ -147,7 +149,7 @@
       savePins(pins);
       toast('Message pinned');
     }
-    redecorate();
+    redecorate(row ? [row] : null);
     refreshHeader();
     if (popover) renderPopover();
   }
@@ -183,12 +185,9 @@
   function makePinButton(idx, pinned) {
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'msg-action-btn hwx-pin-btn' + (pinned ? ' hwx-pin-btn--active' : '');
-    btn.setAttribute('aria-pressed', pinned ? 'true' : 'false');
-    btn.title = pinned ? 'Unpin message' : 'Pin message';
-    btn.setAttribute('aria-label', pinned ? 'Unpin message' : 'Pin message');
-    btn.innerHTML = pinButtonSvg(pinned);
+    btn.className = 'msg-action-btn hwx-pin-btn';
     btn.dataset[BTN_FLAG] = '1';
+    setPinButtonState(btn, pinned);
     btn.addEventListener('click', (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
@@ -197,12 +196,29 @@
     return btn;
   }
 
+  function setPinButtonState(btn, pinned) {
+    const state = pinned ? '1' : '0';
+    // Replacing the SVG creates a child-list mutation. Skip every DOM write when
+    // the button already represents this state, otherwise our observer schedules
+    // an endless no-op redraw on an idle transcript.
+    if (btn.dataset.hwxPinState === state) return;
+    btn.dataset.hwxPinState = state;
+    btn.classList.toggle('hwx-pin-btn--active', pinned);
+    btn.setAttribute('aria-pressed', pinned ? 'true' : 'false');
+    btn.title = pinned ? 'Unpin message' : 'Pin message';
+    btn.setAttribute('aria-label', pinned ? 'Unpin message' : 'Pin message');
+    btn.innerHTML = pinButtonSvg(pinned);
+  }
+
   function decorateRow(row, pins) {
     const idx = rowIdx(row);
     if (idx == null) return;
     const pinned = isPinned(idx, pins);
-    row.dataset[PIN_FLAG] = pinned ? '1' : '0';
-    row.classList.toggle('hwx-pinned-row', pinned);
+    const state = pinned ? '1' : '0';
+    if (row.dataset[PIN_FLAG] !== state) {
+      row.dataset[PIN_FLAG] = state;
+      row.classList.toggle('hwx-pinned-row', pinned);
+    }
 
     let btn = row.querySelector(':scope .hwx-pin-btn');
     if (!btn) {
@@ -220,11 +236,7 @@
       }
     } else {
       // Update existing button state in place.
-      btn.classList.toggle('hwx-pin-btn--active', pinned);
-      btn.setAttribute('aria-pressed', pinned ? 'true' : 'false');
-      btn.title = pinned ? 'Unpin message' : 'Pin message';
-      btn.setAttribute('aria-label', pinned ? 'Unpin message' : 'Pin message');
-      btn.innerHTML = pinButtonSvg(pinned);
+      setPinButtonState(btn, pinned);
     }
   }
 
@@ -242,18 +254,20 @@
                        row.querySelector(':scope .msg-foot .msg-actions') ||
                        row.querySelector(':scope .msg-actions');
     if (!hasContent) return false;
-    // must be visibly laid out (skips display:none anchors + collapsed nodes)
-    const rect = row.getBoundingClientRect();
-    if (rect.height <= 1) return false;
+    // Core marks hidden segments structurally. Do not read geometry here: this
+    // runs for every newly rendered row and would force layout in long sessions.
+    if (row.hidden || row.getAttribute('aria-hidden') === 'true') return false;
     return true;
   }
 
-  function redecorate() {
+  function redecorate(rows) {
     const container = $('messages');
     if (!container) return;
     const pins = loadPins();
     const seen = new Set();
-    container.querySelectorAll('[data-msg-idx]').forEach((row) => {
+    const candidates = rows || container.querySelectorAll('[data-msg-idx]');
+    candidates.forEach((row) => {
+      if (!container.contains(row)) return;
       if (!isRealMessageRow(row)) return;       // skip hidden anchor/worklog segments
       const idx = rowIdx(row);
       if (idx == null || seen.has(idx)) return; // decorate first real node per idx
@@ -441,23 +455,52 @@
   // buttons and decorations are lost. A MutationObserver re-applies them after
   // each rebuild. We also detect a session switch (the data-session-id flips)
   // and refresh the header badge for the new session's pin set.
-  function onMutations() {
+  function onMutations(rows, checkSession) {
     const sid = currentSessionId();
-    if (sid !== lastSessionId) {
+    if (checkSession && sid !== lastSessionId) {
       lastSessionId = sid;
       closePopover();
     }
-    redecorate();
-    refreshHeader();
+    if (rows.size) redecorate(rows);
+    if (rows.size || checkSession) refreshHeader();
   }
 
   let rafScheduled = false;
-  function scheduleSync() {
+  function addCandidateRow(node, rows) {
+    if (!node) return;
+    const el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+    if (!el || !el.closest || el.closest('.hwx-pin-btn')) return;
+    const ownRow = el.closest('[data-msg-idx]');
+    if (ownRow) rows.add(ownRow);
+    if (el.matches && el.matches('[data-msg-idx]')) rows.add(el);
+    if (el.querySelectorAll) {
+      el.querySelectorAll('[data-msg-idx]').forEach((row) => rows.add(row));
+    }
+  }
+
+  function scheduleSync(records) {
+    const rows = new Set();
+    records.forEach((record) => {
+      // Mutations inside our own button are caused by the static icon update;
+      // feeding them back into the observer was the idle CPU loop in #59.
+      const target = record.target && (record.target.nodeType === Node.ELEMENT_NODE
+        ? record.target : record.target.parentElement);
+      if (target && target.closest && target.closest('.hwx-pin-btn')) return;
+      record.addedNodes.forEach((node) => addCandidateRow(node, rows));
+    });
+    const sessionChanged = currentSessionId() !== lastSessionId;
+    if (!rows.size && !sessionChanged) return;
+    rows.forEach((row) => pendingRows.add(row));
+    pendingSessionCheck = pendingSessionCheck || sessionChanged;
     if (rafScheduled) return;
     rafScheduled = true;
     requestAnimationFrame(() => {
       rafScheduled = false;
-      try { onMutations(); } catch (_) {}
+      const rowsToSync = pendingRows;
+      const checkSession = pendingSessionCheck;
+      pendingRows = new Set();
+      pendingSessionCheck = false;
+      try { onMutations(rowsToSync, checkSession); } catch (_) {}
     });
   }
 

--- a/scripts/test-message-pins-sync.mjs
+++ b/scripts/test-message-pins-sync.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const source = readFileSync(
+  path.join(repoRoot, 'extensions/message-pins/assets/message-pins.js'), 'utf8'
+);
+
+// This is intentionally a source-level guard: the extension has no DOM test
+// harness, but these invariants prevent the exact observer/layout feedback loop
+// reported in #59 without adding a browser dependency to the repository.
+assert.match(source, /function scheduleSync\(records\)/,
+  'the observer must receive MutationRecords to limit work to affected rows');
+assert.match(source, /target\.closest\('\.hwx-pin-btn'\)/,
+  'extension-owned pin-button mutations must be ignored');
+assert.match(source, /function setPinButtonState\(btn, pinned\)/,
+  'pin state updates must be centralized');
+assert.match(source, /if \(btn\.dataset\.hwxPinState === state\) return;/,
+  'unchanged pin state must not rewrite the SVG');
+assert.doesNotMatch(source, /function isRealMessageRow\(row\)[\s\S]*?row\.getBoundingClientRect\(\)/,
+  'row eligibility must not force layout during observer sync');
+assert.match(source, /const candidates = rows \|\| container\.querySelectorAll\('\[data-msg-idx\]'\);/,
+  'full scans are allowed only for initial/manual decoration, not observer sync');
+assert.doesNotMatch(source, /try \{ onMutations\(\); \} catch \(_\) \{\}/,
+  'observer sync must pass its affected-row set into onMutations');
+
+console.log('ok - message-pins observer sync regression guard passed');


### PR DESCRIPTION
## Summary

Fixes #59.

- process only rows affected by each transcript mutation instead of rescanning every message row
- ignore mutations created inside extension-owned pin buttons
- skip SVG and state writes when a button already represents the current pin state
- replace the per-row geometry read with Core's structural hidden-row markers
- add a CI guard against reintroducing the observer/layout feedback loop

## Why this matters

The previous observer reacted to extension-owned `innerHTML` writes by scheduling another full transcript scan. Each scan called `getBoundingClientRect()` on every message row, so an idle large transcript could keep forcing layout and consume a CPU core.

## Verification

- `node scripts/test-message-pins-sync.mjs`
- `node --check extensions/message-pins/assets/message-pins.js`
- complete repository validation, safety, sidecar, Desktop Companion, and generated-registry gates

The new test is deliberately a source-level regression guard: this repository has no DOM/browser test dependency. It locks the concrete invariants behind #59, but a Chrome Performance trace on a large transcript remains the post-merge/manual verification for actual CPU and frame behavior.
