### PR TITLE
chore: make repo ProofShot-friendly (ignore artifacts + add config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+proofshot-artifacts/

--- a/proofshot.config.json
+++ b/proofshot.config.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/proofshot-dev/proofshot/main/schema/proofshot.config.schema.json",
+  "project": "hermes-webui-extensions",
+  "devServer": {
+    "url": "http://127.0.0.1:8788",
+    "port": 8788,
+    "note": "Dev instance only. Production runs on 8787 — never record against it."
+  },
+  "viewport": {
+    "width": 1440,
+    "height": 900,
+    "deviceScaleFactor": 1
+  },
+  "artifacts": {
+    "dir": "proofshot-artifacts",
+    "video": true,
+    "screenshots": true,
+    "errorReports": true
+  },
+  "recording": {
+    "trimDeadTime": true,
+    "maxDurationSeconds": 300
+  }
+}


### PR DESCRIPTION
## Summary

This PR lays the groundwork for visual verification testing with **ProofShot** in this repository. It makes no behavioural changes to any extension — it only adds repo-level configuration so contributors can record, screenshot, and share verification sessions without polluting the git history.

## Changes

- **`.gitignore`** — Added `proofshot-artifacts/`. This ensures any generated video recordings, screenshots, and error reports from local verification sessions are ignored by git and never accidentally committed.
- **`proofshot.config.json`** — New config file in the repo root with sensible defaults for this project:
  - Dev server pointed at `http://127.0.0.1:8788` (the **dev** instance — production on `8787` is explicitly out of bounds)
  - Default browser viewport `1440x900` @ 1x DPR
  - Artifacts output dir `proofshot-artifacts/` (matching the new `.gitignore` entry)
  - Video, screenshots, and error reports enabled; dead-time trimming on; 5-minute recording cap

## Request for human review 🙏

I'd appreciate a second set of eyes on a few things:

1. **`proofshot.config.json` defaults** — Are the chosen values sensible as project-wide conventions? In particular:
   - Is `8788` the right canonical dev port to encode, or should this stay contributor-local?
   - Is `1440x900` the viewport we want verification evidence recorded at, or do we want a smaller/mobile viewport as the default (or both)?
   - Is the `proofshot-artifacts` directory name/location the convention we want to standardize on?

2. **Docs** — Should any of these be updated to mention ProofShot?
   - `README.md`
   - `CONTRIBUTING.md` (e.g. a "how to record verification evidence for your PR" section)
   - `docs/extension-entry.md`

3. **Convention implications** — A few things worth a decision before this becomes muscle memory:
   - There's a pre-existing top-level `proofshot/` directory (demo scripts + GIFs, currently untracked). Should it also be ignored, migrated under `proofshot-artifacts/`, or kept as a curated/committed location for demo assets? Right now this PR only ignores `proofshot-artifacts/` as scoped.
   - Should recording ProofShot evidence become a recommended (or required) step in the PR template / review process for UI-facing extension changes?
   - Do we want a shared naming convention for artifacts (per-PR / per-extension) so evidence is easy to find?

Happy to fold any doc updates or config tweaks into this PR once there's consensus.
