### PR TITLE
feat(typography): add role-based font controls

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -148,7 +148,9 @@ jobs:
           repository: nesquena/hermes-webui
           # Pin the independently verified Core contract; update this SHA only
           # after a maintainer reruns the smoke against the new Core head.
-          ref: 320789ae596a3963d726d90f6c7f3bc86f7f2d6d
+          # exp-v0.52.184 — first release carrying the three-font contract
+          # (--font-ui/--font-conversation/--font-mono, #5918) this extension drives.
+          ref: 51e3d09ad677a6b7e4ec3db46611b383d67a2778
           path: .ci/hermes-webui-core
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Test extension validator
         run: node scripts/test-extension-validator.mjs
 
+      - name: Test Typography
+        run: |
+          node scripts/test-typography-rail-entry.mjs
+          node scripts/test-typography.mjs
+
       - name: Test Message Pins observer sync
         run: node scripts/test-message-pins-sync.mjs
 

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -176,6 +176,12 @@ jobs:
           mkdir -p "$COMPATIBILITY_EVIDENCE_DIR"
           python tests/compatibility/browser_smoke.py
 
+      - name: Run Typography browser compatibility smoke
+        env:
+          HERMES_CORE_DIR: .ci/hermes-webui-core
+          COMPATIBILITY_EVIDENCE_DIR: compatibility-evidence
+        run: python tests/compatibility/typography_smoke.py
+
       - name: Upload browser compatibility evidence
         if: always()
         # v5 @ 330a01c490aca151604b8cf639adc76d48f6c5d4

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -22,6 +22,7 @@ need it and maintainers agree on the shared contract.
   drawer close X, and long-press shortcuts for the existing Hermes WebUI mobile drawer.
 - `message-pins`: pin individual messages in a conversation, with a header
   popover, click-to-jump, and client-side per-session persistence.
+- `typography`: choose interface, conversation, and code fonts, including local imports.
 - `model-favorites`: star your most-used models; favorites are promoted to a
   ★ Favorites group at the top of the composer model picker.
 - `custom-avatar`: give the assistant a custom avatar image in the chat

--- a/extensions/typography/README.md
+++ b/extensions/typography/README.md
@@ -50,12 +50,13 @@ Click **Typography** in the rail to open the panel.
 
 ## Browser-local fonts
 
-The panel accepts `.woff2`, `.woff`, `.ttf`, and `.otf` files up to 10 MiB each.
-It rejects empty files, mismatched MIME types when a MIME type is present, and
-files whose signatures are not `wOF2`, `wOFF`, OpenType `OTTO`, or TrueType
-`0x00010000` (`true` is also accepted for `.ttf`). TrueType-outline `.otf`
-files may use `0x00010000`. `FontFace.load()` succeeds before a record is
-persisted.
+The panel accepts `.woff2`, `.woff`, `.ttf`, and `.otf` files up to 10 MiB each,
+with at most 8 browser-local fonts and 40 MiB aggregate. It rejects empty
+files, mismatched MIME types when a MIME type is present, and files whose
+signatures are not `wOF2`, `wOFF`, OpenType `OTTO`, or TrueType `0x00010000`
+(`true` is also accepted for `.ttf`). TrueType-outline `.otf` files may use
+`0x00010000`. Count and aggregate limits are checked before `FontFace.load()`
+and persistence. `FontFace.load()` succeeds before a record is persisted.
 
 Font bytes use native IndexedDB only:
 
@@ -64,15 +65,21 @@ Font bytes use native IndexedDB only:
 - records contain only an opaque ID, display name, format, bytes, and created /
   updated timestamps; browser source paths are not stored
 
-Stored faces are activated on startup with `document.fonts.add`. Active local
-fonts appear in a **Local fonts** group in all three role selectors under stable
-values such as `local:<opaque-id>`. Invalid or unavailable selections fall back
-to their role defaults without deleting stored records. Each imported font can
-be previewed, renamed, replaced, or deleted. Rename trims names to 80
-characters and rejects an empty result. Replace validates and loads first, so a
-failure leaves the previous record and active face intact. Delete removes the
-IndexedDB record and registered face, and returns only roles that directly
-select that font to their defaults.
+Stored faces are enumerated with a bounded cursor on startup and activated with
+`document.fonts.add`. At most 8 records and 40 MiB are retained in memory. If
+the database already exceeds either limit, extra stored fonts are not loaded,
+the retained in-cap records remain usable, and imports/replacements stay
+disabled until browser site-data controls clear the overflow; records are not
+auto-deleted. Active local fonts appear in a **Local fonts** group in all three
+role selectors under stable values such as `local:<opaque-id>`. Invalid or
+unavailable selections fall back to their role defaults without deleting stored
+records. Each imported font can be previewed, renamed, replaced, or deleted.
+Rename trims names to 80 characters and rejects an empty result. Replace
+validates and loads first, so a capacity or write failure leaves the previous
+record, active face, and selection intact. Delete removes the IndexedDB record
+and registered face, and returns only roles that directly select that font to
+their defaults. If `window.confirm` is unavailable, deletion fails closed with
+`Deleting is unavailable in this browser.`; cancel also makes no changes.
 
 Import management is disabled with an explanatory status if IndexedDB,
 `FontFace`, or `document.fonts` support is unavailable; curated fonts and

--- a/extensions/typography/README.md
+++ b/extensions/typography/README.md
@@ -109,10 +109,12 @@ stack, including a local font when selected.
 Generic selection values are stored through
 `window.HermesExtensionSettings.storageForExtension('typography')` when
 available, with the legacy `hermes-ext-typography-selection` localStorage key as
-the older-core fallback. The library metadata declares only that scalar
-selection key as user-visible owned storage; the runtime manifest grants Core's
-owned storage namespace for this accessor. Font bytes are never scalar settings
-values. There is intentionally no `settings_schema`.
+the older-core fallback. Because the runtime manifest grants Core's owned
+storage namespace for this accessor and the extension also creates its own
+`hermes-ext-typography-fonts` IndexedDB database for local font bytes, the
+library metadata declares `storage.owned: true` (whole-namespace ownership)
+rather than a single key. Font bytes are never scalar settings values. There is
+intentionally no `settings_schema`.
 
 The immutable public debug surface is `window.HermesTypographyExtension` with
 the version, curated catalog, preset metadata, selection accessors, and pure

--- a/extensions/typography/README.md
+++ b/extensions/typography/README.md
@@ -1,0 +1,170 @@
+# Typography
+
+Typography lets users choose curated fonts, role-based presets, and browser-local
+font files for the Hermes WebUI interface, conversations, and code. It adds a
+**Typography** button to the WebUI rail.
+
+## Install for local testing
+
+From a Hermes WebUI checkout, point the manifest-bundle loader at this entry:
+
+```bash
+cd /path/to/hermes-webui
+HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/typography \
+HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
+```
+
+Click **Typography** in the rail to open the panel.
+
+## Behavior
+
+- The compact Preset selector applies and persists one complete triple in this
+  order: **WebUI Default** (`default`, `same-ui`, `default`); **Nous**
+  (`courier-prime`, `same-ui`, `courier-prime`); **Modern** (`geist`,
+  `same-ui`, `geist-mono`); **Accessible** (`atkinson-hyperlegible-next`,
+  `same-ui`, `atkinson-hyperlegible-mono`); **Comfortable Reading**
+  (`lexend-deca`, `literata`, `source-code-pro`); **Noto** (`noto-sans`,
+  `noto-serif`, `noto-sans-mono`); **IBM Plex** (`ibm-plex-sans`,
+  `ibm-plex-serif`, `ibm-plex-mono`); **Developer** (`inter`, `same-ui`,
+  `jetbrains-mono`); **Dense** (`public-sans`, `same-ui`, `inconsolata`);
+  **Warm** (`nunito-sans`, `lora`, `fira-code`); and **Cyberdeck** (`oxanium`,
+  `geist`, `space-mono`).
+  Manual changes show **Custom**;
+  matching a triple identifies its preset again.
+- Interface, Conversations, and Code selectors use role-specific curated
+  catalogs and previews. Conversations includes additional reading serifs such
+  as Bitter that are not offered for Interface or Code.
+  Interface and Conversations previews include `Ag Il1 O0 0123456789`;
+  Conversations also exercises semantic *italic* and **bold** text. The code
+  diagnostic preview includes `Il1 O0 {} [] != => ,.;:`.
+- **Google-hosted choices** load selected families from Google and expose the
+  browser IP to Google. Interface and Conversations families request upright
+  weights plus true italic 400/700 faces; Code-only families request upright
+  weights. Shared families are requested once with the union. **WebUI default
+  choices** use core-provided system font stacks; this extension makes no
+  external font request for them. **Local fonts** are read from this browser
+  and are never sent to a server.
+- Clicking **Import font** opens the native file picker; selecting a file
+  validates and imports it immediately. Cancel does nothing, and selecting the
+  same file again is supported.
+
+## Browser-local fonts
+
+The panel accepts `.woff2`, `.woff`, `.ttf`, and `.otf` files up to 10 MiB each.
+It rejects empty files, mismatched MIME types when a MIME type is present, and
+files whose signatures are not `wOF2`, `wOFF`, OpenType `OTTO`, or TrueType
+`0x00010000` (`true` is also accepted for `.ttf`). TrueType-outline `.otf`
+files may use `0x00010000`. `FontFace.load()` succeeds before a record is
+persisted.
+
+Font bytes use native IndexedDB only:
+
+- database: `hermes-ext-typography-fonts`
+- object store: `hermes-ext-typography-font-records`
+- records contain only an opaque ID, display name, format, bytes, and created /
+  updated timestamps; browser source paths are not stored
+
+Stored faces are activated on startup with `document.fonts.add`. Active local
+fonts appear in a **Local fonts** group in all three role selectors under stable
+values such as `local:<opaque-id>`. Invalid or unavailable selections fall back
+to their role defaults without deleting stored records. Each imported font can
+be previewed, renamed, replaced, or deleted. Rename trims names to 80
+characters and rejects an empty result. Replace validates and loads first, so a
+failure leaves the previous record and active face intact. Delete removes the
+IndexedDB record and registered face, and returns only roles that directly
+select that font to their defaults.
+
+Import management is disabled with an explanatory status if IndexedDB,
+`FontFace`, or `document.fonts` support is unavailable; curated fonts and
+presets remain usable. Import only font files you are licensed to use. This
+extension does not upload, sync, share, convert, subset, or server-store local
+font data.
+
+## Trust, permissions, and storage
+
+This is trusted static manifest-bundle code with no dependencies, backend,
+sidecar, remote script, filesystem access, cookies, native host, or server file
+upload. It may load the Google stylesheet for selected curated families; this is
+declared as `network_external: true`. Local font bytes never enter the Google
+request, extension settings, or localStorage.
+
+The extension uses WebUI's stable root font tokens:
+
+- `--font-ui`
+- `--font-conversation`
+- `--font-mono`
+
+It sets or removes only those three inline properties on
+`document.documentElement.style`. WebUI defaults remove the inline property so
+core owns the fallback. **Same as interface** follows the current interface
+stack, including a local font when selected.
+
+Generic selection values are stored through
+`window.HermesExtensionSettings.storageForExtension('typography')` when
+available, with the legacy `hermes-ext-typography-selection` localStorage key as
+the older-core fallback. The library metadata declares only that scalar
+selection key as user-visible owned storage; the runtime manifest grants Core's
+owned storage namespace for this accessor. Font bytes are never scalar settings
+values. There is intentionally no `settings_schema`.
+
+The immutable public debug surface is `window.HermesTypographyExtension` with
+the version, curated catalog, preset metadata, selection accessors, and pure
+validation helpers. It contains no local font names, paths, bytes, or private
+records.
+
+## Disable and uninstall
+
+Disable Typography by restarting Hermes WebUI without the extension directory or
+manifest environment variables. Uninstall it by removing the local
+`extensions/typography/` entry (or removing it from the installed extension
+set). Browser site-data controls remove the selection and the
+`hermes-ext-typography-fonts` IndexedDB database; uninstalling the bundle alone
+does not need to contact a server.
+
+## Compatibility and verification
+
+Compatibility requires a manifest bundle and the core font tokens listed above.
+The three-font Core contract was introduced by `nesquena/hermes-webui#5918`; older
+Core builds do not support all roles.
+The extension-owned storage API is used when available, with a namespaced
+localStorage fallback for older builds. A core without the font tokens still
+loads the extension, but selected fonts cannot affect core views. A browser
+without local-font APIs still supports curated choices and presets.
+
+## Known limitations
+
+Native select option rendering varies by browser. Local-font management depends
+on IndexedDB and the browser Font Loading API. Each imported local font file is
+registered as one family/face, so missing weights and italics may be synthesized.
+Blocking Google requests leaves a selected curated family on its declared system
+fallback stack.
+
+Manual checks:
+
+1. Click the Typography rail button and confirm it opens the panel and the
+   first selector receives focus.
+2. Choose every preset, then change one role and confirm **Custom** appears;
+   restore a triple and confirm its preset is identified again.
+3. Change each role and confirm its preview and root token update. Confirm the
+   `Ag Il1 O0 0123456789` diagnostics, semantic italic/bold Conversations
+   sample, code diagnostic preview, and **Same as interface** behavior. When
+   hosted families are selected, inspect the single extension stylesheet link
+   to confirm role-appropriate Google CSS2 weights and deduplication.
+4. Click **Import font**, select one valid file, cancel once, select the same
+   file again, then try one invalid or oversized file. Confirm the local font
+   appears in all three Local fonts groups, survives reload, and does not create
+   a network request.
+5. Test Preview, Rename, Replace failure/success, Delete, Escape,
+   backdrop click, Close, mobile layout, and focus return to the opener.
+
+Automated checks:
+
+```bash
+node --check extensions/typography/assets/typography.js
+node -e "JSON.parse(require('fs').readFileSync('extensions/typography/extension.json')); JSON.parse(require('fs').readFileSync('extensions/typography/manifest.json'))"
+node scripts/test-typography-rail-entry.mjs
+node scripts/test-typography.mjs
+node scripts/validate-extensions.mjs
+node scripts/scan-extension-safety.mjs
+git diff --check
+```

--- a/extensions/typography/assets/typography.css
+++ b/extensions/typography/assets/typography.css
@@ -71,8 +71,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   border: 1px solid var(--muted, #73777f);
   border-radius: 50%;
@@ -278,7 +278,7 @@
 }
 
 #hwx-type-panel .hwx-type-status-error {
-  color: var(--danger, #b33a3a);
+  color: var(--error, #b33a3a);
 }
 
 #hwx-type-panel .hwx-type-local-list {
@@ -349,7 +349,7 @@
 }
 
 #hwx-type-panel .hwx-type-local-delete {
-  color: var(--danger, #b33a3a);
+  color: var(--error, #b33a3a);
 }
 
 #hwx-type-panel .hwx-type-actions {
@@ -379,7 +379,7 @@
 #hwx-type-panel .hwx-type-close-action {
   border-color: var(--accent, #5b8def);
   background: var(--accent, #5b8def);
-  color: var(--accent-contrast, #111);
+  color: var(--accent-contrast, #fff);
 }
 
 #hwx-type-panel .hwx-type-close-action:hover {

--- a/extensions/typography/assets/typography.css
+++ b/extensions/typography/assets/typography.css
@@ -1,0 +1,449 @@
+#hwx-type-rail-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 36px;
+  min-height: 36px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted, #8a8f98);
+  cursor: pointer;
+  transition: color .12s ease, background .12s ease, border-color .12s ease;
+}
+
+#hwx-type-rail-button:hover,
+#hwx-type-rail-button:focus-visible {
+  color: var(--text, #e6e6e6);
+  background: var(--hover-bg, rgba(127, 127, 127, .14));
+  border-color: var(--border, rgba(127, 127, 127, .24));
+  outline: none;
+}
+
+#hwx-type-panel {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, .48);
+}
+
+#hwx-type-panel .hwx-type-card {
+  display: flex;
+  flex-direction: column;
+  width: min(620px, 100%);
+  max-height: min(780px, calc(100vh - 32px));
+  overflow: auto;
+  border: 1px solid var(--border, rgba(127, 127, 127, .28));
+  border-radius: 14px;
+  background: var(--surface, #fff);
+  color: var(--text, #111);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, .38);
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+}
+
+#hwx-type-panel .hwx-type-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--border, rgba(127, 127, 127, .18));
+}
+
+#hwx-type-panel h2 {
+  margin: 0;
+  font-size: 19px;
+  line-height: 1.2;
+}
+
+#hwx-type-panel .hwx-type-title-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+#hwx-type-panel .hwx-type-info {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid var(--muted, #73777f);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted, #73777f);
+  cursor: help;
+  font: 600 11px/1 var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+}
+
+#hwx-type-panel .hwx-type-info::after {
+  left: 0;
+  width: min(360px, calc(100vw - 72px));
+  transform: none;
+  white-space: normal;
+  text-align: left;
+  line-height: 1.45;
+  letter-spacing: 0;
+  font-weight: 400;
+}
+
+#hwx-type-panel .hwx-type-info:hover,
+#hwx-type-panel .hwx-type-info:focus-visible {
+  border-color: var(--text, #111);
+  color: var(--text, #111);
+  outline: none;
+}
+
+#hwx-type-panel .hwx-type-info.hwx-type-tooltip-open::after {
+  opacity: 1;
+  transition-delay: 0s;
+}
+
+#hwx-type-panel .hwx-type-subtitle {
+  margin: 5px 0 0;
+  color: var(--muted, #73777f);
+  font-size: 13px;
+}
+
+#hwx-type-panel .hwx-type-close {
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted, #73777f);
+  cursor: pointer;
+  font-size: 21px;
+  line-height: 1;
+}
+
+#hwx-type-panel .hwx-type-close:hover,
+#hwx-type-panel .hwx-type-close:focus-visible {
+  background: var(--hover-bg, rgba(127, 127, 127, .14));
+  color: var(--text, #111);
+  outline: none;
+}
+
+#hwx-type-panel .hwx-type-body {
+  overflow: auto;
+  padding: 18px 20px 20px;
+}
+
+#hwx-type-panel .hwx-type-controls {
+  display: grid;
+  gap: 12px;
+}
+
+#hwx-type-panel .hwx-type-preset {
+  display: grid;
+  margin-bottom: 12px;
+}
+
+#hwx-type-panel .hwx-type-preset-field {
+  display: grid;
+  grid-template-columns: minmax(72px, auto) minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  color: var(--text, #111);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+#hwx-type-panel .hwx-type-field {
+  display: grid;
+  gap: 6px;
+  color: var(--text, #111);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+#hwx-type-panel .hwx-type-select {
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 10px;
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 8px;
+  background: var(--surface, #fff);
+  color: var(--text, #111);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+#hwx-type-panel .hwx-type-select:focus-visible,
+#hwx-type-panel .hwx-type-preset-field select:focus-visible,
+#hwx-type-panel .hwx-type-close-action:focus-visible,
+#hwx-type-panel .hwx-type-local-action:focus-visible,
+#hwx-type-panel #hwx-type-import:focus-visible {
+  outline: 2px solid var(--accent, #5b8def);
+  outline-offset: 2px;
+}
+
+#hwx-type-panel .hwx-type-previews {
+  display: grid;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+#hwx-type-panel .hwx-type-preview {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--border, rgba(127, 127, 127, .22));
+  border-radius: 9px;
+  background: var(--code-bg, rgba(127, 127, 127, .08));
+  color: var(--text, #111);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+#hwx-type-panel .hwx-type-preview[data-hwx-type-preview="conversation"] {
+  font-size: var(--message-body-font-size, 14px);
+  line-height: var(--message-body-line-height, 1.75);
+}
+
+#hwx-type-panel .hwx-type-preview-label {
+  color: var(--muted, #73777f);
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+#hwx-type-panel .hwx-type-preview-code code {
+  font: inherit;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+#hwx-type-panel .hwx-type-local {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border, rgba(127, 127, 127, .18));
+}
+
+#hwx-type-panel .hwx-type-local h3 {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.3;
+}
+
+#hwx-type-panel .hwx-type-local-disclosure {
+  margin: 5px 0 12px;
+  color: var(--muted, #73777f);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+#hwx-type-panel #hwx-type-import,
+#hwx-type-panel .hwx-type-local-action {
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text, #111);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+
+#hwx-type-panel #hwx-type-import:hover,
+#hwx-type-panel .hwx-type-local-action:hover {
+  background: var(--hover-bg, rgba(127, 127, 127, .14));
+}
+
+#hwx-type-panel #hwx-type-import:disabled,
+#hwx-type-panel .hwx-type-local-action:disabled {
+  cursor: not-allowed;
+  opacity: .55;
+}
+
+#hwx-type-panel .hwx-type-local-help,
+#hwx-type-panel .hwx-type-local-status {
+  margin: 10px 0 0;
+  color: var(--muted, #73777f);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+#hwx-type-panel .hwx-type-local-status:empty {
+  display: none;
+}
+
+#hwx-type-panel .hwx-type-status-error {
+  color: var(--danger, #b33a3a);
+}
+
+#hwx-type-panel .hwx-type-local-list {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+#hwx-type-panel .hwx-type-local-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px;
+  border: 1px solid var(--border, rgba(127, 127, 127, .22));
+  border-radius: 9px;
+  background: var(--code-bg, rgba(127, 127, 127, .08));
+}
+
+#hwx-type-panel .hwx-type-local-details {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+#hwx-type-panel .hwx-type-local-heading {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+#hwx-type-panel .hwx-type-local-name {
+  overflow-wrap: anywhere;
+  font-size: 13px;
+}
+
+#hwx-type-panel .hwx-type-local-format {
+  flex: 0 0 auto;
+  color: var(--muted, #73777f);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+#hwx-type-panel .hwx-type-local-preview {
+  overflow-wrap: anywhere;
+  color: var(--text, #111);
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+#hwx-type-panel .hwx-type-local-meta,
+#hwx-type-panel .hwx-type-local-empty {
+  color: var(--muted, #73777f);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+#hwx-type-panel .hwx-type-local-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 5px;
+}
+
+#hwx-type-panel .hwx-type-local-delete {
+  color: var(--danger, #b33a3a);
+}
+
+#hwx-type-panel .hwx-type-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--border, rgba(127, 127, 127, .18));
+}
+
+#hwx-type-panel .hwx-type-close-action {
+  min-height: 38px;
+  padding: 8px 12px;
+  border: 1px solid var(--border, rgba(127, 127, 127, .3));
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text, #111);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+}
+
+#hwx-type-panel .hwx-type-close-action:hover {
+  background: var(--hover-bg, rgba(127, 127, 127, .14));
+}
+
+#hwx-type-panel .hwx-type-close-action {
+  border-color: var(--accent, #5b8def);
+  background: var(--accent, #5b8def);
+  color: var(--accent-contrast, #111);
+}
+
+#hwx-type-panel .hwx-type-close-action:hover {
+  filter: brightness(.96);
+}
+
+@media (max-width: 560px) {
+  #hwx-type-panel {
+    align-items: flex-end;
+    padding: 8px;
+  }
+
+  #hwx-type-panel .hwx-type-card {
+    max-height: calc(100vh - 16px);
+    max-height: calc(100dvh - 16px);
+    border-radius: 12px;
+  }
+
+  #hwx-type-panel .hwx-type-header,
+  #hwx-type-panel .hwx-type-body,
+  #hwx-type-panel .hwx-type-actions {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  #hwx-type-panel .hwx-type-actions {
+    justify-content: stretch;
+  }
+
+  #hwx-type-panel .hwx-type-title-row {
+    position: relative;
+  }
+
+  #hwx-type-panel .hwx-type-info {
+    position: static;
+  }
+
+  #hwx-type-panel .hwx-type-info::after {
+    left: 0;
+    width: calc(100vw - 44px);
+  }
+
+  #hwx-type-panel .hwx-type-close-action {
+    flex: 1;
+  }
+
+  #hwx-type-panel .hwx-type-preset-field {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  #hwx-type-panel .hwx-type-local-item {
+    display: grid;
+  }
+
+  #hwx-type-panel .hwx-type-local-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #hwx-type-rail-button,
+  #hwx-type-panel .hwx-type-close-action,
+  #hwx-type-panel .hwx-type-close {
+    transition: none;
+  }
+}

--- a/extensions/typography/assets/typography.js
+++ b/extensions/typography/assets/typography.js
@@ -652,7 +652,7 @@
     button.className = 'rail-btn nav-tab has-tooltip hwx-type-rail-button';
     button.dataset.tooltip = 'Typography';
     button.setAttribute('aria-label', 'Typography');
-    button.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 4v16"/><path d="M4 7V5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v2"/><path d="M9 20h6"/></svg>';
+    button.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 4v16"/><path d="M4 7V5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v2"/><path d="M9 20h6"/></svg>';
     button.addEventListener('click', (event) => { event.preventDefault(); open(button); });
     const spacer = rail.querySelector('.rail-spacer');
     if (spacer) rail.insertBefore(button, spacer);

--- a/extensions/typography/assets/typography.js
+++ b/extensions/typography/assets/typography.js
@@ -621,7 +621,14 @@
       if (first) first.focus();
       return;
     }
-    opener = openerElement && typeof openerElement.focus === 'function' ? openerElement : document.activeElement;
+    const passedOpener = openerElement && typeof openerElement.focus === 'function' ? openerElement : null;
+    const focusedOpener = document.activeElement;
+    const passedRendered = passedOpener && passedOpener.isConnected
+      && typeof passedOpener.getClientRects === 'function' && passedOpener.getClientRects().length;
+    const focusedRendered = focusedOpener && focusedOpener !== document.body
+      && focusedOpener.isConnected && typeof focusedOpener.focus === 'function'
+      && typeof focusedOpener.getClientRects === 'function' && focusedOpener.getClientRects().length;
+    opener = !passedRendered && focusedRendered ? focusedOpener : passedOpener || focusedOpener;
     if (!document.body) return;
     const panel = buildPanel();
     document.body.appendChild(panel);

--- a/extensions/typography/assets/typography.js
+++ b/extensions/typography/assets/typography.js
@@ -645,7 +645,15 @@
     document.removeEventListener('keydown', onKeydown, true);
     const restore = opener;
     opener = null;
-    if (restore && restore.isConnected && typeof restore.focus === 'function') restore.focus();
+    const target = [restore, document.getElementById('btnHamburger')].find((candidate) => {
+      if (!candidate || !candidate.isConnected || typeof candidate.focus !== 'function'
+        || candidate.disabled || typeof candidate.getClientRects !== 'function'
+        || !candidate.getClientRects().length || typeof candidate.getBoundingClientRect !== 'function') return false;
+      const rect = candidate.getBoundingClientRect();
+      return rect.left < window.innerWidth && rect.right > 0
+        && rect.top < window.innerHeight && rect.bottom > 0;
+    });
+    if (target) target.focus();
   }
 
   function ensureRailButton() {

--- a/extensions/typography/assets/typography.js
+++ b/extensions/typography/assets/typography.js
@@ -15,11 +15,14 @@
   const FONT_STORE_NAME = 'hermes-ext-typography-font-records';
   const GOOGLE_FONTS_URL = 'https://fonts.googleapis.com/css2';
   const MAX_FONT_BYTES = 10 * 1024 * 1024;
+  const MAX_LOCAL_FONT_COUNT = 8;
+  const MAX_LOCAL_FONT_TOTAL_BYTES = 40 * 1024 * 1024;
   const FONT_ACCEPT = '.woff2,.woff,.ttf,.otf';
   const ROLES = ['interface', 'conversation', 'code'];
   const ROLE_LABELS = Object.freeze({ interface: 'Interface', conversation: 'Conversations', code: 'Code' });
   const DEFAULTS = Object.freeze({ interface: 'default', conversation: 'same-ui', code: 'default' });
   const LOCAL_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+  const LOCAL_FONT_OVERFLOW_MESSAGE = 'Some stored local fonts were not loaded because the browser-local limits were exceeded. Extra stored fonts were not loaded; use browser site-data controls to clear them. New imports and replacements are unavailable until then.';
 
   const PRESETS = Object.freeze([
     Object.freeze({ id: 'webui-default', label: 'WebUI Default', interface: 'default', conversation: 'same-ui', code: 'default' }),
@@ -113,9 +116,12 @@
   let initialSelection = { ...DEFAULTS };
   let opener = null;
   let localFonts = new Map();
+  let localFontStoredCount = 0;
+  let localFontStoredBytes = 0;
   let localFontState = {
     available: false,
     ready: false,
+    overflow: false,
     message: 'Local font imports are loading.',
     error: false,
   };
@@ -478,7 +484,7 @@
       replace.type = 'button';
       replace.className = 'hwx-type-local-action';
       replace.textContent = 'Replace';
-      replace.disabled = localFontBusy;
+      replace.disabled = localFontBusy || localFontState.overflow;
       replace.addEventListener('click', () => chooseReplacement(record.id));
       const remove = document.createElement('button');
       remove.type = 'button';
@@ -505,7 +511,7 @@
         populateSelect(select, role);
       }
     }
-    setLocalControlsDisabled(!localFontState.available || !localFontState.ready || localFontBusy);
+    setLocalControlsDisabled(!localFontState.available || !localFontState.ready || localFontBusy || localFontState.overflow);
     const status = document.getElementById('hwx-type-local-status');
     if (status) {
       status.textContent = localFontState.message;
@@ -546,7 +552,7 @@
           </div>
           <section class="hwx-type-local" aria-labelledby="hwx-type-local-title">
             <h3 id="hwx-type-local-title">Local fonts</h3>
-            <p class="hwx-type-local-disclosure">Import .woff2, .woff, .ttf, or .otf files up to 10 MiB each.</p>
+            <p class="hwx-type-local-disclosure">Import up to 8 .woff2, .woff, .ttf, or .otf files, 10 MiB each and 40 MiB total.</p>
             <input id="hwx-type-local-file" type="file" accept=".woff2,.woff,.ttf,.otf" hidden>
             <button type="button" id="hwx-type-import">Import font</button>
             <p class="hwx-type-local-help">Choose local fonts in any role selector.</p>
@@ -687,6 +693,23 @@
     return null;
   }
 
+  function byteLengthOf(value) {
+    if (value instanceof ArrayBuffer) return value.byteLength;
+    return ArrayBuffer.isView(value) ? value.byteLength : 0;
+  }
+
+  function localFontCapacity({ currentCount = 0, currentTotalBytes = 0, newBytes = 0, replacing = false, oldBytes = 0 } = {}) {
+    const count = currentCount + (replacing ? 0 : 1);
+    const totalBytes = currentTotalBytes - (replacing ? oldBytes : 0) + newBytes;
+    if (count > MAX_LOCAL_FONT_COUNT) {
+      return { ok: false, count, totalBytes, error: 'You can store up to 8 local fonts.' };
+    }
+    if (totalBytes > MAX_LOCAL_FONT_TOTAL_BYTES) {
+      return { ok: false, count, totalBytes, error: 'Local fonts can use up to 40 MiB in total.' };
+    }
+    return { ok: true, count, totalBytes };
+  }
+
   function signatureForBytes(bytes) {
     const view = new Uint8Array(bytes);
     if (view.length < 4) return '';
@@ -811,7 +834,50 @@
     const database = await openFontDatabase();
     try {
       const transaction = database.transaction(FONT_STORE_NAME, 'readonly');
-      return await transactionRequest(transaction, (store) => store.getAll());
+      const records = [];
+      let count = 0;
+      let totalBytes = 0;
+      let overflow = false;
+      const result = await new Promise((resolve, reject) => {
+        let settled = false;
+        const finish = (callback, value) => {
+          if (settled) return;
+          settled = true;
+          transaction.oncomplete = null;
+          transaction.onerror = null;
+          transaction.onabort = null;
+          callback(value);
+        };
+        transaction.oncomplete = () => finish(resolve, { records, count, totalBytes, overflow });
+        transaction.onerror = () => finish(reject, transaction.error || new Error('IndexedDB transaction failed.'));
+        transaction.onabort = () => finish(reject, transaction.error || new Error('IndexedDB transaction aborted.'));
+        try {
+          const request = transaction.objectStore(FONT_STORE_NAME).openCursor();
+          request.onerror = () => finish(reject, request.error || new Error('IndexedDB cursor failed.'));
+          request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) return;
+            const raw = cursor.value;
+            const capacity = localFontCapacity({
+              currentCount: count,
+              currentTotalBytes: totalBytes,
+              newBytes: byteLengthOf(raw && raw.bytes),
+            });
+            if (!capacity.ok) {
+              overflow = true;
+              return;
+            }
+            count = capacity.count;
+            totalBytes = capacity.totalBytes;
+            const record = normalizeStoredRecord(raw);
+            if (record) records.push(record);
+            cursor.continue();
+          };
+        } catch (error) {
+          finish(reject, error);
+        }
+      });
+      return result;
     } finally {
       database.close();
     }
@@ -889,7 +955,14 @@
   function importLocalFont(file) {
     runLocalOperation(async () => {
       try {
+        if (localFontState.overflow) throw new Error(LOCAL_FONT_OVERFLOW_MESSAGE);
         const imported = await readValidatedFile(file);
+        const capacity = localFontCapacity({
+          currentCount: localFontStoredCount,
+          currentTotalBytes: localFontStoredBytes,
+          newBytes: imported.bytes.byteLength,
+        });
+        if (!capacity.ok) throw new Error(capacity.error);
         let id = makeOpaqueId();
         while (localFonts.has(id)) id = makeOpaqueId();
         const face = await loadFace(id, imported.bytes);
@@ -913,6 +986,8 @@
           throw error;
         }
         localFonts.set(id, record);
+        localFontStoredCount = capacity.count;
+        localFontStoredBytes = capacity.totalBytes;
         setLocalStatus('');
         syncControls();
       } catch (error) {
@@ -956,7 +1031,16 @@
       const previous = localFonts.get(id);
       if (!previous) return;
       try {
+        if (localFontState.overflow) throw new Error(LOCAL_FONT_OVERFLOW_MESSAGE);
         const replacement = await readValidatedFile(file, previous.name);
+        const capacity = localFontCapacity({
+          currentCount: localFontStoredCount,
+          currentTotalBytes: localFontStoredBytes,
+          newBytes: replacement.bytes.byteLength,
+          replacing: true,
+          oldBytes: previous.bytes.byteLength,
+        });
+        if (!capacity.ok) throw new Error(capacity.error);
         const face = await loadFace(id, replacement.bytes);
         document.fonts.add(face);
         const next = {
@@ -976,6 +1060,7 @@
         }
         removeFace(previous.face);
         localFonts.set(id, next);
+        localFontStoredBytes = capacity.totalBytes;
         const persisted = loadSelection();
         if (persisted) {
           selection = normalizeSelection(persisted);
@@ -1019,12 +1104,23 @@
   function deleteLocalFont(id) {
     const record = localFonts.get(id);
     if (!record || localFontBusy) return;
-    if (typeof window.confirm === 'function' && !window.confirm('Delete this imported font?')) return;
+    if (typeof window.confirm !== 'function') {
+      setLocalStatus('Deleting is unavailable in this browser.', true);
+      return;
+    }
+    let confirmed;
+    try { confirmed = window.confirm('Delete this imported font?'); } catch (_) {
+      setLocalStatus('Deleting is unavailable in this browser.', true);
+      return;
+    }
+    if (!confirmed) return;
     runLocalOperation(async () => {
       try {
         await removeFontRecord(id);
         removeFace(record.face);
         localFonts.delete(id);
+        localFontStoredCount = Math.max(0, localFontStoredCount - 1);
+        localFontStoredBytes = Math.max(0, localFontStoredBytes - record.bytes.byteLength);
         const persisted = loadSelection();
         const before = persisted && typeof persisted === 'object' ? persisted : selection;
         const candidate = removeLocalFontFromSelection(before, id);
@@ -1048,6 +1144,7 @@
       localFontState = {
         available: false,
         ready: false,
+        overflow: false,
         message: 'Local font imports are unavailable here because IndexedDB and FontFace support are required. Curated fonts and presets remain available.',
         error: true,
       };
@@ -1056,15 +1153,14 @@
       syncControls();
       return;
     }
-    localFontState = { available: true, ready: false, message: 'Loading stored local fonts.', error: false };
+    localFontState = { available: true, ready: false, overflow: false, message: 'Loading stored local fonts.', error: false };
     syncControls();
     try {
-      const records = await readFontRecords();
+      const stored = await readFontRecords();
+      localFontStoredCount = stored.count;
+      localFontStoredBytes = stored.totalBytes;
       localFonts = new Map();
-      for (const raw of records || []) {
-        const record = normalizeStoredRecord(raw);
-        if (record) localFonts.set(record.id, record);
-      }
+      for (const record of stored.records) localFonts.set(record.id, record);
       let activationFailures = 0;
       for (const record of localFonts.values()) {
         if (record.invalid) {
@@ -1081,19 +1177,24 @@
           activationFailures += 1;
         }
       }
+      const messages = [];
+      if (stored.overflow) messages.push(LOCAL_FONT_OVERFLOW_MESSAGE);
+      if (activationFailures) messages.push('Some stored local fonts could not be activated; their records were kept. Replace or delete them if needed.');
       localFontState = {
         available: true,
         ready: true,
-        message: activationFailures
-          ? 'Some stored local fonts could not be activated; their records were kept. Replace or delete them if needed.'
-          : '',
-        error: Boolean(activationFailures),
+        overflow: stored.overflow,
+        message: messages.join(' '),
+        error: Boolean(messages.length),
       };
     } catch (_) {
       localFonts = new Map();
+      localFontStoredCount = 0;
+      localFontStoredBytes = 0;
       localFontState = {
         available: false,
         ready: false,
+        overflow: false,
         message: 'Local font imports are unavailable because this browser could not open IndexedDB. Curated fonts and presets remain available.',
         error: true,
       };
@@ -1110,6 +1211,9 @@
   }
 
   const DEBUG = Object.freeze({
+    MAX_LOCAL_FONT_COUNT,
+    MAX_LOCAL_FONT_TOTAL_BYTES,
+    localFontCapacity,
     normalizeSelection: (value, localIds = []) => normalizeSelection(value, new Set(localIds)),
     selectionForPersistence: (value, persisted, dirtyRoles = [], ready = false, localIds = []) => selectionForPersistence(
       value,

--- a/extensions/typography/assets/typography.js
+++ b/extensions/typography/assets/typography.js
@@ -1,0 +1,1150 @@
+;(() => {
+  'use strict';
+
+  if (window.__hermesTypographyLoaded) return;
+  window.__hermesTypographyLoaded = true;
+
+  const VERSION = '0.1.0';
+  const RAIL_BUTTON_ID = 'hwx-type-rail-button';
+  const PANEL_ID = 'hwx-type-panel';
+  const GOOGLE_STYLE_ID = 'hwx-type-google-fonts';
+  const DISCLOSURE = 'Google-hosted choices load selected families from Google and expose your browser IP to Google. WebUI default choices use core-provided system font stacks; this extension makes no external font request for them. Local fonts stay in this browser and are never sent to a server.';
+  const STORAGE_KEY = 'selection';
+  const FALLBACK_STORAGE_KEY = 'hermes-ext-typography-selection';
+  const FONT_DB_NAME = 'hermes-ext-typography-fonts';
+  const FONT_STORE_NAME = 'hermes-ext-typography-font-records';
+  const GOOGLE_FONTS_URL = 'https://fonts.googleapis.com/css2';
+  const MAX_FONT_BYTES = 10 * 1024 * 1024;
+  const FONT_ACCEPT = '.woff2,.woff,.ttf,.otf';
+  const ROLES = ['interface', 'conversation', 'code'];
+  const ROLE_LABELS = Object.freeze({ interface: 'Interface', conversation: 'Conversations', code: 'Code' });
+  const DEFAULTS = Object.freeze({ interface: 'default', conversation: 'same-ui', code: 'default' });
+  const LOCAL_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+  const PRESETS = Object.freeze([
+    Object.freeze({ id: 'webui-default', label: 'WebUI Default', interface: 'default', conversation: 'same-ui', code: 'default' }),
+    Object.freeze({ id: 'nous', label: 'Nous', interface: 'courier-prime', conversation: 'same-ui', code: 'courier-prime' }),
+    Object.freeze({ id: 'modern', label: 'Modern', interface: 'geist', conversation: 'same-ui', code: 'geist-mono' }),
+    Object.freeze({ id: 'accessible', label: 'Accessible', interface: 'atkinson-hyperlegible-next', conversation: 'same-ui', code: 'atkinson-hyperlegible-mono' }),
+    Object.freeze({ id: 'comfortable-reading', label: 'Comfortable Reading', interface: 'lexend-deca', conversation: 'literata', code: 'source-code-pro' }),
+    Object.freeze({ id: 'noto', label: 'Noto', interface: 'noto-sans', conversation: 'noto-serif', code: 'noto-sans-mono' }),
+    Object.freeze({ id: 'ibm-plex', label: 'IBM Plex', interface: 'ibm-plex-sans', conversation: 'ibm-plex-serif', code: 'ibm-plex-mono' }),
+    Object.freeze({ id: 'developer', label: 'Developer', interface: 'inter', conversation: 'same-ui', code: 'jetbrains-mono' }),
+    Object.freeze({ id: 'dense', label: 'Dense', interface: 'public-sans', conversation: 'same-ui', code: 'inconsolata' }),
+    Object.freeze({ id: 'warm', label: 'Warm', interface: 'nunito-sans', conversation: 'lora', code: 'fira-code' }),
+    Object.freeze({ id: 'cyberdeck', label: 'Cyberdeck', interface: 'oxanium', conversation: 'geist', code: 'space-mono' }),
+  ]);
+
+  const MIME_TYPES = Object.freeze({
+    woff2: new Set(['font/woff2', 'application/font-woff2']),
+    woff: new Set(['font/woff', 'application/font-woff']),
+    ttf: new Set(['font/ttf', 'font/truetype', 'application/x-font-ttf', 'application/font-sfnt']),
+    otf: new Set(['font/otf', 'font/opentype', 'application/x-font-opentype', 'application/vnd.ms-opentype', 'application/font-sfnt']),
+  });
+  const SIGNATURES = Object.freeze({
+    woff2: Object.freeze(['wOF2']),
+    woff: Object.freeze(['wOFF']),
+    ttf: Object.freeze(['0x00010000', 'true']),
+    otf: Object.freeze(['OTTO', '0x00010000']),
+  });
+
+  const freezeOptions = (options) => Object.freeze(options.map((option) => Object.freeze({ ...option })));
+
+  const UI_OPTIONS = freezeOptions([
+    { value: 'atkinson-hyperlegible-next', label: 'Atkinson Hyperlegible Next', family: 'Atkinson Hyperlegible Next', google: 'Atkinson+Hyperlegible+Next', stack: '"Atkinson Hyperlegible Next", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'courier-prime', label: 'Courier Prime', family: 'Courier Prime', google: 'Courier+Prime', stack: '"Courier Prime", ui-monospace, monospace' },
+    { value: 'dm-sans', label: 'DM Sans', family: 'DM Sans', google: 'DM+Sans', stack: '"DM Sans", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'figtree', label: 'Figtree', family: 'Figtree', google: 'Figtree', stack: 'Figtree, ui-sans-serif, system-ui, sans-serif' },
+    { value: 'geist', label: 'Geist', family: 'Geist', google: 'Geist', stack: 'Geist, ui-sans-serif, system-ui, sans-serif' },
+    { value: 'ibm-plex-sans', label: 'IBM Plex Sans', family: 'IBM Plex Sans', google: 'IBM+Plex+Sans', stack: '"IBM Plex Sans", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'inter', label: 'Inter', family: 'Inter', google: 'Inter', stack: 'Inter, ui-sans-serif, system-ui, sans-serif' },
+    { value: 'lexend-deca', label: 'Lexend Deca', family: 'Lexend Deca', google: 'Lexend+Deca', stack: '"Lexend Deca", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'noto-sans', label: 'Noto Sans', family: 'Noto Sans', google: 'Noto+Sans', stack: '"Noto Sans", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'nunito-sans', label: 'Nunito Sans', family: 'Nunito Sans', google: 'Nunito+Sans', stack: '"Nunito Sans", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'oxanium', label: 'Oxanium', family: 'Oxanium', google: 'Oxanium', stack: '"Oxanium", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'open-sans', label: 'Open Sans', family: 'Open Sans', google: 'Open+Sans', stack: '"Open Sans", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'public-sans', label: 'Public Sans', family: 'Public Sans', google: 'Public+Sans', stack: '"Public Sans", ui-sans-serif, system-ui, sans-serif' },
+    { value: 'source-sans-3', label: 'Source Sans 3', family: 'Source Sans 3', google: 'Source+Sans+3', stack: '"Source Sans 3", ui-sans-serif, system-ui, sans-serif' },
+  ]);
+
+  const READING_OPTIONS = freezeOptions([
+    { value: 'literata', label: 'Literata', family: 'Literata', google: 'Literata', stack: 'Literata, ui-serif, Georgia, serif' },
+    { value: 'merriweather', label: 'Merriweather', family: 'Merriweather', google: 'Merriweather', stack: 'Merriweather, ui-serif, Georgia, serif' },
+    { value: 'source-serif-4', label: 'Source Serif 4', family: 'Source Serif 4', google: 'Source+Serif+4', stack: '"Source Serif 4", ui-serif, Georgia, serif' },
+    { value: 'lora', label: 'Lora', family: 'Lora', google: 'Lora', stack: 'Lora, ui-serif, Georgia, serif' },
+    { value: 'noto-serif', label: 'Noto Serif', family: 'Noto Serif', google: 'Noto+Serif', stack: '"Noto Serif", ui-serif, Georgia, serif' },
+    { value: 'ibm-plex-serif', label: 'IBM Plex Serif', family: 'IBM Plex Serif', google: 'IBM+Plex+Serif', stack: '"IBM Plex Serif", ui-serif, Georgia, serif' },
+    { value: 'newsreader', label: 'Newsreader', family: 'Newsreader', google: 'Newsreader', stack: 'Newsreader, ui-serif, Georgia, serif' },
+    { value: 'bitter', label: 'Bitter', family: 'Bitter', google: 'Bitter', stack: 'Bitter, ui-serif, Georgia, serif' },
+  ]);
+
+  const CODE_OPTIONS = freezeOptions([
+    { value: 'atkinson-hyperlegible-mono', label: 'Atkinson Hyperlegible Mono', family: 'Atkinson Hyperlegible Mono', google: 'Atkinson+Hyperlegible+Mono', stack: '"Atkinson Hyperlegible Mono", ui-monospace, monospace' },
+    { value: 'courier-prime', label: 'Courier Prime', family: 'Courier Prime', google: 'Courier+Prime', stack: '"Courier Prime", ui-monospace, monospace' },
+    { value: 'geist-mono', label: 'Geist Mono', family: 'Geist Mono', google: 'Geist+Mono', stack: '"Geist Mono", ui-monospace, monospace' },
+    { value: 'jetbrains-mono', label: 'JetBrains Mono', family: 'JetBrains Mono', google: 'JetBrains+Mono', stack: '"JetBrains Mono", ui-monospace, monospace' },
+    { value: 'fira-code', label: 'Fira Code', family: 'Fira Code', google: 'Fira+Code', stack: '"Fira Code", ui-monospace, monospace' },
+    { value: 'source-code-pro', label: 'Source Code Pro', family: 'Source Code Pro', google: 'Source+Code+Pro', stack: '"Source Code Pro", ui-monospace, monospace' },
+    { value: 'ibm-plex-mono', label: 'IBM Plex Mono', family: 'IBM Plex Mono', google: 'IBM+Plex+Mono', stack: '"IBM Plex Mono", ui-monospace, monospace' },
+    { value: 'roboto-mono', label: 'Roboto Mono', family: 'Roboto Mono', google: 'Roboto+Mono', stack: '"Roboto Mono", ui-monospace, monospace' },
+    { value: 'inconsolata', label: 'Inconsolata', family: 'Inconsolata', google: 'Inconsolata', stack: 'Inconsolata, ui-monospace, monospace' },
+    { value: 'noto-sans-mono', label: 'Noto Sans Mono', family: 'Noto Sans Mono', google: 'Noto+Sans+Mono', stack: '"Noto Sans Mono", ui-monospace, monospace' },
+    { value: 'space-mono', label: 'Space Mono', family: 'Space Mono', google: 'Space+Mono', stack: '"Space Mono", ui-monospace, monospace' },
+    { value: 'martian-mono', label: 'Martian Mono', family: 'Martian Mono', google: 'Martian+Mono', stack: '"Martian Mono", ui-monospace, monospace' },
+  ]);
+
+  const CATALOG = Object.freeze({
+    interface: freezeOptions([{ value: 'default', label: 'WebUI default' }, ...UI_OPTIONS]),
+    conversation: freezeOptions([
+      { value: 'default', label: 'WebUI default' },
+      { value: 'same-ui', label: 'Same as interface' },
+      ...UI_OPTIONS,
+      ...READING_OPTIONS,
+    ]),
+    code: freezeOptions([{ value: 'default', label: 'WebUI default' }, ...CODE_OPTIONS]),
+  });
+  const PUBLIC_CATALOG = Object.freeze({
+    interface: Object.freeze(CATALOG.interface.map(({ value, label }) => Object.freeze({ value, label }))),
+    conversation: Object.freeze(CATALOG.conversation.map(({ value, label }) => Object.freeze({ value, label }))),
+    code: Object.freeze(CATALOG.code.map(({ value, label }) => Object.freeze({ value, label }))),
+  });
+
+  let selection = { ...DEFAULTS };
+  let initialSelection = { ...DEFAULTS };
+  let opener = null;
+  let localFonts = new Map();
+  let localFontState = {
+    available: false,
+    ready: false,
+    message: 'Local font imports are loading.',
+    error: false,
+  };
+  let localFontBusy = false;
+  const dirtyRoles = new Set();
+
+  function localSelectionValue(id) {
+    return 'local:' + id;
+  }
+
+  function removeLocalFontFromSelection(value, id) {
+    const candidate = value && typeof value === 'object' ? { ...value } : {};
+    const removed = localSelectionValue(id);
+    for (const role of ROLES) {
+      if (candidate[role] === removed) candidate[role] = DEFAULTS[role];
+    }
+    return candidate;
+  }
+
+  function localIdFromValue(value) {
+    if (typeof value !== 'string' || !value.startsWith('local:')) return null;
+    const id = value.slice('local:'.length);
+    return LOCAL_ID_RE.test(id) ? id : null;
+  }
+
+  function activeLocalIds() {
+    return new Set([...localFonts.values()].filter((record) => record.active).map((record) => record.id));
+  }
+
+  function staticOptionFor(role, value) {
+    return CATALOG[role].find((option) => option.value === value) || null;
+  }
+
+  function localFamilyFor(id) {
+    return 'HermesTypographyLocal_' + id;
+  }
+
+  function localFallbackForRole(role) {
+    return role === 'code' ? 'ui-monospace, monospace' : 'ui-sans-serif, system-ui, sans-serif';
+  }
+
+  function localOptionFor(record, role) {
+    const family = localFamilyFor(record.id);
+    return {
+      value: localSelectionValue(record.id),
+      label: record.name,
+      family,
+      stack: '"' + family + '", ' + localFallbackForRole(role),
+    };
+  }
+
+  function optionFor(role, value) {
+    if (role === 'conversation' && value === 'same-ui') return optionFor('interface', selection.interface);
+    const staticOption = staticOptionFor(role, value);
+    if (staticOption) return staticOption;
+    const id = localIdFromValue(value);
+    const record = id ? localFonts.get(id) : null;
+    return record && record.active ? localOptionFor(record, role) : null;
+  }
+
+  function normalizeSelection(value, availableLocalIds = activeLocalIds()) {
+    const candidate = value && typeof value === 'object' ? value : {};
+    const ids = availableLocalIds instanceof Set ? availableLocalIds : new Set(availableLocalIds || []);
+    return Object.fromEntries(ROLES.map((role) => {
+      const roleValue = candidate[role];
+      const valid = staticOptionFor(role, roleValue) || (localIdFromValue(roleValue) && ids.has(localIdFromValue(roleValue)));
+      return [role, valid ? roleValue : DEFAULTS[role]];
+    }));
+  }
+
+  function parseStored(value) {
+    if (typeof value !== 'string') return value;
+    try { return JSON.parse(value); } catch (_) { return null; }
+  }
+
+  function extensionStorage() {
+    try {
+      const api = window.HermesExtensionSettings;
+      if (!api || typeof api.storageForExtension !== 'function') return null;
+      const store = api.storageForExtension('typography');
+      if (!store || store.supported === false) return null;
+      if (typeof store.get === 'function' && typeof store.set === 'function') return store;
+      if (typeof store.getItem === 'function' && typeof store.setItem === 'function') return store;
+    } catch (_) {}
+    return null;
+  }
+
+  function readStore(store) {
+    return typeof store.get === 'function' ? store.get(STORAGE_KEY) : store.getItem(STORAGE_KEY);
+  }
+
+  function writeStore(store, value) {
+    return (typeof store.set === 'function' ? store.set(STORAGE_KEY, value) : store.setItem(STORAGE_KEY, value)) !== false;
+  }
+
+  function loadSelection() {
+    const store = extensionStorage();
+    if (store) {
+      try {
+        const stored = readStore(store);
+        if (stored !== undefined && stored !== null) return parseStored(stored);
+      } catch (_) {}
+    }
+    try { return parseStored(localStorage.getItem(FALLBACK_STORAGE_KEY)); } catch (_) { return null; }
+  }
+
+  function selectionForPersistence(value, persisted, dirty, ready, records) {
+    const candidate = value && typeof value === 'object' ? { ...value } : {};
+    const dirtySet = dirty && typeof dirty.has === 'function' ? dirty : new Set();
+    for (const role of ROLES) {
+      const persistedValue = persisted && persisted[role];
+      const id = localIdFromValue(persistedValue);
+      if (!dirtySet.has(role) && id && (!ready || (records && typeof records.has === 'function' && records.has(id)))) {
+        candidate[role] = persistedValue;
+      }
+    }
+    return candidate;
+  }
+
+  function saveSelection() {
+    const value = JSON.stringify(selectionForPersistence(selection, initialSelection, dirtyRoles, localFontState.ready, localFonts));
+    const store = extensionStorage();
+    if (store) {
+      try { if (writeStore(store, value)) return; } catch (_) {}
+    }
+    try { localStorage.setItem(FALLBACK_STORAGE_KEY, value); } catch (_) {}
+  }
+
+  function stackFor(role, value) {
+    const option = optionFor(role, value);
+    return option && option.stack ? option.stack : '';
+  }
+
+  function googleStylesheetHrefForOptions(optionsByRole) {
+    const families = new Map();
+    for (const role of ROLES) {
+      const option = optionsByRole && optionsByRole[role];
+      if (!option || !option.google) continue;
+      const existing = families.get(option.google);
+      if (existing) {
+        existing.prose = existing.prose || role !== 'code';
+      } else {
+        families.set(option.google, { option, prose: role !== 'code' });
+      }
+    }
+    if (!families.size) return '';
+    return GOOGLE_FONTS_URL + '?'
+      + [...families.values()].map(({ option, prose }) => 'family=' + option.google + (prose
+        ? ':ital,wght@0,400;0,500;0,600;0,700;1,400;1,700'
+        : ':wght@400;500;600;700')).join('&')
+      + '&display=swap';
+  }
+
+  function buildGoogleStylesheetHref(value = {}) {
+    const candidate = value && typeof value === 'object' ? value : {};
+    const interfaceValue = candidate.interface;
+    const options = Object.fromEntries(ROLES.map((role) => {
+      const selectedValue = role === 'conversation' && candidate[role] === 'same-ui'
+        ? interfaceValue
+        : candidate[role];
+      return [role, staticOptionFor(role, selectedValue)];
+    }));
+    return googleStylesheetHrefForOptions(options);
+  }
+
+  function updateGoogleStylesheet() {
+    const options = Object.fromEntries(ROLES.map((role) => [role, optionFor(role, selection[role])]));
+    const href = googleStylesheetHrefForOptions(options);
+    let link = document.getElementById(GOOGLE_STYLE_ID);
+    if (!href) {
+      if (link) link.remove();
+      return;
+    }
+    if (link && link.tagName !== 'LINK') { link.remove(); link = null; }
+    if (!link) {
+      link = document.createElement('link');
+      link.id = GOOGLE_STYLE_ID;
+      link.rel = 'stylesheet';
+      link.dataset.hwxTypeOwned = 'true';
+      link.href = href;
+      if (document.head) document.head.appendChild(link);
+    } else {
+      link.href = href;
+    }
+  }
+
+  function updatePreviews() {
+    const panel = document.getElementById(PANEL_ID);
+    if (!panel) return;
+    for (const role of ROLES) {
+      const stack = stackFor(role, selection[role]);
+      const select = panel.querySelector('#hwx-type-' + role);
+      const preview = panel.querySelector('[data-hwx-type-preview="' + role + '"]');
+      if (select) select.style.fontFamily = stack;
+      if (preview) preview.style.fontFamily = stack;
+    }
+  }
+
+  function apply() {
+    selection = normalizeSelection(selection);
+    const root = document.documentElement;
+    if (root) {
+      const ui = stackFor('interface', selection.interface);
+      const conversation = stackFor('conversation', selection.conversation);
+      const code = stackFor('code', selection.code);
+      if (ui) root.style.setProperty('--font-ui', ui); else root.style.removeProperty('--font-ui');
+      if (conversation) root.style.setProperty('--font-conversation', conversation); else root.style.removeProperty('--font-conversation');
+      if (code) root.style.setProperty('--font-mono', code); else root.style.removeProperty('--font-mono');
+    }
+    updateGoogleStylesheet();
+    updatePreviews();
+    return { ...selection };
+  }
+
+  function matchingPreset(value = selection) {
+    return PRESETS.find((preset) => ROLES.every((role) => preset[role] === value[role])) || null;
+  }
+
+  function setRole(role, value) {
+    if (!ROLES.includes(role)) return;
+    dirtyRoles.add(role);
+    selection = normalizeSelection({ ...selection, [role]: value });
+    saveSelection();
+    apply();
+    syncControls();
+  }
+
+  function setPreset(id) {
+    const preset = PRESETS.find((candidate) => candidate.id === id);
+    if (!preset) return;
+    ROLES.forEach((role) => dirtyRoles.add(role));
+    selection = normalizeSelection(preset);
+    saveSelection();
+    apply();
+    syncControls();
+  }
+
+  function appendSelectOption(select, option) {
+    const element = document.createElement('option');
+    element.value = option.value;
+    element.textContent = option.label;
+    select.appendChild(element);
+  }
+
+  function populateSelect(select, role) {
+    if (!select) return;
+    while (select.firstChild) select.removeChild(select.firstChild);
+    CATALOG[role].forEach((option) => appendSelectOption(select, option));
+    const locals = [...localFonts.values()].filter((record) => record.active);
+    if (locals.length) {
+      const group = document.createElement('optgroup');
+      group.label = 'Local fonts';
+      locals.forEach((record) => appendSelectOption(group, localOptionFor(record, role)));
+      select.appendChild(group);
+    }
+    select.value = selection[role];
+  }
+
+  function buildPresetControl(host) {
+    const field = document.createElement('label');
+    field.className = 'hwx-type-preset-field';
+    const label = document.createElement('span');
+    label.className = 'hwx-type-field-label';
+    label.textContent = 'Preset';
+    const select = document.createElement('select');
+    select.id = 'hwx-type-preset';
+    select.className = 'hwx-type-select';
+    select.setAttribute('aria-label', 'Typography preset');
+    appendSelectOption(select, { value: 'custom', label: 'Custom' });
+    PRESETS.forEach((preset) => appendSelectOption(select, { value: preset.id, label: preset.label }));
+    select.addEventListener('change', () => setPreset(select.value));
+    field.append(label, select);
+    host.appendChild(field);
+  }
+
+  function buildSelect(role, host) {
+    const field = document.createElement('label');
+    field.className = 'hwx-type-field';
+    const label = document.createElement('span');
+    label.className = 'hwx-type-field-label';
+    label.textContent = ROLE_LABELS[role];
+    const select = document.createElement('select');
+    select.id = 'hwx-type-' + role;
+    select.className = 'hwx-type-select';
+    select.setAttribute('aria-label', ROLE_LABELS[role]);
+    populateSelect(select, role);
+    select.addEventListener('change', () => setRole(role, select.value));
+    field.append(label, select);
+    host.appendChild(field);
+  }
+
+  function setLocalStatus(message, error = false) {
+    localFontState.message = message;
+    localFontState.error = error;
+    const status = document.getElementById('hwx-type-local-status');
+    if (status) {
+      status.textContent = message;
+      status.classList.toggle('hwx-type-status-error', error);
+    }
+  }
+
+  function setLocalControlsDisabled(disabled) {
+    const input = document.getElementById('hwx-type-local-file');
+    const importButton = document.getElementById('hwx-type-import');
+    if (input) input.disabled = disabled;
+    if (importButton) importButton.disabled = disabled;
+  }
+
+  function clearChildren(element) {
+    while (element && element.firstChild) element.removeChild(element.firstChild);
+  }
+
+  function renderLocalFonts() {
+    const list = document.getElementById('hwx-type-local-list');
+    if (!list) return;
+    clearChildren(list);
+    if (!localFonts.size) {
+      const empty = document.createElement('li');
+      empty.className = 'hwx-type-local-empty';
+      empty.textContent = 'No local fonts imported yet.';
+      list.appendChild(empty);
+      return;
+    }
+    for (const record of localFonts.values()) {
+      const item = document.createElement('li');
+      item.className = 'hwx-type-local-item';
+
+      const details = document.createElement('div');
+      details.className = 'hwx-type-local-details';
+      const heading = document.createElement('div');
+      heading.className = 'hwx-type-local-heading';
+      const name = document.createElement('strong');
+      name.className = 'hwx-type-local-name';
+      name.textContent = record.name;
+      const format = document.createElement('span');
+      format.className = 'hwx-type-local-format';
+      format.textContent = '· ' + record.format.toUpperCase();
+      heading.append(name, format);
+      const preview = document.createElement('span');
+      preview.className = 'hwx-type-local-preview';
+      preview.style.fontFamily = localFamilyFor(record.id);
+      preview.textContent = 'Il1 O0 {} [] != => ,.;:';
+      details.append(heading, preview);
+      if (!record.active) {
+        const meta = document.createElement('span');
+        meta.className = 'hwx-type-local-meta';
+        meta.textContent = 'Stored but unavailable; replace or delete it.';
+        details.appendChild(meta);
+      }
+
+      const actions = document.createElement('div');
+      actions.className = 'hwx-type-local-actions';
+      const rename = document.createElement('button');
+      rename.type = 'button';
+      rename.className = 'hwx-type-local-action';
+      rename.textContent = 'Rename';
+      rename.disabled = localFontBusy;
+      rename.addEventListener('click', () => renameLocalFont(record.id));
+      const replace = document.createElement('button');
+      replace.type = 'button';
+      replace.className = 'hwx-type-local-action';
+      replace.textContent = 'Replace';
+      replace.disabled = localFontBusy;
+      replace.addEventListener('click', () => chooseReplacement(record.id));
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'hwx-type-local-action hwx-type-local-delete';
+      remove.textContent = 'Delete';
+      remove.disabled = localFontBusy;
+      remove.addEventListener('click', () => deleteLocalFont(record.id));
+      actions.append(rename, replace, remove);
+
+      item.append(details, actions);
+      list.appendChild(item);
+    }
+  }
+
+  function syncControls() {
+    const panel = document.getElementById(PANEL_ID);
+    const active = document.activeElement;
+    const restoreFocus = panel && typeof panel.contains === 'function' && panel.contains(active);
+    if (panel) {
+      const preset = panel.querySelector('#hwx-type-preset');
+      if (preset) preset.value = matchingPreset() ? matchingPreset().id : 'custom';
+      for (const role of ROLES) {
+        const select = panel.querySelector('#hwx-type-' + role);
+        populateSelect(select, role);
+      }
+    }
+    setLocalControlsDisabled(!localFontState.available || !localFontState.ready || localFontBusy);
+    const status = document.getElementById('hwx-type-local-status');
+    if (status) {
+      status.textContent = localFontState.message;
+      status.classList.toggle('hwx-type-status-error', localFontState.error);
+    }
+    renderLocalFonts();
+    updatePreviews();
+    if (restoreFocus && !panel.contains(document.activeElement)) {
+      const target = panel.querySelector('#hwx-type-import:not([disabled])')
+        || panel.querySelector('button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])');
+      if (target) target.focus();
+    }
+  }
+
+  function buildPanel() {
+    const panel = document.createElement('div');
+    panel.id = PANEL_ID;
+    panel.className = 'hwx-type-overlay';
+    panel.innerHTML = `
+      <div class="hwx-type-card" role="dialog" aria-modal="true" aria-labelledby="hwx-type-title">
+        <div class="hwx-type-header">
+          <div>
+            <div class="hwx-type-title-row">
+              <h2 id="hwx-type-title">Typography</h2>
+              <button type="button" class="hwx-type-info has-tooltip has-tooltip--bottom" data-tooltip="${DISCLOSURE}" aria-label="Privacy and network information: ${DISCLOSURE}">i</button>
+            </div>
+            <p class="hwx-type-subtitle">Choose a font for each part of Hermes.</p>
+          </div>
+          <button type="button" class="hwx-type-close" aria-label="Close typography">&times;</button>
+        </div>
+        <div class="hwx-type-body">
+          <div class="hwx-type-preset"></div>
+          <div class="hwx-type-controls"></div>
+          <div class="hwx-type-previews" aria-label="Font previews">
+            <div class="hwx-type-preview" data-hwx-type-preview="interface"><span class="hwx-type-preview-label">Interface</span><span>Ag Il1 O0 0123456789 · Clear controls and compact labels</span></div>
+            <div class="hwx-type-preview" data-hwx-type-preview="conversation"><span class="hwx-type-preview-label">Conversations</span><span>Ag Il1 O0 0123456789 · Readable paragraphs <em>feel at home</em> with <strong>clear emphasis</strong>.</span></div>
+            <div class="hwx-type-preview hwx-type-preview-code" data-hwx-type-preview="code"><span class="hwx-type-preview-label">Code</span><code>Il1 O0 {} [] != =&gt; ,.;:</code></div>
+          </div>
+          <section class="hwx-type-local" aria-labelledby="hwx-type-local-title">
+            <h3 id="hwx-type-local-title">Local fonts</h3>
+            <p class="hwx-type-local-disclosure">Import .woff2, .woff, .ttf, or .otf files up to 10 MiB each.</p>
+            <input id="hwx-type-local-file" type="file" accept=".woff2,.woff,.ttf,.otf" hidden>
+            <button type="button" id="hwx-type-import">Import font</button>
+            <p class="hwx-type-local-help">Choose local fonts in any role selector.</p>
+            <p id="hwx-type-local-status" class="hwx-type-local-status" role="status" aria-live="polite" aria-atomic="true"></p>
+            <ul id="hwx-type-local-list" class="hwx-type-local-list"></ul>
+          </section>
+        </div>
+        <div class="hwx-type-actions">
+          <button type="button" class="hwx-type-close-action">Close</button>
+        </div>
+      </div>`;
+    const preset = panel.querySelector('.hwx-type-preset');
+    const controls = panel.querySelector('.hwx-type-controls');
+    buildPresetControl(preset);
+    ROLES.forEach((role) => buildSelect(role, controls));
+    const fileInput = panel.querySelector('#hwx-type-local-file');
+    const importButton = panel.querySelector('#hwx-type-import');
+    const info = panel.querySelector('.hwx-type-info');
+    fileInput.accept = FONT_ACCEPT;
+    importButton.addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files && fileInput.files[0];
+      fileInput.value = '';
+      if (file) importLocalFont(file);
+    });
+    info.addEventListener('click', () => info.classList.toggle('hwx-type-tooltip-open'));
+    info.addEventListener('blur', () => info.classList.remove('hwx-type-tooltip-open'));
+    panel.querySelector('.hwx-type-close').addEventListener('click', close);
+    panel.querySelector('.hwx-type-close-action').addEventListener('click', close);
+    panel.addEventListener('click', (event) => { if (event.target === panel) close(); });
+    return panel;
+  }
+
+  function onKeydown(event) {
+    const panel = document.getElementById(PANEL_ID);
+    if (!panel) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      close();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const focusable = panel.querySelectorAll('button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])');
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!panel.contains(document.activeElement)) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+      return;
+    }
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function open(openerElement) {
+    const existing = document.getElementById(PANEL_ID);
+    if (existing) {
+      const first = existing.querySelector('select');
+      if (first) first.focus();
+      return;
+    }
+    opener = openerElement && typeof openerElement.focus === 'function' ? openerElement : document.activeElement;
+    if (!document.body) return;
+    const panel = buildPanel();
+    document.body.appendChild(panel);
+    syncControls();
+    document.addEventListener('keydown', onKeydown, true);
+    const first = panel.querySelector('select');
+    if (first) first.focus();
+  }
+
+  function close() {
+    const panel = document.getElementById(PANEL_ID);
+    if (!panel) return;
+    panel.remove();
+    document.removeEventListener('keydown', onKeydown, true);
+    const restore = opener;
+    opener = null;
+    if (restore && restore.isConnected && typeof restore.focus === 'function') restore.focus();
+  }
+
+  function ensureRailButton() {
+    const existing = document.getElementById(RAIL_BUTTON_ID);
+    if (existing) return existing;
+    const rail = document.querySelector('.rail');
+    if (!rail) return null;
+    const button = document.createElement('button');
+    button.id = RAIL_BUTTON_ID;
+    button.type = 'button';
+    button.className = 'rail-btn nav-tab has-tooltip hwx-type-rail-button';
+    button.dataset.tooltip = 'Typography';
+    button.setAttribute('aria-label', 'Typography');
+    button.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 4v16"/><path d="M4 7V5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v2"/><path d="M9 20h6"/></svg>';
+    button.addEventListener('click', (event) => { event.preventDefault(); open(button); });
+    const spacer = rail.querySelector('.rail-spacer');
+    if (spacer) rail.insertBefore(button, spacer);
+    else rail.appendChild(button);
+    if (typeof MutationObserver === 'function') {
+      new MutationObserver(() => {
+        const currentSpacer = rail.querySelector('.rail-spacer');
+        const children = Array.from(rail.children);
+        const buttonIndex = children.indexOf(button);
+        const spacerIndex = children.indexOf(currentSpacer);
+        if (buttonIndex < 0 || spacerIndex < 0 || spacerIndex <= buttonIndex) return;
+        if (children.slice(buttonIndex + 1, spacerIndex).some((child) =>
+          child.classList.contains('nav-tab') && child.dataset.panel !== undefined
+        )) rail.insertBefore(button, currentSpacer);
+      }).observe(rail, { childList: true });
+    }
+    return button;
+  }
+
+  function installRailButton(attempt = 0) {
+    if (ensureRailButton() || attempt >= 80) return;
+    setTimeout(() => installRailButton(attempt + 1), 150);
+  }
+
+  function hasLocalFontSupport() {
+    return typeof window.indexedDB !== 'undefined'
+      && window.indexedDB && typeof window.indexedDB.open === 'function'
+      && typeof window.FontFace === 'function'
+      && typeof document !== 'undefined'
+      && document.fonts
+      && typeof document.fonts.add === 'function'
+      && typeof document.fonts.delete === 'function';
+  }
+
+  function toArrayBuffer(value) {
+    if (value instanceof ArrayBuffer) return value.slice(0);
+    if (ArrayBuffer.isView(value)) return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+    return null;
+  }
+
+  function signatureForBytes(bytes) {
+    const view = new Uint8Array(bytes);
+    if (view.length < 4) return '';
+    const ascii = String.fromCharCode(view[0], view[1], view[2], view[3]);
+    if (ascii === 'wOF2' || ascii === 'wOFF' || ascii === 'OTTO' || ascii === 'true') return ascii;
+    if (view[0] === 0x00 && view[1] === 0x01 && view[2] === 0x00 && view[3] === 0x00) return '0x00010000';
+    return '';
+  }
+
+  function extensionForFilename(filename) {
+    const base = String(filename || '').split(/[\\/]/).pop() || '';
+    const dot = base.lastIndexOf('.');
+    return dot > 0 ? base.slice(dot + 1).toLowerCase() : '';
+  }
+
+  function displayNameForFilename(filename) {
+    const base = String(filename || '').split(/[\\/]/).pop() || '';
+    const extension = extensionForFilename(base);
+    const withoutExtension = extension ? base.slice(0, -(extension.length + 1)) : base;
+    return withoutExtension.trim().slice(0, 80) || 'Imported font';
+  }
+
+  function validateLocalFontMetadata({ name, type, size, signature } = {}) {
+    const format = extensionForFilename(name);
+    if (!Object.prototype.hasOwnProperty.call(SIGNATURES, format)) return { ok: false, error: 'Use a .woff2, .woff, .ttf, or .otf font file.' };
+    if (!Number.isInteger(size) || size <= 0) return { ok: false, error: 'The font file is empty.' };
+    if (size > MAX_FONT_BYTES) return { ok: false, error: 'Font files must be 10 MiB or smaller.' };
+    const mime = typeof type === 'string' ? type.trim().toLowerCase() : '';
+    if (mime && mime !== 'application/octet-stream' && !MIME_TYPES[format].has(mime)) return { ok: false, error: 'The file MIME type does not match its extension.' };
+    if (!SIGNATURES[format].includes(signature)) return { ok: false, error: 'The file signature does not match a supported font format.' };
+    return { ok: true, format };
+  }
+
+  function normalizeStoredRecord(record) {
+    if (!record || typeof record !== 'object' || typeof record.id !== 'string' || !LOCAL_ID_RE.test(record.id)) return null;
+    const bytes = toArrayBuffer(record.bytes) || new ArrayBuffer(0);
+    const formatValue = typeof record.format === 'string' ? record.format.trim().toLowerCase() : '';
+    const format = Object.prototype.hasOwnProperty.call(SIGNATURES, formatValue) ? formatValue : 'unknown';
+    const metadata = format === 'unknown' ? { ok: false } : validateLocalFontMetadata({
+      name: record.id + '.' + format,
+      type: '',
+      size: bytes.byteLength,
+      signature: signatureForBytes(bytes),
+    });
+    const name = typeof record.name === 'string' ? record.name.trim().slice(0, 80) || 'Imported font' : 'Imported font';
+    const createdAt = Number.isFinite(record.createdAt) ? record.createdAt : Date.now();
+    const updatedAt = Number.isFinite(record.updatedAt) ? record.updatedAt : createdAt;
+    return {
+      id: record.id,
+      name,
+      format,
+      bytes,
+      createdAt,
+      updatedAt,
+      active: false,
+      face: null,
+      invalid: !(metadata.ok && metadata.format === format),
+    };
+  }
+
+  function storedRecord(record) {
+    return {
+      id: record.id,
+      name: record.name,
+      format: record.format,
+      bytes: record.bytes.slice(0),
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    };
+  }
+
+  function idbRequest(request) {
+    return new Promise((resolve, reject) => {
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error || new Error('IndexedDB request failed.'));
+    });
+  }
+
+  function transactionComplete(transaction) {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = (callback, value) => {
+        if (settled) return;
+        settled = true;
+        transaction.oncomplete = null;
+        transaction.onerror = null;
+        transaction.onabort = null;
+        callback(value);
+      };
+      transaction.oncomplete = () => finish(resolve);
+      transaction.onerror = () => finish(reject, transaction.error || new Error('IndexedDB transaction failed.'));
+      transaction.onabort = () => finish(reject, transaction.error || new Error('IndexedDB transaction aborted.'));
+    });
+  }
+
+  async function transactionRequest(transaction, requestFactory) {
+    const complete = transactionComplete(transaction);
+    try {
+      const result = await idbRequest(requestFactory(transaction.objectStore(FONT_STORE_NAME)));
+      await complete;
+      return result;
+    } catch (error) {
+      try { await complete; } catch (_) {}
+      throw error;
+    }
+  }
+
+  function openFontDatabase() {
+    return new Promise((resolve, reject) => {
+      let request;
+      try { request = window.indexedDB.open(FONT_DB_NAME, 1); } catch (error) { reject(error); return; }
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains(FONT_STORE_NAME)) database.createObjectStore(FONT_STORE_NAME, { keyPath: 'id' });
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error || new Error('Could not open local font storage.'));
+    });
+  }
+
+  async function readFontRecords() {
+    const database = await openFontDatabase();
+    try {
+      const transaction = database.transaction(FONT_STORE_NAME, 'readonly');
+      return await transactionRequest(transaction, (store) => store.getAll());
+    } finally {
+      database.close();
+    }
+  }
+
+  async function putFontRecord(record) {
+    const database = await openFontDatabase();
+    try {
+      const transaction = database.transaction(FONT_STORE_NAME, 'readwrite');
+      await transactionRequest(transaction, (store) => store.put(storedRecord(record)));
+    } finally {
+      database.close();
+    }
+  }
+
+  async function removeFontRecord(id) {
+    const database = await openFontDatabase();
+    try {
+      const transaction = database.transaction(FONT_STORE_NAME, 'readwrite');
+      await transactionRequest(transaction, (store) => store.delete(id));
+    } finally {
+      database.close();
+    }
+  }
+
+  function makeOpaqueId() {
+    try {
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') return window.crypto.randomUUID();
+    } catch (_) {}
+    return 'font-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 12);
+  }
+
+  async function loadFace(id, bytes) {
+    const face = new window.FontFace(localFamilyFor(id), bytes);
+    await face.load();
+    return face;
+  }
+
+  function removeFace(face) {
+    if (face && document.fonts && typeof document.fonts.delete === 'function') document.fonts.delete(face);
+  }
+
+  function localErrorMessage(error, fallback) {
+    return error && typeof error.message === 'string' && error.message ? error.message : fallback;
+  }
+
+  async function readValidatedFile(file, nameOverride) {
+    if (!file || typeof file.arrayBuffer !== 'function') throw new Error('This browser cannot read local font files.');
+    if (Number.isFinite(file.size) && file.size > MAX_FONT_BYTES) throw new Error('Font files must be 10 MiB or smaller.');
+    const bytes = toArrayBuffer(await file.arrayBuffer());
+    if (!bytes) throw new Error('The selected file could not be read.');
+    const metadata = validateLocalFontMetadata({
+      name: file.name,
+      type: file.type,
+      size: bytes.byteLength,
+      signature: signatureForBytes(bytes),
+    });
+    if (!metadata.ok) throw new Error(metadata.error);
+    const name = nameOverride === undefined ? displayNameForFilename(file.name) : String(nameOverride).trim().slice(0, 80);
+    return { bytes, format: metadata.format, name: name || 'Imported font' };
+  }
+
+  async function runLocalOperation(operation) {
+    if (localFontBusy) return;
+    localFontBusy = true;
+    syncControls();
+    try {
+      await operation();
+    } finally {
+      localFontBusy = false;
+      syncControls();
+    }
+  }
+
+  function importLocalFont(file) {
+    runLocalOperation(async () => {
+      try {
+        const imported = await readValidatedFile(file);
+        let id = makeOpaqueId();
+        while (localFonts.has(id)) id = makeOpaqueId();
+        const face = await loadFace(id, imported.bytes);
+        document.fonts.add(face);
+        const now = Date.now();
+        const record = {
+          id,
+          name: imported.name,
+          format: imported.format,
+          bytes: imported.bytes,
+          createdAt: now,
+          updatedAt: now,
+          active: true,
+          face,
+          invalid: false,
+        };
+        try {
+          await putFontRecord(record);
+        } catch (error) {
+          removeFace(face);
+          throw error;
+        }
+        localFonts.set(id, record);
+        setLocalStatus('');
+        syncControls();
+      } catch (error) {
+        setLocalStatus(localErrorMessage(error, 'The font could not be imported.'), true);
+      }
+    });
+  }
+
+  function chooseReplacement(id) {
+    if (localFontBusy) return;
+    if (!document.body) return;
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = FONT_ACCEPT;
+    input.tabIndex = -1;
+    input.setAttribute('aria-hidden', 'true');
+    input.style.display = 'none';
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      input.remove();
+    };
+    input.addEventListener('change', () => {
+      const file = input.files && input.files[0];
+      cleanup();
+      if (file) replaceLocalFont(id, file);
+    });
+    input.addEventListener('cancel', cleanup, { once: true });
+    document.body.appendChild(input);
+    try {
+      input.click();
+    } catch (error) {
+      cleanup();
+      setLocalStatus(localErrorMessage(error, 'The replacement picker could not open.'), true);
+    }
+  }
+
+  function replaceLocalFont(id, file) {
+    runLocalOperation(async () => {
+      const previous = localFonts.get(id);
+      if (!previous) return;
+      try {
+        const replacement = await readValidatedFile(file, previous.name);
+        const face = await loadFace(id, replacement.bytes);
+        document.fonts.add(face);
+        const next = {
+          ...previous,
+          format: replacement.format,
+          bytes: replacement.bytes,
+          updatedAt: Date.now(),
+          active: true,
+          face,
+          invalid: false,
+        };
+        try {
+          await putFontRecord(next);
+        } catch (error) {
+          removeFace(face);
+          throw error;
+        }
+        removeFace(previous.face);
+        localFonts.set(id, next);
+        const persisted = loadSelection();
+        if (persisted) {
+          selection = normalizeSelection(persisted);
+          apply();
+        }
+        setLocalStatus('Font replaced. Its name and selections were preserved.');
+        syncControls();
+      } catch (error) {
+        setLocalStatus(localErrorMessage(error, 'The font could not be replaced; the previous font is unchanged.'), true);
+      }
+    });
+  }
+
+  function renameLocalFont(id) {
+    const record = localFonts.get(id);
+    if (!record || localFontBusy) return;
+    if (typeof window.prompt !== 'function') {
+      setLocalStatus('Renaming is unavailable in this browser.', true);
+      return;
+    }
+    const entered = window.prompt('Font name (80 characters maximum)', record.name);
+    if (entered === null) return;
+    const name = String(entered).trim().slice(0, 80);
+    if (!name) {
+      setLocalStatus('Font names cannot be empty.', true);
+      return;
+    }
+    runLocalOperation(async () => {
+      const next = { ...record, name, updatedAt: Date.now() };
+      try {
+        await putFontRecord(next);
+        localFonts.set(id, next);
+        setLocalStatus('Font renamed.');
+        syncControls();
+      } catch (error) {
+        setLocalStatus(localErrorMessage(error, 'The font could not be renamed.'), true);
+      }
+    });
+  }
+
+  function deleteLocalFont(id) {
+    const record = localFonts.get(id);
+    if (!record || localFontBusy) return;
+    if (typeof window.confirm === 'function' && !window.confirm('Delete this imported font?')) return;
+    runLocalOperation(async () => {
+      try {
+        await removeFontRecord(id);
+        removeFace(record.face);
+        localFonts.delete(id);
+        const persisted = loadSelection();
+        const before = persisted && typeof persisted === 'object' ? persisted : selection;
+        const candidate = removeLocalFontFromSelection(before, id);
+        const changedRoles = ROLES.filter((role) => candidate[role] !== before[role]);
+        if (changedRoles.length) {
+          changedRoles.forEach((role) => dirtyRoles.add(role));
+          selection = normalizeSelection(candidate);
+          saveSelection();
+          apply();
+        }
+        setLocalStatus('Font deleted.');
+        syncControls();
+      } catch (error) {
+        setLocalStatus(localErrorMessage(error, 'The font could not be deleted.'), true);
+      }
+    });
+  }
+
+  async function initializeLocalFonts() {
+    if (!hasLocalFontSupport()) {
+      localFontState = {
+        available: false,
+        ready: false,
+        message: 'Local font imports are unavailable here because IndexedDB and FontFace support are required. Curated fonts and presets remain available.',
+        error: true,
+      };
+      selection = normalizeSelection(selection);
+      apply();
+      syncControls();
+      return;
+    }
+    localFontState = { available: true, ready: false, message: 'Loading stored local fonts.', error: false };
+    syncControls();
+    try {
+      const records = await readFontRecords();
+      localFonts = new Map();
+      for (const raw of records || []) {
+        const record = normalizeStoredRecord(raw);
+        if (record) localFonts.set(record.id, record);
+      }
+      let activationFailures = 0;
+      for (const record of localFonts.values()) {
+        if (record.invalid) {
+          activationFailures += 1;
+          continue;
+        }
+        try {
+          record.face = await loadFace(record.id, record.bytes);
+          document.fonts.add(record.face);
+          record.active = true;
+        } catch (_) {
+          record.face = null;
+          record.active = false;
+          activationFailures += 1;
+        }
+      }
+      localFontState = {
+        available: true,
+        ready: true,
+        message: activationFailures
+          ? 'Some stored local fonts could not be activated; their records were kept. Replace or delete them if needed.'
+          : '',
+        error: Boolean(activationFailures),
+      };
+    } catch (_) {
+      localFonts = new Map();
+      localFontState = {
+        available: false,
+        ready: false,
+        message: 'Local font imports are unavailable because this browser could not open IndexedDB. Curated fonts and presets remain available.',
+        error: true,
+      };
+      selection = normalizeSelection(selection);
+      apply();
+      syncControls();
+      return;
+    }
+    const candidate = { ...initialSelection };
+    for (const role of dirtyRoles) candidate[role] = selection[role];
+    selection = normalizeSelection(candidate);
+    apply();
+    syncControls();
+  }
+
+  const DEBUG = Object.freeze({
+    normalizeSelection: (value, localIds = []) => normalizeSelection(value, new Set(localIds)),
+    selectionForPersistence: (value, persisted, dirtyRoles = [], ready = false, localIds = []) => selectionForPersistence(
+      value,
+      persisted,
+      new Set(Array.isArray(dirtyRoles) ? dirtyRoles : []),
+      ready,
+      new Set(Array.isArray(localIds) ? localIds : []),
+    ),
+    normalizeStoredRecord,
+    removeLocalFontFromSelection,
+    validateLocalFontMetadata,
+    isStableLocalSelection: (value) => Boolean(localIdFromValue(value)),
+    localFallbackForRole,
+    buildGoogleStylesheetHref,
+  });
+
+  window.HermesTypographyExtension = Object.freeze({
+    version: VERSION,
+    open,
+    close,
+    getSelection: () => ({ ...selection }),
+    apply,
+    catalog: PUBLIC_CATALOG,
+    presets: PRESETS,
+    debug: DEBUG,
+  });
+
+  function init() {
+    initialSelection = loadSelection();
+    selection = normalizeSelection(initialSelection);
+    apply();
+    installRailButton();
+    initializeLocalFonts();
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init, { once: true });
+  else init();
+})();

--- a/extensions/typography/extension.json
+++ b/extensions/typography/extension.json
@@ -1,0 +1,49 @@
+{
+  "id": "typography",
+  "name": "Typography",
+  "description": "Choose interface, conversation, and code fonts independently with curated Google Fonts, role-based presets, and browser-local imports.",
+  "version": "0.1.0",
+  "author": "starship-s",
+  "assets": {
+    "scripts": [
+      "assets/typography.js"
+    ],
+    "stylesheets": [
+      "assets/typography.css"
+    ]
+  },
+  "capabilities": [
+    "manifest-bundle"
+  ],
+  "lifecycle": {
+    "webui_restart_required": false,
+    "sidecar_start_required": false,
+    "native_host_start_required": false,
+    "native_host_autostart": "none"
+  },
+  "screenshots": [],
+  "permissions": {
+    "webui_api": {
+      "read": [],
+      "write": []
+    },
+    "webui_navigation": false,
+    "dom": {
+      "owned": true,
+      "mutates_core_views": true
+    },
+    "storage": {
+      "owned": [
+        "hermes-ext-typography-selection"
+      ],
+      "shared_webui_keys": []
+    },
+    "loopback_sidecar": false,
+    "native_host": false,
+    "filesystem": {
+      "arbitrary": false,
+      "serves_bundled_assets": true
+    },
+    "network_external": true
+  }
+}

--- a/extensions/typography/extension.json
+++ b/extensions/typography/extension.json
@@ -4,6 +4,7 @@
   "description": "Choose interface, conversation, and code fonts independently with curated Google Fonts, role-based presets, and browser-local imports.",
   "version": "0.1.0",
   "author": "starship-s",
+  "min_webui_version": "0.52.184",
   "assets": {
     "scripts": [
       "assets/typography.js"
@@ -33,9 +34,7 @@
       "mutates_core_views": true
     },
     "storage": {
-      "owned": [
-        "hermes-ext-typography-selection"
-      ],
+      "owned": true,
       "shared_webui_keys": []
     },
     "loopback_sidecar": false,

--- a/extensions/typography/manifest.json
+++ b/extensions/typography/manifest.json
@@ -1,0 +1,20 @@
+{
+  "extensions": [
+    {
+      "id": "typography",
+      "name": "Typography",
+      "description": "Choose interface, conversation, and code fonts independently with curated Google Fonts, role-based presets, and browser-local imports.",
+      "scripts": [
+        "assets/typography.js"
+      ],
+      "stylesheets": [
+        "assets/typography.css"
+      ],
+      "permissions": {
+        "storage": {
+          "owned": true
+        }
+      }
+    }
+  ]
+}

--- a/scripts/test-typography-rail-entry.mjs
+++ b/scripts/test-typography-rail-entry.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import * as vm from 'node:vm';
+
+const source = await readFile(new URL('../extensions/typography/assets/typography.js', import.meta.url), 'utf8');
+
+const RAIL_ID = 'hwx-type-rail-button';
+const buildPanelStart = source.indexOf('  function buildPanel()');
+const buildPanelEnd = source.indexOf('  function onKeydown', buildPanelStart);
+const panelSource = source.slice(buildPanelStart, buildPanelEnd);
+assert.equal(source.includes('    document.body.appendChild(panel);\n    syncControls();'), true, 'controls sync after panel attachment');
+assert.equal(panelSource.includes('\n    syncControls();\n    return panel;'), false, 'detached panel does not sync controls');
+assert.equal(source.includes("button.title = 'Typography';"), false, 'rail button uses WebUI tooltip without native title');
+assert.equal(source.includes('if (!panel.contains(document.activeElement))'), true, 'Tab pulls escaped focus into the panel');
+assert.equal(source.includes("panel.querySelector('#hwx-type-import:not([disabled])')"), true, 'rerender restores focus to an enabled in-panel control');
+assert.equal(
+  !panelSource.includes('hwx-type-reset')
+    && !panelSource.includes('Font file')
+    && panelSource.includes('Choose local fonts in any role selector.')
+    && panelSource.includes('hwx-type-info has-tooltip has-tooltip--bottom')
+    && !panelSource.includes('id="hwx-type-disclosure"')
+    && /fileInput\.addEventListener\('change',[\s\S]*?fileInput\.value = '';\s*if \(file\) importLocalFont\(file\);/.test(panelSource),
+  true,
+  'Import font has no reset or visible file label and imports directly on file selection',
+);
+const actionRegistration = ['register', 'Action'].join('');
+const optionalRegistration = ['register', 'Con', 'figure', 'Action'].join('');
+assert.equal(source.includes(actionRegistration), false, 'runtime has no action registration API');
+assert.equal(source.includes(optionalRegistration), false, 'runtime has no optional registration API');
+
+function makeElement(tagName, className = '') {
+  const detach = (child) => {
+    const parent = child.parentNode;
+    if (!parent) return;
+    const index = parent.children.indexOf(child);
+    if (index >= 0) parent.children.splice(index, 1);
+  };
+  const element = {
+    tagName: tagName.toUpperCase(),
+    className,
+    children: [],
+    parentNode: null,
+    dataset: {},
+    style: { setProperty() {}, removeProperty() {} },
+    appendChild(child) {
+      detach(child);
+      this.children.push(child);
+      child.parentNode = this;
+      child.isConnected = true;
+      return child;
+    },
+    insertBefore(child, reference) {
+      if (child === reference) return child;
+      if (!this.children.includes(reference)) return this.appendChild(child);
+      detach(child);
+      this.children.splice(this.children.indexOf(reference), 0, child);
+      child.parentNode = this;
+      child.isConnected = true;
+      return child;
+    },
+    remove() {
+      if (this.parentNode) this.parentNode.children = this.parentNode.children.filter((child) => child !== this);
+      this.parentNode = null;
+      this.isConnected = false;
+    },
+    addEventListener() {},
+    setAttribute(name, value) { this[name] = value; },
+    classList: {
+      toggle() {},
+      contains(name) { return element.className.split(/\s+/).includes(name); },
+    },
+    querySelector(selector) {
+      if (selector !== '.rail-spacer') return null;
+      return this.children.find((child) => child.className.split(/\s+/).includes('rail-spacer')) || null;
+    },
+  };
+  return element;
+}
+
+function run() {
+  const body = makeElement('body');
+  const rail = makeElement('nav');
+  const nativeTabs = ['chat', 'settings'].map((panel) => {
+    const tab = makeElement('button', 'rail-btn nav-tab');
+    tab.dataset.panel = panel;
+    return tab;
+  });
+  const spacer = makeElement('div', 'rail-spacer');
+  nativeTabs.forEach((tab) => rail.appendChild(tab));
+  rail.appendChild(spacer);
+  body.appendChild(rail);
+  const findById = (node, id) => {
+    if (node.id === id) return node;
+    for (const child of node.children) {
+      const match = findById(child, id);
+      if (match) return match;
+    }
+    return null;
+  };
+  const document = {
+    readyState: 'complete',
+    body,
+    head: makeElement('head'),
+    documentElement: makeElement('html'),
+    activeElement: makeElement('button'),
+    getElementById: (id) => findById(body, id),
+    querySelector: (selector) => selector === '.rail' ? rail : null,
+    createElement: (tagName) => makeElement(tagName),
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  const observers = [];
+  class TestMutationObserver {
+    constructor(callback) {
+      this.callback = callback;
+      observers.push(this);
+    }
+
+    observe(target, options) {
+      this.target = target;
+      this.options = options;
+    }
+
+    flush() {
+      this.callback([], this);
+    }
+  }
+  const context = {
+    window: {},
+    document,
+    MutationObserver: TestMutationObserver,
+    localStorage: { getItem: () => null, setItem() {} },
+    setTimeout: () => { throw new Error('unexpected retry timer'); },
+    console,
+  };
+  vm.runInNewContext(source, context);
+  return {
+    context,
+    rail,
+    spacer,
+    nativeTabs,
+    observers,
+    flushObservers: () => observers.forEach((observer) => observer.flush()),
+    extension: context.window.HermesTypographyExtension,
+  };
+}
+
+const result = run();
+const button = result.rail.children.find((child) => child.id === RAIL_ID);
+assert.ok(button, 'rail button is inserted');
+assert.equal(result.rail.children.filter((child) => child.id === RAIL_ID).length, 1, 'one rail button is inserted');
+assert.ok(result.rail.children.indexOf(button) < result.rail.children.indexOf(result.spacer), 'rail button precedes the spacer');
+assert.equal(button.dataset.panel, undefined, 'Typography remains an extension action without a panel');
+vm.runInNewContext(source, result.context);
+assert.equal(result.rail.children.filter((child) => child.id === RAIL_ID).length, 1, 'duplicate initialization does not duplicate the rail button');
+result.nativeTabs.forEach((tab) => result.rail.insertBefore(tab, result.spacer));
+result.flushObservers();
+const buttonIndex = result.rail.children.indexOf(button);
+const spacerIndex = result.rail.children.indexOf(result.spacer);
+assert.ok(result.nativeTabs.every((tab) => result.rail.children.indexOf(tab) < buttonIndex), 'Typography ends after all native panel buttons');
+assert.equal(buttonIndex, spacerIndex - 1, 'Typography ends immediately before the spacer');
+assert.equal(result.extension.version, '0.1.0');
+assert.equal(Object.isFrozen(result.extension.presets), true, 'preset metadata is immutable');
+assert.equal(Object.isFrozen(result.extension.presets[0]), true, 'preset entries are immutable');
+assert.equal(result.extension.presets[0].conversation, 'same-ui');
+assert.equal(result.extension.debug.isStableLocalSelection('local:font-123'), true);
+
+console.log('typography rail-entry check passed');

--- a/scripts/test-typography-rail-entry.mjs
+++ b/scripts/test-typography-rail-entry.mjs
@@ -5,28 +5,6 @@ import * as vm from 'node:vm';
 const source = await readFile(new URL('../extensions/typography/assets/typography.js', import.meta.url), 'utf8');
 
 const RAIL_ID = 'hwx-type-rail-button';
-const buildPanelStart = source.indexOf('  function buildPanel()');
-const buildPanelEnd = source.indexOf('  function onKeydown', buildPanelStart);
-const panelSource = source.slice(buildPanelStart, buildPanelEnd);
-assert.equal(source.includes('    document.body.appendChild(panel);\n    syncControls();'), true, 'controls sync after panel attachment');
-assert.equal(panelSource.includes('\n    syncControls();\n    return panel;'), false, 'detached panel does not sync controls');
-assert.equal(source.includes("button.title = 'Typography';"), false, 'rail button uses WebUI tooltip without native title');
-assert.equal(source.includes('if (!panel.contains(document.activeElement))'), true, 'Tab pulls escaped focus into the panel');
-assert.equal(source.includes("panel.querySelector('#hwx-type-import:not([disabled])')"), true, 'rerender restores focus to an enabled in-panel control');
-assert.equal(
-  !panelSource.includes('hwx-type-reset')
-    && !panelSource.includes('Font file')
-    && panelSource.includes('Choose local fonts in any role selector.')
-    && panelSource.includes('hwx-type-info has-tooltip has-tooltip--bottom')
-    && !panelSource.includes('id="hwx-type-disclosure"')
-    && /fileInput\.addEventListener\('change',[\s\S]*?fileInput\.value = '';\s*if \(file\) importLocalFont\(file\);/.test(panelSource),
-  true,
-  'Import font has no reset or visible file label and imports directly on file selection',
-);
-const actionRegistration = ['register', 'Action'].join('');
-const optionalRegistration = ['register', 'Con', 'figure', 'Action'].join('');
-assert.equal(source.includes(actionRegistration), false, 'runtime has no action registration API');
-assert.equal(source.includes(optionalRegistration), false, 'runtime has no optional registration API');
 
 function makeElement(tagName, className = '') {
   const detach = (child) => {

--- a/scripts/test-typography.mjs
+++ b/scripts/test-typography.mjs
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import * as vm from 'node:vm';
+
+const source = await readFile(new URL('../extensions/typography/assets/typography.js', import.meta.url), 'utf8');
+const css = await readFile(new URL('../extensions/typography/assets/typography.css', import.meta.url), 'utf8');
+const document = {
+  readyState: 'complete',
+  documentElement: { style: { setProperty() {}, removeProperty() {} } },
+  getElementById: () => null,
+  querySelector: () => null,
+  addEventListener() {},
+  removeEventListener() {},
+};
+const writes = [];
+const window = {};
+vm.runInNewContext(source, {
+  window,
+  document,
+  localStorage: {
+    getItem: () => JSON.stringify({ interface: 'local:font-123', conversation: 'same-ui', code: 'default' }),
+    setItem: (...args) => writes.push(args),
+  },
+  setTimeout() {},
+  console,
+});
+
+const extension = window.HermesTypographyExtension;
+assert.equal(extension.version, '0.1.0');
+const expectedPresets = [
+  ['webui-default', 'WebUI Default', 'default', 'same-ui', 'default'],
+  ['nous', 'Nous', 'courier-prime', 'same-ui', 'courier-prime'],
+  ['modern', 'Modern', 'geist', 'same-ui', 'geist-mono'],
+  ['accessible', 'Accessible', 'atkinson-hyperlegible-next', 'same-ui', 'atkinson-hyperlegible-mono'],
+  ['comfortable-reading', 'Comfortable Reading', 'lexend-deca', 'literata', 'source-code-pro'],
+  ['noto', 'Noto', 'noto-sans', 'noto-serif', 'noto-sans-mono'],
+  ['ibm-plex', 'IBM Plex', 'ibm-plex-sans', 'ibm-plex-serif', 'ibm-plex-mono'],
+  ['developer', 'Developer', 'inter', 'same-ui', 'jetbrains-mono'],
+  ['dense', 'Dense', 'public-sans', 'same-ui', 'inconsolata'],
+  ['warm', 'Warm', 'nunito-sans', 'lora', 'fira-code'],
+  ['cyberdeck', 'Cyberdeck', 'oxanium', 'geist', 'space-mono'],
+];
+assert.equal(extension.presets.length, expectedPresets.length);
+const bitter = extension.catalog.conversation.find(option => option.value === 'bitter');
+assert.ok(bitter, 'Bitter is a Conversations catalog option');
+assert.equal(bitter.label, 'Bitter');
+assert.equal(extension.catalog.interface.some(option => option.value === 'bitter'), false, 'Bitter is not an Interface option');
+assert.equal(extension.catalog.code.some(option => option.value === 'bitter'), false, 'Bitter is not a Code option');
+assert.equal(
+  JSON.stringify(extension.presets.map(({ id, label, interface: interfaceFont, conversation, code }) => [id, label, interfaceFont, conversation, code])),
+  JSON.stringify(expectedPresets),
+);
+for (const [id, label, interfaceFont, conversation, code] of expectedPresets) {
+  const preset = extension.presets.find((candidate) => candidate.id === id);
+  assert.ok(preset, `missing preset: ${label}`);
+  assert.equal(preset.label, label);
+  assert.equal(preset.interface, interfaceFont);
+  assert.equal(preset.conversation, conversation);
+  assert.notEqual(preset.conversation, preset.interface, `${label} uses same-ui instead of repeating the interface family`);
+  assert.equal(preset.code, code);
+  assert.ok(extension.catalog.interface.some(option => option.value === interfaceFont), `${label} interface font is catalogued`);
+  assert.ok(
+    conversation === 'same-ui' || extension.catalog.conversation.some(option => option.value === conversation),
+    `${label} conversation font is catalogued`,
+  );
+  assert.ok(extension.catalog.code.some(option => option.value === code), `${label} code font is catalogued`);
+}
+
+const buildGoogleStylesheetHref = extension.debug.buildGoogleStylesheetHref;
+assert.equal(
+  buildGoogleStylesheetHref({ interface: 'default', conversation: 'default', code: 'space-mono' }),
+  'https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;500;600;700&display=swap',
+  'code-only hosted families use upright weights',
+);
+assert.equal(
+  buildGoogleStylesheetHref({ interface: 'geist', conversation: 'geist', code: 'default' }),
+  'https://fonts.googleapis.com/css2?family=Geist:ital,wght@0,400;0,500;0,600;0,700;1,400;1,700&display=swap',
+  'interface and conversation hosted families include true italics',
+);
+assert.equal(
+  buildGoogleStylesheetHref({ interface: 'default', conversation: 'bitter', code: 'default' }),
+  'https://fonts.googleapis.com/css2?family=Bitter:ital,wght@0,400;0,500;0,600;0,700;1,400;1,700&display=swap',
+  'Bitter is a hosted prose family',
+);
+const sharedHref = buildGoogleStylesheetHref({ interface: 'courier-prime', conversation: 'default', code: 'courier-prime' });
+assert.equal(
+  sharedHref,
+  'https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@0,400;0,500;0,600;0,700;1,400;1,700&display=swap',
+  'shared hosted families use the prose union once',
+);
+assert.equal((sharedHref.match(/family=/g) || []).length, 1, 'shared hosted families are deduplicated');
+
+assert.equal(
+  source.includes('Ag Il1 O0 0123456789 · Clear controls and compact labels'),
+  true,
+  'interface preview includes the glyph diagnostic and representative text',
+);
+assert.equal(
+  source.includes('Ag Il1 O0 0123456789 · Readable paragraphs <em>feel at home</em> with <strong>clear emphasis</strong>.'),
+  true,
+  'conversation preview includes the glyph diagnostic and semantic emphasis',
+);
+assert.equal(source.includes('<code>Il1 O0 {} [] != =&gt; ,.;:</code>'), true, 'code diagnostic preview remains unchanged');
+assert.equal(
+  css.includes('#hwx-type-panel .hwx-type-preview[data-hwx-type-preview="conversation"] {\n  font-size: var(--message-body-font-size, 14px);\n  line-height: var(--message-body-line-height, 1.75);\n}'),
+  true,
+  'conversation preview follows the core message sizing contract',
+);
+
+const validate = extension.debug.validateLocalFontMetadata;
+assert.equal(validate({ name: 'sample.woff2', type: 'font/woff2', size: 4, signature: 'wOF2' }).ok, true);
+assert.equal(validate({ name: 'sample.woff2', type: 'application/octet-stream', size: 4, signature: 'wOF2' }).ok, true);
+assert.equal(validate({ name: 'sample.woff', type: '', size: 4, signature: 'wOFF' }).ok, true);
+assert.equal(validate({ name: 'sample.ttf', type: 'font/ttf', size: 4, signature: '0x00010000' }).ok, true);
+assert.equal(validate({ name: 'sample.otf', type: 'font/otf', size: 4, signature: 'OTTO' }).ok, true);
+assert.equal(validate({ name: 'sample.otf', type: 'font/otf', size: 4, signature: '0x00010000' }).ok, true);
+assert.equal(validate({ name: 'sample.ttf', type: 'font/ttf', size: 4, signature: 'OTTO' }).ok, false);
+assert.equal(validate({ name: 'sample.otf', type: 'font/otf', size: 4, signature: 'true' }).ok, false);
+assert.equal(validate({ name: 'sample.woff2', type: '', size: 0, signature: 'wOF2' }).ok, false);
+assert.equal(validate({ name: 'sample.woff2', type: '', size: 4, signature: 'wOFF' }).ok, false);
+assert.equal(validate({ name: 'sample.woff2', type: 'font/ttf', size: 4, signature: 'wOF2' }).ok, false);
+assert.equal(validate({ name: 'sample.txt', type: '', size: 4, signature: 'wOF2' }).ok, false);
+assert.equal(validate({ name: 'sample.woff2', type: '', size: 10 * 1024 * 1024 + 1, signature: 'wOF2' }).ok, false);
+
+assert.equal(extension.debug.isStableLocalSelection('local:font-123'), true);
+assert.equal(extension.debug.isStableLocalSelection('local:display name'), false);
+assert.equal(
+  JSON.stringify(extension.debug.removeLocalFontFromSelection({
+    interface: 'local:font-123',
+    conversation: 'same-ui',
+    code: 'local:font-123',
+  }, 'font-123')),
+  JSON.stringify({ interface: 'default', conversation: 'same-ui', code: 'default' }),
+  'deleting a local font clears every persisted role that selects it',
+);
+const normalizeStoredRecord = extension.debug.normalizeStoredRecord;
+const corrupt = normalizeStoredRecord({
+  id: 'font-corrupt',
+  name: 'Broken font',
+  format: 'woff2',
+  bytes: new Uint8Array([0, 1, 2, 3]),
+  createdAt: 123,
+  updatedAt: 456,
+});
+assert.ok(corrupt, 'valid IDs retain corrupt stored rows');
+assert.equal(corrupt.invalid, true);
+assert.equal(corrupt.active, false);
+assert.equal(corrupt.face, null);
+assert.equal(corrupt.name, 'Broken font');
+assert.equal(corrupt.format, 'woff2');
+assert.equal(corrupt.bytes.byteLength, 4);
+assert.equal(corrupt.createdAt, 123);
+assert.equal(corrupt.updatedAt, 456);
+const validStored = normalizeStoredRecord({
+  id: 'font-valid',
+  name: 'Valid font',
+  format: 'otf',
+  bytes: new Uint8Array([0, 1, 0, 0]),
+});
+assert.equal(validStored.invalid, false);
+const emptyStored = normalizeStoredRecord({ id: 'font-empty' });
+assert.equal(emptyStored.invalid, true);
+assert.equal(emptyStored.format, 'unknown');
+assert.equal(emptyStored.bytes.byteLength, 0);
+for (const id of ['', 'bad id', '../font', 'local:font-123', '<script>', 42, null]) {
+  assert.equal(normalizeStoredRecord({ id }), null, `rejects unsafe stored ID: ${String(id)}`);
+}
+const normalized = extension.debug.normalizeSelection({
+  interface: 'local:font-123',
+  conversation: 'local:missing',
+  code: 'local:font-123',
+}, ['font-123']);
+assert.equal(normalized.interface, 'local:font-123');
+assert.equal(normalized.conversation, 'same-ui');
+assert.equal(normalized.code, 'local:font-123');
+assert.equal(
+  JSON.stringify(extension.debug.selectionForPersistence(
+    { interface: 'default', conversation: 'default', code: 'default' },
+    { interface: 'local:font-123', conversation: 'local:font-456', code: 'default' },
+    ['interface'],
+  )),
+  JSON.stringify({ interface: 'default', conversation: 'local:font-456', code: 'default' }),
+  'pending persistence keeps untouched unresolved local selections',
+);
+assert.equal(
+  JSON.stringify(extension.debug.selectionForPersistence(
+    { interface: 'default', conversation: 'default', code: 'default' },
+    { interface: 'local:font-123', conversation: 'local:font-456', code: 'default' },
+    ['interface'],
+    true,
+    ['font-123', 'font-456'],
+  )),
+  JSON.stringify({ interface: 'default', conversation: 'local:font-456', code: 'default' }),
+  'ready persistence keeps a known stored local selection and lets dirty roles win',
+);
+assert.equal(
+  JSON.stringify(extension.debug.selectionForPersistence(
+    { interface: 'default', conversation: 'default', code: 'default' },
+    { interface: 'local:font-123', conversation: 'local:font-456', code: 'default' },
+    [],
+    true,
+    ['font-123'],
+  )),
+  JSON.stringify({ interface: 'local:font-123', conversation: 'default', code: 'default' }),
+  'ready persistence does not restore a missing local selection',
+);
+assert.equal(extension.debug.localFallbackForRole('interface'), 'ui-sans-serif, system-ui, sans-serif');
+assert.equal(extension.debug.localFallbackForRole('conversation'), 'ui-sans-serif, system-ui, sans-serif');
+assert.equal(extension.debug.localFallbackForRole('code'), 'ui-monospace, monospace');
+assert.equal((source.match(/Choose local fonts in any role selector\./g) || []).length, 1, 'role-selector guidance appears only below Import font');
+assert.equal(source.includes("format.textContent = '· ' + record.format.toUpperCase();"), true, 'format label does not rely on leading whitespace');
+assert.equal((source.match(/Local fonts stay in this browser and are never sent to a server\./g) || []).length, 1, 'local-font privacy disclosure appears once');
+assert.equal(extension.getSelection().interface, 'default', 'unsupported local fonts use in-memory defaults');
+assert.equal(writes.length, 0, 'unsupported local fonts do not overwrite persisted selection');
+
+console.log('typography presets, local-font validation, and selection check passed');

--- a/scripts/test-typography.mjs
+++ b/scripts/test-typography.mjs
@@ -108,6 +108,30 @@ assert.equal(
 );
 
 const validate = extension.debug.validateLocalFontMetadata;
+const capacity = extension.debug.localFontCapacity;
+const maxLocalFontCount = extension.debug.MAX_LOCAL_FONT_COUNT;
+const maxLocalFontTotalBytes = extension.debug.MAX_LOCAL_FONT_TOTAL_BYTES;
+assert.equal(capacity({ currentCount: 0, currentTotalBytes: 0, newBytes: 1 }).ok, true, 'an empty collection accepts its first font');
+assert.equal(capacity({ currentCount: 1, currentTotalBytes: 1, newBytes: 1 }).count, 2, 'capacity counts the existing and new fonts');
+assert.equal(capacity({ currentCount: maxLocalFontCount - 1, currentTotalBytes: 0, newBytes: 1 }).count, maxLocalFontCount, 'the maximum count is accepted exactly');
+assert.equal(capacity({ currentCount: maxLocalFontCount - 1, currentTotalBytes: 0, newBytes: 1 }).ok, true, 'the maximum count remains valid');
+assert.equal(capacity({ currentCount: maxLocalFontCount, currentTotalBytes: 0, newBytes: 1 }).ok, false, 'count above the maximum is rejected');
+assert.equal(capacity({ currentCount: maxLocalFontCount + 1, currentTotalBytes: 0, newBytes: 1 }).ok, false, 'an already over-count collection remains rejected');
+const maxCountReplacement = capacity({ currentCount: maxLocalFontCount, currentTotalBytes: 1, newBytes: 1, replacing: true, oldBytes: 1 });
+assert.equal(maxCountReplacement.ok, true, 'replacement is allowed at the maximum count');
+assert.equal(maxCountReplacement.count, maxLocalFontCount, 'replacement does not increase the count');
+assert.equal(capacity({ currentCount: 0, currentTotalBytes: maxLocalFontTotalBytes - 1, newBytes: 1 }).totalBytes, maxLocalFontTotalBytes, 'the aggregate byte maximum is accepted exactly');
+assert.equal(capacity({ currentCount: 0, currentTotalBytes: maxLocalFontTotalBytes - 1, newBytes: 1 }).ok, true, 'the aggregate byte maximum remains valid');
+assert.equal(capacity({ currentCount: 0, currentTotalBytes: maxLocalFontTotalBytes, newBytes: 1 }).ok, false, 'aggregate bytes above the maximum are rejected');
+const replacementCapacity = capacity({ currentCount: 3, currentTotalBytes: 30, newBytes: 20, replacing: true, oldBytes: 10 });
+assert.equal(replacementCapacity.ok, true, 'replacement keeps count and subtracts the old bytes before adding the new bytes');
+assert.equal(replacementCapacity.count, 3);
+assert.equal(replacementCapacity.totalBytes, 40);
+assert.equal(
+  capacity({ currentCount: 3, currentTotalBytes: maxLocalFontTotalBytes, newBytes: 2, replacing: true, oldBytes: 1 }).ok,
+  false,
+  'replacement rejects the aggregate total after subtracting the old record',
+);
 assert.equal(validate({ name: 'sample.woff2', type: 'font/woff2', size: 4, signature: 'wOF2' }).ok, true);
 assert.equal(validate({ name: 'sample.woff2', type: 'application/octet-stream', size: 4, signature: 'wOF2' }).ok, true);
 assert.equal(validate({ name: 'sample.woff', type: '', size: 4, signature: 'wOFF' }).ok, true);

--- a/scripts/test-typography.mjs
+++ b/scripts/test-typography.mjs
@@ -3,7 +3,6 @@ import { readFile } from 'node:fs/promises';
 import * as vm from 'node:vm';
 
 const source = await readFile(new URL('../extensions/typography/assets/typography.js', import.meta.url), 'utf8');
-const css = await readFile(new URL('../extensions/typography/assets/typography.css', import.meta.url), 'utf8');
 const document = {
   readyState: 'complete',
   documentElement: { style: { setProperty() {}, removeProperty() {} } },
@@ -90,22 +89,6 @@ assert.equal(
 );
 assert.equal((sharedHref.match(/family=/g) || []).length, 1, 'shared hosted families are deduplicated');
 
-assert.equal(
-  source.includes('Ag Il1 O0 0123456789 · Clear controls and compact labels'),
-  true,
-  'interface preview includes the glyph diagnostic and representative text',
-);
-assert.equal(
-  source.includes('Ag Il1 O0 0123456789 · Readable paragraphs <em>feel at home</em> with <strong>clear emphasis</strong>.'),
-  true,
-  'conversation preview includes the glyph diagnostic and semantic emphasis',
-);
-assert.equal(source.includes('<code>Il1 O0 {} [] != =&gt; ,.;:</code>'), true, 'code diagnostic preview remains unchanged');
-assert.equal(
-  css.includes('#hwx-type-panel .hwx-type-preview[data-hwx-type-preview="conversation"] {\n  font-size: var(--message-body-font-size, 14px);\n  line-height: var(--message-body-line-height, 1.75);\n}'),
-  true,
-  'conversation preview follows the core message sizing contract',
-);
 
 const validate = extension.debug.validateLocalFontMetadata;
 const capacity = extension.debug.localFontCapacity;
@@ -231,9 +214,6 @@ assert.equal(
 assert.equal(extension.debug.localFallbackForRole('interface'), 'ui-sans-serif, system-ui, sans-serif');
 assert.equal(extension.debug.localFallbackForRole('conversation'), 'ui-sans-serif, system-ui, sans-serif');
 assert.equal(extension.debug.localFallbackForRole('code'), 'ui-monospace, monospace');
-assert.equal((source.match(/Choose local fonts in any role selector\./g) || []).length, 1, 'role-selector guidance appears only below Import font');
-assert.equal(source.includes("format.textContent = '· ' + record.format.toUpperCase();"), true, 'format label does not rely on leading whitespace');
-assert.equal((source.match(/Local fonts stay in this browser and are never sent to a server\./g) || []).length, 1, 'local-font privacy disclosure appears once');
 assert.equal(extension.getSelection().interface, 'default', 'unsupported local fonts use in-memory defaults');
 assert.equal(writes.length, 0, 'unsupported local fonts do not overwrite persisted selection');
 

--- a/tests/compatibility/test_typography_smoke.py
+++ b/tests/compatibility/test_typography_smoke.py
@@ -1,0 +1,26 @@
+import unittest
+
+from browser_smoke import EXPECTED_CORE_BASELINE_REQUESTS
+from typography_smoke import _filtered_unexpected_http
+
+
+class TypographyNetworkFilterTests(unittest.TestCase):
+    def test_only_one_exact_core_reload_is_filtered_per_url(self) -> None:
+        url, (resource_type, max_occurrences) = next(iter(EXPECTED_CORE_BASELINE_REQUESTS.items()))
+        reload_event = {
+            "url": url,
+            "method": "GET",
+            "resource_type": resource_type,
+            "occurrence": max_occurrences + 1,
+        }
+        wrong_method = {**reload_event, "method": "POST"}
+
+        self.assertEqual(
+            _filtered_unexpected_http([reload_event, reload_event, wrong_method], True),
+            [reload_event, wrong_method],
+        )
+        self.assertEqual(_filtered_unexpected_http([reload_event], False), [reload_event])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/compatibility/typography_smoke.py
+++ b/tests/compatibility/typography_smoke.py
@@ -522,9 +522,46 @@ def _mobile_flow(base_url: str, evidence_dir: Path, browser: Any) -> dict[str, A
     screenshot = evidence_dir / "typography-mobile.png"
     try:
         _boot_page(page, base_url)
-        page.evaluate("() => window.HermesTypographyExtension.open(document.getElementById('hwx-type-rail-button'))")
-        page.locator("#hwx-type-panel").wait_for(state="visible", timeout=5_000)
-        _record_screenshot(page, screenshot)
+        mirror = page.locator(
+            '.sidebar-nav [data-nav-action-mirror="hwx-type-rail-button"]'
+        )
+        mirror.wait_for(state="attached", timeout=15_000)
+        menu = page.locator("#btnHamburger")
+        menu.wait_for(state="visible", timeout=5_000)
+        page.evaluate(
+            """
+            () => {
+              window.__typographyListenerStats = {add: 0, remove: 0};
+              const add = document.addEventListener;
+              const remove = document.removeEventListener;
+              document.addEventListener = function(type, listener, options) {
+                if (type === 'keydown') window.__typographyListenerStats.add += 1;
+                return add.call(this, type, listener, options);
+              };
+              document.removeEventListener = function(type, listener, options) {
+                if (type === 'keydown') window.__typographyListenerStats.remove += 1;
+                return remove.call(this, type, listener, options);
+              };
+            }
+            """
+        )
+        for attempt in range(2):
+            menu.click()
+            page.locator(".sidebar.mobile-open").wait_for(state="visible", timeout=5_000)
+            mirror.wait_for(state="visible", timeout=5_000)
+            mirror.click()
+            page.locator("#hwx-type-panel").wait_for(state="visible", timeout=5_000)
+            if page.locator("#hwx-type-panel").count() != 1:
+                raise CompatibilityFailure("mobile mirror open created a duplicate panel")
+            if attempt == 0:
+                _record_screenshot(page, screenshot)
+            page.get_by_role("button", name="Close typography").click()
+            page.locator("#hwx-type-panel").wait_for(state="detached", timeout=5_000)
+            if not mirror.evaluate("mirror => document.activeElement === mirror"):
+                raise CompatibilityFailure("mobile close did not restore focus to the mobile mirror")
+        listener_stats = page.evaluate("() => window.__typographyListenerStats")
+        if listener_stats != {"add": 2, "remove": 2}:
+            raise CompatibilityFailure(f"mobile panel listener lifecycle duplicated: {listener_stats!r}")
         _assert_typography_health(
             case_name="typography-mobile",
             console_errors=console_errors,

--- a/tests/compatibility/typography_smoke.py
+++ b/tests/compatibility/typography_smoke.py
@@ -557,8 +557,28 @@ def _mobile_flow(base_url: str, evidence_dir: Path, browser: Any) -> dict[str, A
                 _record_screenshot(page, screenshot)
             page.get_by_role("button", name="Close typography").click()
             page.locator("#hwx-type-panel").wait_for(state="detached", timeout=5_000)
-            if not mirror.evaluate("mirror => document.activeElement === mirror"):
-                raise CompatibilityFailure("mobile close did not restore focus to the mobile mirror")
+            focus_state = page.evaluate(
+                """
+                () => {
+                  const target = document.activeElement;
+                  const rect = target && target.getBoundingClientRect();
+                  return {
+                    id: target && target.id,
+                    renderable: Boolean(target && target.isConnected && target.getClientRects().length),
+                    intersectsViewport: Boolean(
+                      rect && rect.left < window.innerWidth && rect.right > 0
+                      && rect.top < window.innerHeight && rect.bottom > 0
+                    ),
+                  };
+                }
+                """
+            )
+            if focus_state != {
+                "id": "btnHamburger",
+                "renderable": True,
+                "intersectsViewport": True,
+            }:
+                raise CompatibilityFailure(f"mobile close focus target was not visible hamburger: {focus_state!r}")
         listener_stats = page.evaluate("() => window.__typographyListenerStats")
         if listener_stats != {"add": 2, "remove": 2}:
             raise CompatibilityFailure(f"mobile panel listener lifecycle duplicated: {listener_stats!r}")

--- a/tests/compatibility/typography_smoke.py
+++ b/tests/compatibility/typography_smoke.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""Real-browser lifecycle smoke for the Typography extension."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import shutil
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from typing import Any
+
+try:
+    from browser_smoke import (
+        CompatibilityFailure,
+        EXPECTED_CORE_BASELINE_REQUESTS,
+        SetupFailure,
+        _assert_browser_health,
+        _install_network_guards,
+        _record_screenshot,
+        _start_server,
+        _terminate,
+        _write_json,
+    )
+except ModuleNotFoundError:  # pragma: no cover - supports module execution.
+    from tests.compatibility.browser_smoke import (
+        CompatibilityFailure,
+        EXPECTED_CORE_BASELINE_REQUESTS,
+        SetupFailure,
+        _assert_browser_health,
+        _install_network_guards,
+        _record_screenshot,
+        _start_server,
+        _terminate,
+        _write_json,
+    )
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_VIEWPORT = {"width": 1440, "height": 1000}
+MOBILE_VIEWPORT = {"width": 390, "height": 844}
+EXTENSION_RESOURCES = (
+    "/extensions/typography/assets/typography.js",
+    "/extensions/typography/assets/typography.css",
+)
+GOOGLE_CSS_PREFIX = "https://fonts.googleapis.com/css2"
+FONT_CANDIDATES = (
+    "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/liberation2/LiberationSerif-Regular.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSerif-Regular.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--core-dir",
+        default=os.environ.get("HERMES_CORE_DIR", ""),
+        help="independent Hermes WebUI Core checkout (or HERMES_CORE_DIR)",
+    )
+    parser.add_argument(
+        "--extension-root",
+        default=os.environ.get("HERMES_EXTENSION_ROOT", str(REPO_ROOT / "extensions")),
+        help="extension source root (default: this checkout's extensions/)",
+    )
+    parser.add_argument(
+        "--evidence-dir",
+        default=os.environ.get(
+            "COMPATIBILITY_EVIDENCE_DIR",
+            str(REPO_ROOT / ".compatibility-evidence"),
+        ),
+        help="directory for screenshots and results JSON",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("HERMES_COMPATIBILITY_PORT", "0") or "0"),
+        help="optional fixed non-production port; 0 chooses a free ephemeral port",
+    )
+    return parser.parse_args()
+
+
+def _find_fonts() -> tuple[Path, Path]:
+    found = [Path(candidate) for candidate in FONT_CANDIDATES if Path(candidate).is_file()]
+    if not found:
+        raise SetupFailure(f"no installed Liberation/DejaVu font found in {FONT_CANDIDATES!r}")
+    first = found[0]
+    second = next((candidate for candidate in found[1:] if candidate.stat().st_size != first.stat().st_size), None)
+    if second is None:
+        raise SetupFailure("two installed Liberation/DejaVu fonts with distinct sizes are required")
+    return first, second
+
+
+def _new_page(browser: Any, viewport: dict[str, int], init_script: str | None = None) -> tuple[Any, Any, list[dict[str, str]], list[str], dict[str, list[dict[str, Any]]]]:
+    context = browser.new_context(
+        viewport=viewport,
+        is_mobile=viewport == MOBILE_VIEWPORT,
+        service_workers="block",
+    )
+    if init_script:
+        context.add_init_script(init_script)
+    network_events = _install_network_guards(context)
+    page = context.new_page()
+    console_errors: list[dict[str, str]] = []
+    page_errors: list[str] = []
+
+    def on_console(message: Any) -> None:
+        if message.type != "error":
+            return
+        location = getattr(message, "location", {}) or {}
+        location_url = location.get("url", "") if isinstance(location, dict) else getattr(location, "url", "")
+        console_errors.append({"text": str(message.text), "url": str(location_url)})
+
+    page.on("console", on_console)
+    page.on("pageerror", lambda error: page_errors.append(str(error)))
+    return context, page, console_errors, page_errors, network_events
+
+
+def _is_google_css_event(event: dict[str, Any]) -> bool:
+    return str(event.get("url", "")).startswith(GOOGLE_CSS_PREFIX)
+
+
+def _is_expected_core_reload(event: dict[str, Any]) -> bool:
+    expected = EXPECTED_CORE_BASELINE_REQUESTS.get(str(event.get("url", "")))
+    return bool(
+        expected
+        and event.get("method") == "GET"
+        and event.get("resource_type") == expected[0]
+        and event.get("occurrence") == expected[1] + 1
+    )
+
+
+def _filtered_unexpected_http(events: list[dict[str, Any]], allow_core_reload: bool) -> list[dict[str, Any]]:
+    filtered = []
+    allowed_reload_urls = set()
+    for event in events:
+        if _is_google_css_event(event):
+            continue
+        url = str(event.get("url", ""))
+        if allow_core_reload and url not in allowed_reload_urls and _is_expected_core_reload(event):
+            allowed_reload_urls.add(url)
+            continue
+        filtered.append(event)
+    return filtered
+
+
+def _assert_typography_health(
+    *,
+    case_name: str,
+    console_errors: list[dict[str, str]],
+    page_errors: list[str],
+    network_events: dict[str, list[dict[str, Any]]],
+    allow_core_reload: bool = False,
+) -> None:
+    # Google CSS is deliberately blocked and expected; every other off-origin
+    # request remains a failure through the shared deny-by-default guard.
+    filtered_console = [
+        entry for entry in console_errors
+        if not str(entry.get("url", "")).startswith(GOOGLE_CSS_PREFIX)
+    ]
+    filtered_network = {key: list(value) for key, value in network_events.items()}
+    filtered_network["unexpected_http"] = _filtered_unexpected_http(
+        filtered_network.get("unexpected_http", []),
+        allow_core_reload,
+    )
+    _assert_browser_health(
+        case_name=case_name,
+        console_errors=filtered_console,
+        page_errors=page_errors,
+        extension_fragments=EXTENSION_RESOURCES,
+        network_events=filtered_network,
+    )
+
+
+def _network_summary(events: dict[str, list[dict[str, Any]]]) -> dict[str, int]:
+    return {
+        "blocked_http": len(events.get("blocked_http", [])),
+        "unexpected_http": len(events.get("unexpected_http", [])),
+        "blocked_websockets": len(events.get("blocked_websockets", [])),
+        "google_css_requests": sum(
+            1 for event in events.get("blocked_http", []) if _is_google_css_event(event)
+        ),
+    }
+
+
+def _boot_page(page: Any, base_url: str) -> None:
+    page.goto(f"{base_url}/", wait_until="domcontentloaded", timeout=30_000)
+    try:
+        page.wait_for_load_state("networkidle", timeout=8_000)
+    except Exception:
+        pass
+    page.wait_for_function(
+        "resources => resources.every(resource => performance.getEntriesByType('resource').some(entry => entry.name.includes(resource)))",
+        arg=list(EXTENSION_RESOURCES),
+        timeout=15_000,
+    )
+    page.locator("#hwx-type-rail-button").wait_for(state="attached", timeout=15_000)
+
+
+def _open_panel(page: Any) -> None:
+    page.locator("#hwx-type-rail-button").click()
+    page.locator("#hwx-type-panel").wait_for(state="visible", timeout=5_000)
+
+
+def _wait_for_status(page: Any, expected: str, *, contains: bool = False) -> None:
+    expression = (
+        "expected => { const node = document.querySelector('#hwx-type-local-status'); "
+        "return node && (expected ? "
+        "(node.textContent || '').includes(expected) : !(node.textContent || '').trim()); }"
+        if contains
+        else "expected => { const node = document.querySelector('#hwx-type-local-status'); return node && (node.textContent || '') === expected; }"
+    )
+    page.wait_for_function(expression, arg=expected, timeout=10_000)
+
+
+def _db_summary(page: Any) -> dict[str, Any]:
+    return page.evaluate(
+        """
+        () => new Promise((resolve, reject) => {
+          const request = indexedDB.open('hermes-ext-typography-fonts', 1);
+          request.onerror = () => reject(request.error || new Error('database summary open failed'));
+          request.onupgradeneeded = () => {
+            if (!request.result.objectStoreNames.contains('hermes-ext-typography-font-records')) {
+              request.result.createObjectStore('hermes-ext-typography-font-records', {keyPath: 'id'});
+            }
+          };
+          request.onsuccess = () => {
+            const database = request.result;
+            const transaction = database.transaction('hermes-ext-typography-font-records', 'readonly');
+            const cursorRequest = transaction.objectStore('hermes-ext-typography-font-records').openCursor();
+            let count = 0;
+            let totalBytes = 0;
+            let updatedAt = [];
+            cursorRequest.onerror = () => reject(cursorRequest.error || new Error('database summary cursor failed'));
+            cursorRequest.onsuccess = () => {
+              const cursor = cursorRequest.result;
+              if (!cursor) return;
+              const value = cursor.value || {};
+              count += 1;
+              totalBytes += value.bytes && Number.isFinite(value.bytes.byteLength) ? value.bytes.byteLength : 0;
+              updatedAt.push(Number.isFinite(value.updatedAt) ? value.updatedAt : 0);
+              cursor.continue();
+            };
+            transaction.oncomplete = () => {
+              database.close();
+              resolve({count, totalBytes, updatedAt});
+            };
+            transaction.onerror = () => reject(transaction.error || new Error('database summary transaction failed'));
+          };
+        })
+        """
+    )
+
+
+def _local_face_count(page: Any) -> int:
+    return int(
+        page.evaluate(
+            """
+            () => Array.from(document.fonts || []).filter(face =>
+              String(face.family || '').includes('HermesTypographyLocal_')).length
+            """
+        )
+    )
+
+
+def _local_option_values(page: Any) -> list[str]:
+    return list(
+        page.evaluate(
+            """
+            () => Array.from(document.querySelectorAll('#hwx-type-interface optgroup option'))
+              .map(option => option.value)
+            """
+        )
+    )
+
+
+def _selection(page: Any) -> dict[str, str]:
+    return dict(page.evaluate("() => window.HermesTypographyExtension.getSelection()"))
+
+
+def _local_snapshot(page: Any) -> dict[str, Any]:
+    return {
+        "database": _db_summary(page),
+        "face_count": _local_face_count(page),
+        "selection": _selection(page),
+    }
+
+
+def _assert_same_local_snapshot(before: dict[str, Any], after: dict[str, Any], label: str) -> None:
+    if before["database"] != after["database"]:
+        raise CompatibilityFailure(f"{label}: IndexedDB changed unexpectedly")
+    if before["face_count"] != after["face_count"]:
+        raise CompatibilityFailure(f"{label}: registered FontFace state changed unexpectedly")
+    if before["selection"] != after["selection"]:
+        raise CompatibilityFailure(f"{label}: selection changed unexpectedly")
+
+
+def _replace(page: Any, font_path: Path) -> None:
+    with page.expect_file_chooser() as chooser_info:
+        page.get_by_role("button", name="Replace").click()
+    chooser_info.value.set_files(str(font_path))
+
+
+def _main_flow(base_url: str, evidence_dir: Path, browser: Any, first_font: Path, second_font: Path) -> dict[str, Any]:
+    context, page, console_errors, page_errors, network_events = _new_page(browser, DESKTOP_VIEWPORT)
+    screenshot = evidence_dir / "typography-desktop.png"
+    try:
+        _boot_page(page, base_url)
+        default_tokens = page.evaluate(
+            """() => ['--font-ui', '--font-conversation', '--font-mono'].map(name =>
+              document.documentElement.style.getPropertyValue(name).trim())"""
+        )
+        if default_tokens != ["", "", ""]:
+            raise CompatibilityFailure(f"default root tokens were not removed: {default_tokens!r}")
+        if page.locator("#hwx-type-google-fonts").count() != 0:
+            raise CompatibilityFailure("default choices created a Google stylesheet")
+        if _network_summary(network_events).get("google_css_requests", 0):
+            raise CompatibilityFailure("default choices requested Google CSS")
+
+        page.evaluate(
+            """
+            () => {
+              window.__typographyListenerStats = {add: 0, remove: 0};
+              const add = document.addEventListener;
+              const remove = document.removeEventListener;
+              document.addEventListener = function(type, listener, options) {
+                if (type === 'keydown') window.__typographyListenerStats.add += 1;
+                return add.call(this, type, listener, options);
+              };
+              document.removeEventListener = function(type, listener, options) {
+                if (type === 'keydown') window.__typographyListenerStats.remove += 1;
+                return remove.call(this, type, listener, options);
+              };
+            }
+            """
+        )
+        rail = page.locator("#hwx-type-rail-button")
+        rail.click()
+        page.locator("#hwx-type-panel").wait_for(state="visible")
+        page.evaluate("() => window.HermesTypographyExtension.open(document.getElementById('hwx-type-rail-button'))")
+        if page.locator("#hwx-type-panel").count() != 1:
+            raise CompatibilityFailure("repeated panel open created a duplicate panel")
+        page.get_by_role("button", name="Close typography").click()
+        page.locator("#hwx-type-panel").wait_for(state="detached")
+        rail.click()
+        page.locator("#hwx-type-panel").wait_for(state="visible")
+        listener_stats = page.evaluate("() => window.__typographyListenerStats")
+        if listener_stats != {"add": 2, "remove": 1}:
+            raise CompatibilityFailure(f"panel listener lifecycle duplicated: {listener_stats!r}")
+
+        page.select_option("#hwx-type-interface", "courier-prime")
+        page.select_option("#hwx-type-conversation", "bitter")
+        page.select_option("#hwx-type-code", "space-mono")
+        link = page.locator("#hwx-type-google-fonts")
+        link.wait_for(state="attached")
+        href = link.get_attribute("href") or ""
+        if page.locator("#hwx-type-google-fonts").count() != 1 or any(
+            family not in href for family in ("Courier+Prime", "Bitter", "Space+Mono")
+        ):
+            raise CompatibilityFailure(f"hosted font stylesheet was not deduplicated: {href!r}")
+        page.wait_for_timeout(250)
+        if _network_summary(network_events)["google_css_requests"] < 1:
+            raise CompatibilityFailure("hosted font stylesheet was not intercepted as an off-origin request")
+        tokens = page.evaluate(
+            """() => ['--font-ui', '--font-conversation', '--font-mono'].map(name =>
+              document.documentElement.style.getPropertyValue(name))"""
+        )
+        if not all(expected in actual for expected, actual in zip(("Courier Prime", "Bitter", "Space Mono"), tokens)):
+            raise CompatibilityFailure(f"role root tokens were not applied: {tokens!r}")
+        page.select_option("#hwx-type-preset", "webui-default")
+        page.locator("#hwx-type-google-fonts").wait_for(state="detached")
+        default_tokens = page.evaluate(
+            """() => ['--font-ui', '--font-conversation', '--font-mono'].map(name =>
+              document.documentElement.style.getPropertyValue(name).trim())"""
+        )
+        if default_tokens != ["", "", ""]:
+            raise CompatibilityFailure(f"returning to defaults kept root tokens: {default_tokens!r}")
+
+        page.locator("#hwx-type-import:not([disabled])").wait_for(state="visible", timeout=10_000)
+        page.locator("#hwx-type-local-file").set_input_files(str(first_font))
+        page.wait_for_function(
+            "() => document.querySelectorAll('#hwx-type-local-list .hwx-type-local-item').length === 1",
+            timeout=15_000,
+        )
+        _wait_for_status(page, "")
+        local_value = _local_option_values(page)[0]
+        for role in ("interface", "conversation", "code"):
+            if page.locator(f"#hwx-type-{role} optgroup option").count() != 1:
+                raise CompatibilityFailure(f"imported font missing from {role} selector")
+        page.select_option("#hwx-type-interface", local_value)
+        if _selection(page)["interface"] != local_value:
+            raise CompatibilityFailure("local selection was not applied")
+        persisted = _db_summary(page)
+        if persisted["count"] != 1 or persisted["totalBytes"] != first_font.stat().st_size:
+            raise CompatibilityFailure(f"imported font was not persisted: {persisted!r}")
+        if _local_face_count(page) != 1:
+            raise CompatibilityFailure("imported FontFace was not registered")
+        _record_screenshot(page, screenshot)
+
+        page.reload(wait_until="domcontentloaded", timeout=30_000)
+        page.locator("#hwx-type-rail-button").wait_for(state="visible", timeout=15_000)
+        _open_panel(page)
+        page.locator("#hwx-type-import:not([disabled])").wait_for(state="visible", timeout=10_000)
+        if local_value not in _local_option_values(page) or _selection(page)["interface"] != local_value:
+            raise CompatibilityFailure("reload did not restore the IndexedDB font and selection")
+        if _local_face_count(page) != 1:
+            raise CompatibilityFailure("reload did not activate the persisted FontFace")
+
+        page.evaluate(
+            """
+            () => {
+              const prototype = Object.getPrototypeOf(document.fonts);
+              window.__typographyFontDeleteCalls = 0;
+              window.__typographyOriginalFontDelete = prototype.delete;
+              prototype.delete = function(face) {
+                window.__typographyFontDeleteCalls += 1;
+                return window.__typographyOriginalFontDelete.call(this, face);
+              };
+            }
+            """
+        )
+        delete_calls_before_replace = page.evaluate("() => window.__typographyFontDeleteCalls")
+        _replace(page, second_font)
+        _wait_for_status(page, "Font replaced.", contains=True)
+        replaced = _db_summary(page)
+        if replaced["count"] != 1 or replaced["totalBytes"] != second_font.stat().st_size:
+            raise CompatibilityFailure(f"replacement was not persisted: {replaced!r}")
+        if _selection(page)["interface"] != local_value or _local_face_count(page) != 1:
+            raise CompatibilityFailure("replacement changed the active selection or face count")
+        if page.evaluate("() => window.__typographyFontDeleteCalls") <= delete_calls_before_replace:
+            raise CompatibilityFailure("replacement did not clean up the previous FontFace")
+
+        before_unavailable = _local_snapshot(page)
+        page.evaluate("() => { window.__typographySavedConfirm = window.confirm; window.confirm = undefined; }")
+        page.get_by_role("button", name="Delete").click()
+        _wait_for_status(page, "Deleting is unavailable in this browser.")
+        _assert_same_local_snapshot(before_unavailable, _local_snapshot(page), "missing confirmation")
+        page.evaluate(
+            """() => {
+              document.querySelector('#hwx-type-local-status').textContent = 'Awaiting throwing confirmation.';
+              window.confirm = () => { throw new Error('blocked'); };
+            }"""
+        )
+        page.get_by_role("button", name="Delete").click()
+        _wait_for_status(page, "Deleting is unavailable in this browser.")
+        _assert_same_local_snapshot(before_unavailable, _local_snapshot(page), "throwing confirmation")
+        page.evaluate("() => { window.confirm = () => false; }")
+        page.get_by_role("button", name="Delete").click()
+        page.wait_for_timeout(100)
+        _assert_same_local_snapshot(before_unavailable, _local_snapshot(page), "cancelled deletion")
+        page.evaluate("() => { window.confirm = window.__typographySavedConfirm; }")
+        page.once("dialog", lambda dialog: dialog.accept())
+        page.get_by_role("button", name="Delete").click()
+        page.wait_for_function(
+            "() => document.querySelectorAll('#hwx-type-local-list .hwx-type-local-item').length === 0",
+            timeout=10_000,
+        )
+        if _db_summary(page)["count"] != 0 or _local_face_count(page) != 0:
+            raise CompatibilityFailure("confirmed deletion did not remove storage and FontFace")
+        if _selection(page)["interface"] != "default":
+            raise CompatibilityFailure("confirmed deletion did not clear the local selection")
+        _assert_typography_health(
+            case_name="typography-main",
+            console_errors=console_errors,
+            page_errors=page_errors,
+            network_events=network_events,
+            allow_core_reload=True,
+        )
+        return {
+            "status": "passed",
+            "checks": [
+                "defaults/root-tokens",
+                "hosted-stylesheet/network-block",
+                "import/persistence/reload",
+                "replacement/fontface-cleanup",
+                "delete-unavailable/cancel/confirm",
+                "panel-deduplication/listeners",
+            ],
+            "screenshot": screenshot.name,
+        }
+    except Exception:
+        _record_screenshot(page, screenshot)
+        raise
+    finally:
+        context.close()
+
+
+def _mobile_flow(base_url: str, evidence_dir: Path, browser: Any) -> dict[str, Any]:
+    context, page, console_errors, page_errors, network_events = _new_page(browser, MOBILE_VIEWPORT)
+    screenshot = evidence_dir / "typography-mobile.png"
+    try:
+        _boot_page(page, base_url)
+        page.evaluate("() => window.HermesTypographyExtension.open(document.getElementById('hwx-type-rail-button'))")
+        page.locator("#hwx-type-panel").wait_for(state="visible", timeout=5_000)
+        _record_screenshot(page, screenshot)
+        _assert_typography_health(
+            case_name="typography-mobile",
+            console_errors=console_errors,
+            page_errors=page_errors,
+            network_events=network_events,
+        )
+        return {"status": "passed", "screenshot": screenshot.name}
+    except Exception:
+        _record_screenshot(page, screenshot)
+        raise
+    finally:
+        context.close()
+
+
+def _open_failure_flow(base_url: str, browser: Any) -> dict[str, Any]:
+    context, page, console_errors, page_errors, network_events = _new_page(
+        browser,
+        DESKTOP_VIEWPORT,
+        """
+        (() => {
+          const originalOpen = window.indexedDB.open.bind(window.indexedDB);
+          window.indexedDB.open = function() {
+            throw new Error('Injected IndexedDB open failure.');
+          };
+          window.__typographyOriginalOpen = originalOpen;
+        })();
+        """,
+    )
+    try:
+        _boot_page(page, base_url)
+        _open_panel(page)
+        _wait_for_status(page, "could not open IndexedDB", contains=True)
+        if not page.locator("#hwx-type-import").is_disabled():
+            raise CompatibilityFailure("IndexedDB open failure left import enabled")
+        if page.locator("#hwx-type-local-list .hwx-type-local-item").count() != 0:
+            raise CompatibilityFailure("IndexedDB open failure exposed stored records")
+        _assert_typography_health(
+            case_name="typography-open-failure",
+            console_errors=console_errors,
+            page_errors=page_errors,
+            network_events=network_events,
+        )
+        return {"status": "passed", "checks": ["graceful-indexeddb-open-failure"]}
+    finally:
+        context.close()
+
+
+def _write_failure_flow(base_url: str, browser: Any, first_font: Path, second_font: Path) -> dict[str, Any]:
+    context, page, console_errors, page_errors, network_events = _new_page(browser, DESKTOP_VIEWPORT)
+    try:
+        _boot_page(page, base_url)
+        _open_panel(page)
+        page.locator("#hwx-type-import:not([disabled])").wait_for(state="visible", timeout=10_000)
+        page.locator("#hwx-type-local-file").set_input_files(str(first_font))
+        page.wait_for_function(
+            "() => document.querySelectorAll('#hwx-type-local-list .hwx-type-local-item').length === 1",
+            timeout=15_000,
+        )
+        page.evaluate(
+            """
+            () => {
+              const prototype = Object.getPrototypeOf(document.fonts);
+              window.__typographyFontDeleteCalls = 0;
+              window.__typographyOriginalFontDelete = prototype.delete;
+              prototype.delete = function(face) {
+                window.__typographyFontDeleteCalls += 1;
+                return window.__typographyOriginalFontDelete.call(this, face);
+              };
+              window.__typographyOriginalPut = IDBObjectStore.prototype.put;
+              IDBObjectStore.prototype.put = function() {
+                throw new Error('Injected IndexedDB write failure.');
+              };
+            }
+            """
+        )
+        _replace(page, second_font)
+        _wait_for_status(page, "Injected IndexedDB write failure.", contains=True)
+        failed = _db_summary(page)
+        if failed["count"] != 1 or failed["totalBytes"] != first_font.stat().st_size:
+            raise CompatibilityFailure(f"failed replacement changed the prior record: {failed!r}")
+        if _local_face_count(page) != 1:
+            raise CompatibilityFailure("failed replacement did not preserve the prior FontFace")
+        if page.evaluate("() => window.__typographyFontDeleteCalls") < 1:
+            raise CompatibilityFailure("failed replacement did not clean up its new FontFace")
+
+        page.evaluate("() => { IDBObjectStore.prototype.put = window.__typographyOriginalPut; }")
+        page.reload(wait_until="domcontentloaded", timeout=30_000)
+        page.locator("#hwx-type-rail-button").wait_for(state="visible", timeout=15_000)
+        _open_panel(page)
+        page.locator("#hwx-type-import:not([disabled])").wait_for(state="visible", timeout=10_000)
+        page.evaluate(
+            """
+            () => {
+              window.__typographyOriginalPut = IDBObjectStore.prototype.put;
+              IDBObjectStore.prototype.put = function() {
+                throw new Error('Injected IndexedDB import write failure.');
+              };
+            }
+            """
+        )
+        # The existing record is replaced only after a successful put; this
+        # import failure is checked on a fresh ID so it cannot alter the record.
+        page.locator("#hwx-type-local-file").set_input_files(str(second_font))
+        _wait_for_status(page, "Injected IndexedDB import write failure.", contains=True)
+        if _db_summary(page)["count"] != 1 or _local_face_count(page) != 1:
+            raise CompatibilityFailure("failed import did not leave existing storage and face intact")
+        page.evaluate("() => { IDBObjectStore.prototype.put = window.__typographyOriginalPut; }")
+        _assert_typography_health(
+            case_name="typography-write-failure",
+            console_errors=console_errors,
+            page_errors=page_errors,
+            network_events=network_events,
+            allow_core_reload=True,
+        )
+        return {
+            "status": "passed",
+            "checks": ["failed-replacement-preservation", "failed-import-preservation"],
+        }
+    finally:
+        context.close()
+
+
+def _seed_overflow_database(page: Any, font_path: Path) -> None:
+    valid_bytes = base64.b64encode(font_path.read_bytes()).decode("ascii")
+    invalid_bytes = base64.b64encode(bytes((1, 2, 3, 4))).decode("ascii")
+    page.evaluate(
+        """
+        ({records}) => new Promise((resolve, reject) => {
+          const request = indexedDB.open('hermes-ext-typography-fonts', 1);
+          request.onerror = () => reject(request.error || new Error('seed database open failed'));
+          request.onupgradeneeded = () => {
+            request.result.createObjectStore('hermes-ext-typography-font-records', {keyPath: 'id'});
+          };
+          request.onsuccess = () => {
+            const database = request.result;
+            const transaction = database.transaction('hermes-ext-typography-font-records', 'readwrite');
+            const store = transaction.objectStore('hermes-ext-typography-font-records');
+            for (const record of records) {
+              const binary = Uint8Array.from(atob(record.bytesBase64), character => character.charCodeAt(0)).buffer;
+              store.put({
+                id: record.id,
+                name: record.name,
+                format: 'ttf',
+                bytes: binary,
+                createdAt: 1,
+                updatedAt: 1,
+              });
+            }
+            transaction.oncomplete = () => { database.close(); resolve(); };
+            transaction.onerror = () => reject(transaction.error || new Error('seed database transaction failed'));
+          };
+        })
+        """,
+        {"records": [
+            {"id": "font-01", "name": "Retained font", "bytesBase64": valid_bytes},
+            *[
+                {"id": f"font-{index:02d}", "name": f"Unavailable {index}", "bytesBase64": invalid_bytes}
+                for index in range(2, 10)
+            ],
+        ]},
+    )
+
+
+def _overflow_flow(base_url: str, browser: Any, evidence_dir: Path, first_font: Path) -> dict[str, Any]:
+    context, page, console_errors, page_errors, network_events = _new_page(browser, DESKTOP_VIEWPORT)
+    screenshot = evidence_dir / "typography-overflow.png"
+    try:
+        page.goto(f"{base_url}/health", wait_until="domcontentloaded", timeout=15_000)
+        _seed_overflow_database(page, first_font)
+        _boot_page(page, base_url)
+        _open_panel(page)
+        _wait_for_status(page, "Extra stored fonts were not loaded", contains=True)
+        status = page.locator("#hwx-type-local-status").text_content() or ""
+        if "browser site-data controls" not in status or "New imports and replacements" not in status:
+            raise CompatibilityFailure(f"overflow status was not actionable: {status!r}")
+        if not page.locator("#hwx-type-import").is_disabled():
+            raise CompatibilityFailure("overflow database left import enabled")
+        if page.locator("#hwx-type-local-list .hwx-type-local-item").count() != 8:
+            raise CompatibilityFailure("overflow startup retained an unbounded or incomplete record list")
+        if len(_local_option_values(page)) != 1 or _local_face_count(page) != 1:
+            raise CompatibilityFailure("the retained in-cap font was not usable after overflow startup")
+        stored = _db_summary(page)
+        if stored["count"] != 9:
+            raise CompatibilityFailure("overflow startup deleted or hid database records")
+        _record_screenshot(page, screenshot)
+        _assert_typography_health(
+            case_name="typography-overflow",
+            console_errors=console_errors,
+            page_errors=page_errors,
+            network_events=network_events,
+        )
+        return {"status": "passed", "checks": ["bounded-overflow-startup"], "screenshot": screenshot.name}
+    except Exception:
+        _record_screenshot(page, screenshot)
+        raise
+    finally:
+        context.close()
+
+
+def main() -> int:
+    args = _parse_args()
+    evidence_dir = Path(args.evidence_dir).expanduser().resolve()
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    results: dict[str, Any] = {"status": "running", "cases": {}}
+    results_path = evidence_dir / "typography-results.json"
+    proc = None
+    log_file = None
+    try:
+        core_dir = Path(args.core_dir).expanduser().resolve()
+        extension_root = Path(args.extension_root).expanduser().resolve()
+        if not core_dir.is_dir():
+            raise SetupFailure("HERMES_CORE_DIR/--core-dir must point to an independent Hermes WebUI checkout")
+        source_dir = extension_root / "typography"
+        if not source_dir.is_dir():
+            raise SetupFailure(f"Typography extension directory not found: {source_dir}")
+        first_font, second_font = _find_fonts()
+
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise SetupFailure("Playwright is required; install tests/compatibility/requirements.txt") from exc
+
+        with tempfile.TemporaryDirectory(prefix="hermes-typography-compat-") as temp:
+            temp_root = Path(temp)
+            bundle_root = temp_root / "typography-bundle"
+            shutil.copytree(source_dir, bundle_root / "typography")
+            state_root = temp_root / "state"
+            proc, log_file, base_url, port = _start_server(
+                core_dir=core_dir,
+                extension_root=bundle_root,
+                manifest_relative="typography/manifest.json",
+                state_root=state_root,
+                log_path=temp_root / "typography-server.log",
+                requested_port=args.port,
+            )
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch(
+                    headless=True,
+                    args=["--no-sandbox", "--disable-dev-shm-usage"],
+                )
+                try:
+                    main_result = _main_flow(base_url, evidence_dir, browser, first_font, second_font)
+                    results["cases"]["main"] = {**main_result, "port": port}
+                    results["cases"]["mobile"] = _mobile_flow(base_url, evidence_dir, browser)
+                    results["cases"]["open-failure"] = _open_failure_flow(base_url, browser)
+                    results["cases"]["write-failure"] = _write_failure_flow(base_url, browser, first_font, second_font)
+                    results["cases"]["overflow"] = _overflow_flow(base_url, browser, evidence_dir, first_font)
+                finally:
+                    browser.close()
+        results["status"] = "passed"
+        _write_json(results_path, results)
+        print("TYPOGRAPHY COMPATIBILITY PASSED")
+        print(f"evidence={evidence_dir}")
+        return 0
+    except SetupFailure as exc:
+        results["status"] = "setup_failure"
+        results["error"] = str(exc)
+        _write_json(results_path, results)
+        print(f"SETUP FAILURE: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 2
+    except CompatibilityFailure as exc:
+        results["status"] = "failed"
+        results["error"] = str(exc)
+        results["traceback"] = traceback.format_exc()
+        _write_json(results_path, results)
+        print(f"TYPOGRAPHY COMPATIBILITY FAILED: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        results["status"] = "harness_error"
+        results["error"] = f"{type(exc).__name__}: {exc}"
+        results["traceback"] = traceback.format_exc()
+        _write_json(results_path, results)
+        print(f"HARNESS ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 2
+    finally:
+        _terminate(proc, log_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/compatibility/typography_smoke.py
+++ b/tests/compatibility/typography_smoke.py
@@ -373,6 +373,32 @@ def _main_flow(base_url: str, evidence_dir: Path, browser: Any, first_font: Path
         )
         if not all(expected in actual for expected, actual in zip(("Courier Prime", "Bitter", "Space Mono"), tokens)):
             raise CompatibilityFailure(f"role root tokens were not applied: {tokens!r}")
+        # Prove Core actually CONSUMES --font-conversation, not merely that the
+        # extension wrote the inline custom property. Core's base rule
+        # `.msg-body{font-family:var(--font-conversation);...}` (static/style.css)
+        # is global, so a probe element carrying that class resolves its computed
+        # font-family from the token this extension set. Asserting the inline
+        # property alone would pass even against a Core that predates the
+        # three-font contract (the vacuous-gate that let a stale Core pin slip by).
+        consumed = page.evaluate(
+            """() => {
+              const probe = document.createElement('div');
+              probe.className = 'msg-body';
+              probe.style.position = 'absolute';
+              probe.style.left = '-9999px';
+              probe.textContent = 'x';
+              document.body.appendChild(probe);
+              const family = getComputedStyle(probe).fontFamily;
+              probe.remove();
+              return family;
+            }"""
+        )
+        if "Bitter" not in consumed:
+            raise CompatibilityFailure(
+                "Core did not consume --font-conversation on .msg-body "
+                f"(computed font-family={consumed!r}); the pinned Core likely "
+                "predates the three-font contract (#5918)"
+            )
         page.select_option("#hwx-type-preset", "webui-default")
         page.locator("#hwx-type-google-fonts").wait_for(state="detached")
         default_tokens = page.evaluate(


### PR DESCRIPTION
## Summary

- Add a **Typography** rail editor for choosing interface, conversation, and code fonts through Core's `--font-ui`, `--font-conversation`, and `--font-mono` tokens.
- Provide curated role-specific Google Fonts, curated presets, live previews, and selected-family CSS loading.
- Support browser-local `.woff2`, `.woff`, `.ttf`, and `.otf` imports with IndexedDB persistence, preview, rename, replacement, and deletion.
- Bound local storage to 8 fonts, 10 MiB per file, and 40 MiB total. Startup uses cursor-based bounded loading and preserves over-cap records without loading or deleting them.
- Add focused Node checks and an isolated real-browser lifecycle smoke without packaging test code in the install artifact.

## Trust and compatibility

Google-hosted selections request only the selected families and expose the browser IP to Google. The editor discloses this behavior. WebUI defaults make no Typography font request. Local font bytes stay in the browser and are never uploaded, synchronized, or sent to Google.

The extension has no backend, sidecar, native host, remote script, filesystem access, cookies, or WebUI API access. Its runtime manifest grants only an extension-owned browser-storage namespace for scalar font selections; font bytes remain in IndexedDB. Deletion fails closed when browser confirmation is unavailable.

Typography requires the merged three-font Core contract from [nesquena/hermes-webui#5918](https://github.com/nesquena/hermes-webui/pull/5918). Compatibility CI pins Core release `exp-v0.52.184` at `51e3d09ad677a6b7e4ec3db46611b383d67a2778`, the first release that includes this contract.

## Screenshots

These screenshots came from extension head `f9e0d6ec` in an isolated standalone WebUI instance at Core `51e3d09a`, with fresh temporary state and only Typography installed.

### Desktop

![Typography Nous preset with Courier Prime](https://github.com/user-attachments/assets/f511146c-2f88-45fe-86ac-5a9e59edbc04)

### Narrow/mobile

![Typography narrow mobile panel](https://github.com/user-attachments/assets/ea285cb7-232c-4e0d-b118-cc0c15e99e76)

## Verification

- Extension validation and safety scanning pass for all 18 entries.
- Typography syntax, rail-entry, catalog, preset, capacity-boundary, local-font validation, selection-persistence, and Google CSS checks pass.
- All 16 compatibility unit tests pass.
- The existing maintained-pin `mobile-conversations` browser smoke passes.
- The new Typography-only real-browser smoke passes all five isolated cases:
  - default token and no-egress behavior;
  - Google stylesheet creation, update, and removal;
  - import, IndexedDB persistence, reload activation, replacement, deletion, and `FontFace` cleanup;
  - missing/throwing/cancelled confirmation and IndexedDB open/write failures;
  - pre-existing over-cap startup, repeated panel lifecycle, and desktop/mobile rendering.
- The generated `0.1.0` artifact contains five publishable files and no test code (`sha256: aa1a1641b210cfda13540a390812d0b3068788e1e1345d895e713516224cd594`).
- `git diff --check` passes.

## Contribution checklist

- [x] The change belongs in the extension library, not Hermes WebUI core.
- [x] Runtime extension files are isolated under `extensions/typography/`.
- [x] The README explains installation, workflow, disable/uninstall, compatibility, and trust behavior.
- [x] The manifest uses same-origin local assets.
- [x] Network and browser-local storage behavior are disclosed.
- [x] No sidecar, native integration, secrets, generated local state, or binaries are included.

