### PR TITLE
fix(registry): exclude dotfiles from extension artifacts

### DIFF
--- a/scripts/extension-registry-lib.mjs
+++ b/scripts/extension-registry-lib.mjs
@@ -154,6 +154,7 @@ function isSafeLocalPath(value) {
   const normalized = path.posix.normalize(value);
   if (normalized === '.' || normalized.startsWith('../') || normalized === '..') return false;
   if (normalized.includes('\0')) return false;
+  if (normalized.split('/').some((segment) => segment.startsWith('.'))) return false;
   return normalized === value;
 }
 

--- a/scripts/extension-registry-lib.mjs
+++ b/scripts/extension-registry-lib.mjs
@@ -174,6 +174,7 @@ function localPathHasSymlink(entryRoot, rel) {
 function collectFiles(dir, prefix = '') {
   const files = [];
   for (const item of readdirSync(dir, { withFileTypes: true })) {
+    if (item.name.startsWith('.')) continue;
     const rel = prefix ? `${prefix}/${item.name}` : item.name;
     const target = path.join(dir, item.name);
     if (item.isDirectory()) {

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -197,6 +197,44 @@ try {
     'ZIP artifacts must retain ordinary files while filtering dot-prefixed paths'
   );
 
+  // Regression: declared assets with dot-prefixed path segments must fail
+  // validation instead of being silently omitted from generated artifacts.
+  const hiddenAsset = '.hidden/adapter.js';
+  errors = validationErrors('', {
+    assets: { scripts: [hiddenAsset], stylesheets: [] }
+  }, {
+    scripts: [hiddenAsset], stylesheets: []
+  }, ({ root }) => {
+    mkdirSync(path.join(root, '.hidden'), { recursive: true });
+    writeFileSync(path.join(root, hiddenAsset), 'console.log("hidden asset");\n', 'utf8');
+  });
+  assert(
+    errors.includes('asset path is not safe/local: .hidden/adapter.js'),
+    'declared assets under dot-prefixed directories must fail closed'
+  );
+
+  // The same path contract applies to vendored sidecar runtime directories;
+  // runtime paths that artifact collection would omit must be rejected.
+  const hiddenRuntime = 'sidecar/.runtime';
+  errors = validationErrors('', {
+    capabilities: ['manifest-bundle', 'loopback-sidecar'],
+    sidecar: {
+      type: 'loopback',
+      origin: 'http://127.0.0.1:17790',
+      health_path: '/health',
+      proxy_auth: 'token-v1',
+      runtime: { kind: 'vendored', path: hiddenRuntime }
+    },
+    lifecycle: { sidecar_start_required: true },
+    permissions: { loopback_sidecar: true }
+  }, {}, ({ root }) => {
+    mkdirSync(path.join(root, hiddenRuntime), { recursive: true });
+  });
+  assert(
+    errors.includes('sidecar.runtime.path is required for a vendored runtime'),
+    'vendored sidecar runtime paths with dot-prefixed segments must fail closed'
+  );
+
   errors = validationErrors("fetch('/api/session/draft');\n");
   assert(errors.includes('permissions.webui_api.write must include session/draft'));
   assert(!errors.includes('permissions.webui_api.read must include session'));

--- a/scripts/test-extension-validator.mjs
+++ b/scripts/test-extension-validator.mjs
@@ -167,6 +167,36 @@ try {
   assert(JSON.parse(listed.stdout).includes(`${unicodeResult.id}/${unicodeAsset}`),
     'ZIP artifacts must mark UTF-8 member names so consumers decode them losslessly');
 
+  // Regression: artifact collection must omit every dot-prefixed path segment,
+  // including dotfiles and files nested under dot-directories, while retaining
+  // ordinary files in the same extension tree.
+  const filteredPathResult = validationResult('', {}, {}, ({ root }) => {
+    writeFileSync(path.join(root, '.gitkeep'), 'placeholder\n', 'utf8');
+    mkdirSync(path.join(root, '.config', 'nested'), { recursive: true });
+    writeFileSync(path.join(root, '.config', 'settings.json'), '{}\n', 'utf8');
+    mkdirSync(path.join(root, 'docs', 'nested'), { recursive: true });
+    writeFileSync(path.join(root, 'docs', 'nested', 'guide.md'), '# Guide\n', 'utf8');
+  });
+  assert.deepEqual(filteredPathResult.errors, []);
+  const filteredPathArtifact = buildExtensionArtifact(filteredPathResult);
+  const filteredPathZip = path.join(tmpRoot, 'filtered-dot-path-artifact.zip');
+  writeFileSync(filteredPathZip, filteredPathArtifact.buffer);
+  const filteredPathListed = spawnSync('python3', [
+    '-c',
+    'import json,sys,zipfile; print(json.dumps(zipfile.ZipFile(sys.argv[1]).namelist()))',
+    filteredPathZip
+  ], { encoding: 'utf8' });
+  assert.equal(filteredPathListed.status, 0, filteredPathListed.stderr);
+  const filteredPathMembers = JSON.parse(filteredPathListed.stdout);
+  assert(
+    !filteredPathMembers.some((name) => name.split('/').some((segment) => segment.startsWith('.'))),
+    `ZIP artifacts must omit dot-prefixed path segments: ${filteredPathMembers.join(', ')}`
+  );
+  assert(
+    filteredPathMembers.includes(`${filteredPathResult.id}/docs/nested/guide.md`),
+    'ZIP artifacts must retain ordinary files while filtering dot-prefixed paths'
+  );
+
   errors = validationErrors("fetch('/api/session/draft');\n");
   assert(errors.includes('permissions.webui_api.write must include session/draft'));
   assert(!errors.includes('permissions.webui_api.read must include session'));


### PR DESCRIPTION
## Summary

Fixes #78 by excluding every dot-prefixed file or directory segment from generated extension artifacts and rejecting declared install paths that the artifact builder cannot publish.

## Root cause

The registry artifact builder recursively packaged every file in an extension tree, including Git-only placeholders such as `screenshots/.gitkeep`. Core intentionally rejects archive members with dot-prefixed path segments, so otherwise valid Gallery installs failed with `Unsafe archive member`.

A maintainer self-review also found the companion contract gap: filtering only during packaging allowed a declared asset such as `.hidden/adapter.js` to pass validation and then disappear from the ZIP. The validator and artifact builder now enforce the same path boundary, so declared runtime resources fail closed before publication rather than producing an incomplete install.

## Scope

- filter unreferenced dot-prefixed entries at the shared artifact file-collection chokepoint;
- reject dot-prefixed segments in declared scripts, stylesheets, and vendored sidecar runtime paths;
- cover dotfiles and files nested below dot-directories;
- retain ordinary nested files;
- keep Core's safe-extraction policy unchanged.

The repository's `.gitkeep` files remain in source control; they are only omitted from published install artifacts.

## Regression proof

Before the packaging change, a fresh registry generation contained two real incompatible members:

- `auto-list/screenshots/.gitkeep`
- `profile-avatars/screenshots/.gitkeep`

Before the validator alignment, the new declared-asset regression failed because `.hidden/adapter.js` produced no validation error even though artifact collection omitted it.

After both changes:

- declared dot-prefixed assets and vendored runtime paths fail validation;
- a fresh 17-artifact generation reports `dot_member_count=0`;
- ordinary nested files remain packaged.

## Verification

- `node scripts/test-extension-validator.mjs`
- `node scripts/validate-extensions.mjs`
- `node scripts/scan-extension-safety.mjs`
- `node scripts/test-message-pins-sync.mjs`
- `node scripts/test-sidecar-contract.mjs`
- `python3 scripts/test-sidecar-scaffold.py`
- `python3 scripts/test-profile-avatars.py`
- `node --test scripts/test-auto-list-keyboard.mjs`
- `node scripts/sync-sidecar-base.mjs --check`
- `node scripts/check-sidecar-usage.mjs`
- `node scripts/validate-desktop-companion.mjs`
- fresh registry generation plus ZIP-member audit — 17 artifacts, zero dot-prefixed members
- `git diff --check origin/main..HEAD`

All commands exited 0.

## Out of scope

- no Core installer changes;
- no weakening of safe path validation;
- no unrelated screenshot-schema, extension, or release-note changes.
