### PR TITLE
test: certify E0/B1 capabilities against real Core

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -148,9 +148,9 @@ jobs:
           repository: nesquena/hermes-webui
           # Pin the independently verified Core contract; update this SHA only
           # after a maintainer reruns the smoke against the new Core head.
-          # exp-v0.52.184 — first release carrying the three-font contract
-          # (--font-ui/--font-conversation/--font-mono, #5918) this extension drives.
-          ref: 51e3d09ad677a6b7e4ec3db46611b383d67a2778
+          # exp-v0.52.201 — first release carrying both the cooperative E0
+          # identity handle and B1 turn-lifecycle event contract.
+          ref: 3c7fbe3809ff573199faee9d812179fcbeff2028
           path: .ci/hermes-webui-core
           fetch-depth: 1
           persist-credentials: false
@@ -177,6 +177,12 @@ jobs:
         run: |
           mkdir -p "$COMPATIBILITY_EVIDENCE_DIR"
           python tests/compatibility/browser_smoke.py
+
+      - name: Run E0/B1 capability baseline smoke
+        env:
+          HERMES_CORE_DIR: .ci/hermes-webui-core
+          COMPATIBILITY_EVIDENCE_DIR: compatibility-evidence
+        run: python tests/compatibility/capability_smoke.py
 
       - name: Run Typography browser compatibility smoke
         env:

--- a/docs/compatibility-smoke.md
+++ b/docs/compatibility-smoke.md
@@ -1,8 +1,9 @@
 # Browser compatibility smoke
 
-The first compatibility-certification stage runs a real Hermes WebUI Core
-checkout and headless Chromium. It is deliberately an allowlist, not a claim
-that every changed extension has browser coverage.
+The compatibility-certification job runs a real Hermes WebUI Core checkout and
+headless Chromium. It combines an allow-listed merged extension reference, a
+test-only E0/B1 capability probe, and Typography's dedicated browser scenarios;
+it is not a claim that every changed extension has browser coverage.
 
 ## Current contract
 
@@ -57,6 +58,26 @@ Assertions use the extension's own id/data/ARIA surfaces. The Core host
 selector is only a readiness precondition, not the extension pass/fail oracle;
 Core remains the real host that serves the app shell and injected assets.
 
+### E0/B1 capability baseline
+
+The separate test-only `capability-probe` fixture certifies the public Core
+foundation that merged extensions can build on. It runs in the same isolated,
+no-provider real Core browser environment and proves that:
+
+- a boot-trusted manifest ID receives the frozen E0 handle with the documented
+  `id`, `settings`, `storage`, and `events` fields;
+- an unknown ID fails closed without creating browser-storage state;
+- Core's real `attachLiveStream` → SSE `done` path emits one `turn:start` and
+  one `turn:complete` with the original session/stream identity;
+- the terminal callback observes the active stream cleared, the pane idle, and
+  the settled assistant transcript; and
+- a duplicate terminal dispatch for that session/stream is rejected.
+
+The fixture replaces `EventSource` only for the controlled lifecycle invocation;
+Core still owns the live-stream handler, state transition, event normalization,
+and duplicate suppression being exercised. It does not contact a provider or
+claim durable/global event delivery.
+
 ## Local run
 
 Install the hash-locked Core/browser-smoke dependencies in an isolated
@@ -70,25 +91,28 @@ python3.12 -m playwright install --with-deps chromium
 Run with an explicit independent Core checkout:
 
 ```bash
-HERMES_CORE_DIR=/path/to/hermes-webui \
-COMPATIBILITY_EVIDENCE_DIR="$PWD/compatibility-evidence" \
+export HERMES_CORE_DIR=/path/to/hermes-webui
+export COMPATIBILITY_EVIDENCE_DIR="$PWD/compatibility-evidence"
 python3.12 tests/compatibility/browser_smoke.py
+python3.12 tests/compatibility/capability_smoke.py
+python3.12 tests/compatibility/typography_smoke.py
 ```
 
-The command exits `0` only when the normal reference case passes and the
-resource-only case detects the missing entry. A compatibility assertion exits
-`1` with status `failed`. Missing setup (for example, a Core checkout or
-Playwright browser that is unavailable) and unexpected harness/driver
-exceptions exit `2`; the latter is recorded as status `harness_error` with a
-traceback rather than being reported as an extension regression. Evidence
-includes `compatibility-results.json`, one server log and one network-block
-record per case, and screenshots when the browser reaches the relevant page.
+Each command exits `0` only when its positive and negative contracts pass. A
+compatibility assertion exits `1` with status `failed`. Missing setup (for
+example, a Core checkout or Playwright browser that is unavailable) and
+unexpected harness/driver exceptions exit `2`; the latter is recorded as
+status `harness_error` with a traceback rather than being reported as an
+extension regression. Evidence includes JSON results, server logs,
+network-block records, and screenshots when the browser reaches the relevant
+page.
 
 ## CI boundary
 
 The `browser-compatibility` job checks out `nesquena/hermes-webui` independently
 at the pinned, maintainer-verified Core SHA in
-`.github/workflows/extensions.yml` (`320789ae596a3963d726d90f6c7f3bc86f7f2d6d`),
+`.github/workflows/extensions.yml` (`3c7fbe3809ff573199faee9d812179fcbeff2028`,
+release `exp-v0.52.201`),
 installs the complete hash-locked Core/browser-smoke and Playwright dependency
 surface from `tests/compatibility/requirements.txt` with
 `pip --require-hashes`, and
@@ -102,11 +126,11 @@ To update the pin, first rerun this smoke against the candidate Core checkout,
 review the logs/screenshots/results, then change the SHA and repeat the CI
 verification. Do not replace the pin with a moving branch reference.
 
-Adding another reference requires a merged entry, an explicit `ReferenceSpec`
-allowlist item, an extension-owned id/ARIA observable, and a positive plus
-resource-only negative scenario. Until then, this stage covers only
-`mobile-conversations`; it does not certify all 16 entries or every changed
-extension.
+Adding another merged reference requires an explicit `ReferenceSpec` allowlist
+item, an extension-owned id/ARIA observable, and a positive plus resource-only
+negative scenario. Until then, the merged-entry reference covers only
+`mobile-conversations`; the E0/B1 and Typography tracks have their own explicit
+contracts and none of these tracks certifies every merged or changed extension.
 
 The Playwright requirement is kept in `tests/compatibility/requirements.txt`
 because a real browser is necessary to execute injected JavaScript. Removing

--- a/tests/compatibility/capability_smoke.py
+++ b/tests/compatibility/capability_smoke.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Certify the pinned Core E0 identity and B1 turn-lifecycle contracts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from typing import Any
+
+import browser_smoke
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_ROOT = Path(__file__).resolve().parent / "fixtures" / "e0-b1-capability-probe"
+PROBE_SCRIPT_FRAGMENT = "/extensions/capability-probe/assets/capability-probe.js"
+SESSION_ID = "capability-session"
+STREAM_ID = "capability-stream"
+
+SetupFailure = browser_smoke.SetupFailure
+CompatibilityFailure = browser_smoke.CompatibilityFailure
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--core-dir",
+        default=os.environ.get("HERMES_CORE_DIR", ""),
+        help="path to the independently checked-out Hermes WebUI Core",
+    )
+    parser.add_argument(
+        "--evidence-dir",
+        default=os.environ.get(
+            "COMPATIBILITY_EVIDENCE_DIR",
+            str(REPO_ROOT / ".compatibility-evidence"),
+        ),
+        help="directory for logs, screenshots, and results JSON",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("HERMES_CAPABILITY_PORT", "0") or "0"),
+        help="optional fixed non-production port; 0 chooses a free ephemeral port",
+    )
+    return parser.parse_args()
+
+
+def _validate_probe_result(result: dict[str, Any]) -> None:
+    registration = result.get("registration")
+    expected_registration = {
+        "id": "capability-probe",
+        "handle_fields": ["events", "id", "settings", "storage"],
+        "handle_frozen": True,
+        "events_frozen": True,
+        "same_handle": True,
+        "unknown_is_null": True,
+        "unknown_storage_unchanged": True,
+    }
+    if registration != expected_registration:
+        raise CompatibilityFailure(
+            f"E0 registration contract mismatch: {registration!r}"
+        )
+
+    events = result.get("events")
+    if not isinstance(events, list) or len(events) != 2:
+        raise CompatibilityFailure(
+            f"B1 lifecycle must emit exactly start + complete once: {events!r}"
+        )
+    start, complete = events
+    if not isinstance(start, dict) or not isinstance(complete, dict):
+        raise CompatibilityFailure(
+            f"B1 lifecycle events must be objects: {events!r}"
+        )
+    expected_identity = {
+        "session_id": SESSION_ID,
+        "stream_id": STREAM_ID,
+    }
+    if (
+        start.get("type") != "turn:start"
+        or {key: start.get(key) for key in expected_identity} != expected_identity
+        or start.get("active_stream_id") != STREAM_ID
+        or start.get("busy") is not True
+        or start.get("last_content") != "question"
+    ):
+        raise CompatibilityFailure(f"B1 start event mismatch: {start!r}")
+    if (
+        complete.get("type") != "turn:complete"
+        or {key: complete.get(key) for key in expected_identity} != expected_identity
+        or complete.get("status") != "completed"
+        or complete.get("active_stream_id") is not None
+        or complete.get("busy") is not False
+        or complete.get("last_content") != "settled-done"
+    ):
+        raise CompatibilityFailure(
+            f"B1 terminal callback did not observe settled idle state: {complete!r}"
+        )
+    if result.get("duplicate_terminal_accepted") is not False:
+        raise CompatibilityFailure(
+            "B1 accepted a duplicate terminal event for the same session/stream"
+        )
+
+
+def _run_probe(base_url: str, evidence_dir: Path) -> dict[str, Any]:
+    try:
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise SetupFailure(
+            "Playwright is required; install tests/compatibility/requirements.txt"
+        ) from exc
+
+    responses: list[dict[str, Any]] = []
+    request_failures: list[str] = []
+    console_errors: list[dict[str, str]] = []
+    page_errors: list[str] = []
+    screenshot_path = evidence_dir / "e0-b1-capability.png"
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
+        )
+        context = browser.new_context(service_workers="block")
+        network_events = browser_smoke._install_network_guards(context)
+        page = context.new_page()
+
+        def on_response(response: Any) -> None:
+            if PROBE_SCRIPT_FRAGMENT in response.url:
+                responses.append({"url": response.url, "status": response.status})
+
+        def on_request_failed(request: Any) -> None:
+            if PROBE_SCRIPT_FRAGMENT in request.url:
+                request_failures.append(f"{request.url}: {request.failure}")
+
+        def on_console(message: Any) -> None:
+            if message.type != "error":
+                return
+            location = getattr(message, "location", {}) or {}
+            location_url = (
+                location.get("url", "")
+                if isinstance(location, dict)
+                else getattr(location, "url", "")
+            )
+            console_errors.append({"text": str(message.text), "url": str(location_url)})
+
+        page.on("response", on_response)
+        page.on("requestfailed", on_request_failed)
+        page.on("console", on_console)
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        try:
+            page.goto(f"{base_url}/", wait_until="domcontentloaded", timeout=30_000)
+            try:
+                page.wait_for_load_state("networkidle", timeout=8_000)
+            except PlaywrightTimeoutError:
+                pass
+            try:
+                page.wait_for_function(
+                    "() => window.HermesCapabilityBaselineProbe?.ready === true",
+                    timeout=browser_smoke.ENTRY_TIMEOUT_MS,
+                )
+                page.locator(".messages-shell").wait_for(
+                    state="visible", timeout=browser_smoke.ENTRY_TIMEOUT_MS
+                )
+            except PlaywrightTimeoutError as exc:
+                raise CompatibilityFailure(
+                    "E0/B1 capability probe or Core host did not become ready"
+                ) from exc
+            if request_failures or not responses or any(item["status"] >= 400 for item in responses):
+                raise CompatibilityFailure(
+                    f"capability probe resource failed: {request_failures or responses!r}"
+                )
+            browser_smoke._assert_browser_health(
+                case_name="e0-b1-capability",
+                console_errors=console_errors,
+                page_errors=page_errors,
+                extension_fragments=(PROBE_SCRIPT_FRAGMENT,),
+                network_events=network_events,
+            )
+            boot_result = page.evaluate(
+                "() => ({error: window.HermesCapabilityBaselineProbe.error || null})"
+            )
+            if boot_result.get("error"):
+                raise CompatibilityFailure(
+                    f"E0 registration unavailable: {boot_result['error']}"
+                )
+            result = page.evaluate(
+                "() => window.HermesCapabilityBaselineProbe.runCompleteLifecycle()"
+            )
+            _validate_probe_result(result)
+            page.wait_for_timeout(250)
+            browser_smoke._record_screenshot(page, screenshot_path)
+            browser_smoke._assert_browser_health(
+                case_name="e0-b1-capability",
+                console_errors=console_errors,
+                page_errors=page_errors,
+                extension_fragments=(PROBE_SCRIPT_FRAGMENT,),
+                network_events=network_events,
+            )
+            return {
+                "status": "passed",
+                "probe": result,
+                "resource_urls": [item["url"] for item in responses],
+                "screenshot": str(screenshot_path),
+                "blocked_http": list(network_events["blocked_http"]),
+                "blocked_websockets": list(network_events["blocked_websockets"]),
+            }
+        finally:
+            browser_smoke._write_json(
+                evidence_dir / "e0-b1-capability-network.json", network_events
+            )
+            context.close()
+            browser.close()
+
+
+def main() -> int:
+    args = _parse_args()
+    evidence_dir = Path(args.evidence_dir).expanduser().resolve()
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    result_path = evidence_dir / "e0-b1-capability-results.json"
+    result: dict[str, Any] = {
+        "core_contract": "E0+B1",
+        "fixture_extension": "capability-probe",
+    }
+    proc = None
+    log_file = None
+    try:
+        core_dir = Path(args.core_dir).expanduser().resolve()
+        if not core_dir.is_dir():
+            raise SetupFailure(
+                "HERMES_CORE_DIR/--core-dir must point to an independent Hermes WebUI checkout"
+            )
+        if not (FIXTURE_ROOT / "manifest.json").is_file():
+            raise SetupFailure(f"capability fixture is unavailable: {FIXTURE_ROOT}")
+
+        with tempfile.TemporaryDirectory(prefix="hermes-e0-b1-compat-") as temp:
+            temp_root = Path(temp)
+            extension_root = temp_root / "extensions"
+            fixture_target = extension_root / "capability-probe"
+            extension_root.mkdir()
+            shutil.copytree(FIXTURE_ROOT, fixture_target)
+            try:
+                proc, log_file, base_url, port = browser_smoke._start_server(
+                    core_dir=core_dir,
+                    extension_root=extension_root,
+                    manifest_relative="capability-probe/manifest.json",
+                    state_root=temp_root / "state",
+                    log_path=evidence_dir / "e0-b1-capability-server.log",
+                    requested_port=args.port,
+                )
+                result.update(_run_probe(base_url, evidence_dir))
+                result["port"] = port
+            finally:
+                browser_smoke._terminate(proc, log_file)
+                proc = None
+                log_file = None
+        browser_smoke._write_json(result_path, result)
+        print("E0/B1 CAPABILITY COMPATIBILITY PASSED")
+        print("registration=passed lifecycle=start+complete-once settled-idle=passed")
+        print(f"evidence={evidence_dir}")
+        return 0
+    except SetupFailure as exc:
+        result["status"] = "setup_failure"
+        result["error"] = str(exc)
+        browser_smoke._write_json(result_path, result)
+        print(f"SETUP FAILURE: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 2
+    except CompatibilityFailure as exc:
+        result["status"] = "failed"
+        result["error"] = str(exc)
+        browser_smoke._write_json(result_path, result)
+        print(f"E0/B1 CAPABILITY COMPATIBILITY FAILED: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        result["status"] = "harness_error"
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        result["traceback"] = traceback.format_exc()
+        browser_smoke._write_json(result_path, result)
+        print(f"HARNESS ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 2
+    finally:
+        browser_smoke._terminate(proc, log_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/compatibility/fixtures/e0-b1-capability-probe/assets/capability-probe.js
+++ b/tests/compatibility/fixtures/e0-b1-capability-probe/assets/capability-probe.js
@@ -1,0 +1,143 @@
+(() => {
+  'use strict';
+
+  const EXTENSION_ID = 'capability-probe';
+  const SESSION_ID = 'capability-session';
+  const STREAM_ID = 'capability-stream';
+  const events = [];
+
+  const storageKeys = () => Array.from(
+    { length: window.localStorage.length },
+    (_, index) => window.localStorage.key(index),
+  ).sort();
+
+  const register = window.hermesExt && typeof window.hermesExt.register === 'function'
+    ? window.hermesExt.register.bind(window.hermesExt)
+    : null;
+  const beforeUnknown = storageKeys();
+  const unknown = register ? register('untrusted-capability-probe') : undefined;
+  const afterUnknown = storageKeys();
+  const extension = register ? register(EXTENSION_ID) : null;
+
+  const probe = {
+    ready: false,
+    registration: {
+      id: extension && extension.id,
+      handle_fields: extension ? Object.keys(extension).sort() : [],
+      handle_frozen: Boolean(extension && Object.isFrozen(extension)),
+      events_frozen: Boolean(extension && Object.isFrozen(extension.events)),
+      same_handle: Boolean(extension && register(`  ${EXTENSION_ID}  `) === extension),
+      unknown_is_null: unknown === null,
+      unknown_storage_unchanged: JSON.stringify(beforeUnknown) === JSON.stringify(afterUnknown),
+    },
+    events,
+  };
+  window.HermesCapabilityBaselineProbe = probe;
+
+  if (!extension) {
+    probe.error = register
+      ? 'trusted capability probe did not register'
+      : 'hermesExt.register is unavailable';
+    probe.ready = true;
+    return;
+  }
+
+  const record = event => {
+    const lastMessage = Array.isArray(S.messages) ? S.messages.at(-1) : null;
+    events.push({
+      type: event.type,
+      session_id: event.sessionId,
+      stream_id: event.streamId,
+      status: event.status || null,
+      active_stream_id: S.activeStreamId || null,
+      busy: Boolean(S.busy),
+      last_content: lastMessage && lastMessage.content || null,
+    });
+  };
+  extension.events.on('turn:start', record);
+  extension.events.on('turn:complete', record);
+
+  class MockEventSource {
+    static OPEN = 1;
+    static instances = [];
+
+    constructor(url) {
+      this.url = String(url);
+      this.readyState = MockEventSource.OPEN;
+      this.listeners = new Map();
+      MockEventSource.instances.push(this);
+    }
+
+    addEventListener(name, listener) {
+      const listeners = this.listeners.get(name) || [];
+      listeners.push(listener);
+      this.listeners.set(name, listeners);
+    }
+
+    removeEventListener(name, listener) {
+      this.listeners.set(
+        name,
+        (this.listeners.get(name) || []).filter(candidate => candidate !== listener),
+      );
+    }
+
+    close() {
+      this.readyState = 2;
+    }
+
+    async emit(name, payload) {
+      const event = { type: name, data: JSON.stringify(payload), lastEventId: '' };
+      for (const listener of this.listeners.get(name) || []) {
+        await listener(event);
+      }
+    }
+  }
+
+  probe.runCompleteLifecycle = async () => {
+    events.splice(0, events.length);
+    const NativeEventSource = window.EventSource;
+    window.EventSource = MockEventSource;
+    try {
+      S.session = {
+        session_id: SESSION_ID,
+        messages: [{ role: 'user', content: 'question' }],
+      };
+      S.messages = [{ role: 'user', content: 'question' }];
+      S.toolCalls = [];
+      S.activeStreamId = STREAM_ID;
+      S.busy = true;
+
+      attachLiveStream(SESSION_ID, STREAM_ID, []);
+      const source = MockEventSource.instances.at(-1);
+      if (!source) throw new Error('Core did not create the live EventSource');
+      await source.emit('done', {
+        status: 'completed',
+        stream_id: STREAM_ID,
+        session: {
+          session_id: SESSION_ID,
+          messages: [{ role: 'assistant', content: 'settled-done' }],
+          tool_calls: [],
+        },
+      });
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+
+      const duplicateAccepted = window.HermesExtensionSettings._dispatchTurnLifecycle(
+        'turn:complete',
+        {
+          sessionId: SESSION_ID,
+          streamId: STREAM_ID,
+          status: 'late-duplicate',
+        },
+      );
+      return {
+        registration: probe.registration,
+        events: events.map(event => ({ ...event })),
+        duplicate_terminal_accepted: duplicateAccepted,
+      };
+    } finally {
+      window.EventSource = NativeEventSource;
+    }
+  };
+
+  probe.ready = true;
+})();

--- a/tests/compatibility/fixtures/e0-b1-capability-probe/manifest.json
+++ b/tests/compatibility/fixtures/e0-b1-capability-probe/manifest.json
@@ -1,0 +1,13 @@
+{
+  "extensions": [
+    {
+      "id": "capability-probe",
+      "name": "E0/B1 capability compatibility probe",
+      "description": "Test-only extension for the pinned Core identity and turn-lifecycle contract.",
+      "scripts": [
+        "assets/capability-probe.js"
+      ],
+      "stylesheets": []
+    }
+  ]
+}

--- a/tests/compatibility/test_capability_smoke.py
+++ b/tests/compatibility/test_capability_smoke.py
@@ -1,0 +1,80 @@
+"""Regression tests for the E0/B1 compatibility result contract."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import capability_smoke  # noqa: E402
+
+
+def _valid_result() -> dict:
+    return {
+        "registration": {
+            "id": "capability-probe",
+            "handle_fields": ["events", "id", "settings", "storage"],
+            "handle_frozen": True,
+            "events_frozen": True,
+            "same_handle": True,
+            "unknown_is_null": True,
+            "unknown_storage_unchanged": True,
+        },
+        "events": [
+            {
+                "type": "turn:start",
+                "session_id": "capability-session",
+                "stream_id": "capability-stream",
+                "active_stream_id": "capability-stream",
+                "busy": True,
+                "last_content": "question",
+            },
+            {
+                "type": "turn:complete",
+                "session_id": "capability-session",
+                "stream_id": "capability-stream",
+                "status": "completed",
+                "active_stream_id": None,
+                "busy": False,
+                "last_content": "settled-done",
+            },
+        ],
+        "duplicate_terminal_accepted": False,
+    }
+
+
+class CapabilityResultContractTests(unittest.TestCase):
+    def test_complete_lifecycle_result_is_accepted(self) -> None:
+        capability_smoke._validate_probe_result(_valid_result())
+
+    def test_duplicate_terminal_event_is_rejected(self) -> None:
+        result = _valid_result()
+        result["events"].append(dict(result["events"][-1]))
+        with self.assertRaises(capability_smoke.CompatibilityFailure):
+            capability_smoke._validate_probe_result(result)
+
+    def test_malformed_event_is_a_compatibility_failure(self) -> None:
+        result = _valid_result()
+        result["events"][0] = None
+        with self.assertRaises(capability_smoke.CompatibilityFailure):
+            capability_smoke._validate_probe_result(result)
+
+    def test_unknown_registration_must_fail_closed_without_storage_side_effects(self) -> None:
+        result = _valid_result()
+        result["registration"]["unknown_is_null"] = False
+        result["registration"]["unknown_storage_unchanged"] = False
+        with self.assertRaises(capability_smoke.CompatibilityFailure):
+            capability_smoke._validate_probe_result(result)
+
+    def test_terminal_callback_must_observe_idle_settled_state(self) -> None:
+        result = _valid_result()
+        result["events"][-1]["active_stream_id"] = "capability-stream"
+        result["events"][-1]["busy"] = True
+        with self.assertRaises(capability_smoke.CompatibilityFailure):
+            capability_smoke._validate_probe_result(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- advance the browser-compatibility Core pin to `3c7fbe3809ff573199faee9d812179fcbeff2028` (`exp-v0.52.201`), the first release carrying both E0 and B1;
- add a test-only real-Core browser probe for the cooperative `hermesExt.register(...)` handle and the page-local turn lifecycle event contract;
- run that probe beside the existing `mobile-conversations` and Typography browser tracks, and document the exact coverage boundary.

Refs #76 and #40.

## Why this slice

The existing certification proves that an allow-listed extension still renders in a pinned Core shell. It did not prove that the newly shipped extension capability foundation is actually present and usable from injected extension code. Keeping this as a separate baseline avoids mixing a 68-commit Core roll-forward with a consumer behavior migration such as `mobile-haptics`.

No shipped extension asset or product behavior changes in this PR.

## Contract exercised

The boot-trusted test fixture verifies that:

- `hermesExt.register` returns the same frozen handle for the normalized trusted ID;
- the handle exposes the frozen `id`, `settings`, `storage`, and `events` surface;
- an unknown ID fails closed without creating browser-storage state;
- Core real `attachLiveStream` to SSE `done` processing emits exactly one `turn:start` and one `turn:complete` with preserved session and stream identity;
- the terminal callback observes cleared stream ownership, an idle pane, and the settled assistant transcript; and
- the Core lifecycle state machine rejects a duplicate terminal dispatch.

The fixture replaces `EventSource` and seeds Core page state only to drive a deterministic no-provider lifecycle. Those private Core symbols are test drivers, not extension APIs or new compatibility promises. The assertions remain on the public extension handle/events and Core observable settlement.

This does not certify all 18 entries, durable/global delivery, tokens/tools, or every terminal class. Consumer migration remains a separate PR.

## Discriminating regression proof

Against the previous pinned Core `51e3d09ad677a6b7e4ec3db46611b383d67a2778`, the new probe exits 1 with:

```text
E0/B1 CAPABILITY COMPATIBILITY FAILED: E0 registration unavailable: hermesExt.register is unavailable
```

Against `3c7fbe3809ff573199faee9d812179fcbeff2028`, the same probe exits 0:

```text
E0/B1 CAPABILITY COMPATIBILITY PASSED
registration=passed lifecycle=start+complete-once settled-idle=passed
```

## Verification

Local checks:

```text
python -m unittest discover -s tests/compatibility -p 'test_*.py' -v
Ran 22 tests in 17.144s — OK

browser_smoke.py
EXTENSION COMPATIBILITY PASSED
normal-reference=passed resource-only-negative=expected_failure_detected

capability_smoke.py
E0/B1 CAPABILITY COMPATIBILITY PASSED
registration=passed lifecycle=start+complete-once settled-idle=passed

node scripts/test-extension-validator.mjs
extension validator self-tests passed

node scripts/validate-extensions.mjs
validated 18 extension entries

node scripts/scan-extension-safety.mjs
safety scan passed for 18 extension entries

git diff --check upstream/main...HEAD
exit 0
```

The remaining repository validators, sidecar checks, desktop-companion validation, and registry generation also exited 0. Registry generation produced 18 entries/artifacts.

The Typography real-browser smoke was not claimed as a local pass on macOS: its Linux-only font probe returned setup exit 2 because `/usr/share/fonts/...` Liberation/DejaVu files are absent. The unchanged Ubuntu GitHub job is the final Typography gate.

## Risks and rollback

- The exact Core pin can age; future updates still require rerunning and reviewing all three browser tracks.
- The deterministic lifecycle driver touches pinned Core internals, so an internal Core refactor can cause a deliberate certification failure even if the public event shape remains compatible. The pin/update review is where that driver must be adapted.
- Rollback is isolated to the Core pin, capability step/fixture/runner, and documentation; existing static and registry gates remain independent.

AI-assisted implementation: Luna Max performed the mechanical rebase and first verification pass. The final six-file diff, old-Core RED, current-Core browser result, unit suite, and key static gates were independently reviewed and rerun before publication.
