### PR TITLE
fix(external-app-tab): expose installed settings metadata

### DIFF
--- a/extensions/external-app-tab/manifest.json
+++ b/extensions/external-app-tab/manifest.json
@@ -9,6 +9,25 @@
       ],
       "stylesheets": [
         "assets/external-app-tab.css"
+      ],
+      "permissions": {
+        "storage": {
+          "owned": true
+        }
+      },
+      "settings_schema": [
+        {
+          "key": "url",
+          "type": "string",
+          "label": "App URL",
+          "default": ""
+        },
+        {
+          "key": "label",
+          "type": "string",
+          "label": "Rail label",
+          "default": "App"
+        }
       ]
     }
   ]

--- a/tests/compatibility/test_installed_artifact_settings.py
+++ b/tests/compatibility/test_installed_artifact_settings.py
@@ -1,4 +1,4 @@
-"""Regression coverage for the production mobile-haptics install artifact."""
+"""Regression coverage for installed extension settings metadata."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from urllib.parse import urlsplit
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-class MobileHapticsInstalledArtifactTest(unittest.TestCase):
+class InstalledArtifactSettingsTest(unittest.TestCase):
     """Exercise registry generation, Core installation, and runtime metadata."""
 
     def _core_root(self) -> Path:
@@ -25,12 +25,10 @@ class MobileHapticsInstalledArtifactTest(unittest.TestCase):
             return Path(configured).expanduser().resolve()
         return (REPO_ROOT / ".ci" / "hermes-webui-core").resolve()
 
-    def test_production_artifact_install_exposes_haptics_setting(self) -> None:
+    def _install_artifact(self, extension_id: str) -> tuple[dict[str, object], dict[str, object]]:
+        """Generate, install, and inspect one production registry artifact."""
         core_root = self._core_root()
-        if not (core_root / "api" / "extensions.py").is_file():
-            self.skipTest(f"Hermes WebUI Core checkout is unavailable: {core_root}")
-
-        with tempfile.TemporaryDirectory(prefix="hermes-mobile-haptics-compat-") as temp:
+        with tempfile.TemporaryDirectory(prefix=f"hermes-{extension_id}-compat-") as temp:
             temp_root = Path(temp)
             registry_path = temp_root / "registry.json"
             generate = subprocess.run(
@@ -52,10 +50,10 @@ class MobileHapticsInstalledArtifactTest(unittest.TestCase):
             )
 
             registry = json.loads(registry_path.read_text(encoding="utf-8"))
-            mobile_haptics = next(
-                entry for entry in registry["extensions"] if entry["id"] == "mobile-haptics"
+            registry_entry = next(
+                entry for entry in registry["extensions"] if entry["id"] == extension_id
             )
-            download_url = mobile_haptics["download"]
+            download_url = registry_entry["download"]
             artifact_name = Path(urlsplit(download_url).path).name
             artifact_path = registry_path.parent / "artifacts" / artifact_name
             self.assertTrue(artifact_path.is_file(), artifact_path)
@@ -91,13 +89,14 @@ class MobileHapticsInstalledArtifactTest(unittest.TestCase):
                 artifact_path = Path(sys.argv[2]).resolve()
                 download_url = sys.argv[3]
                 sha256 = sys.argv[4]
+                extension_id = sys.argv[5]
                 sys.path.insert(0, str(core_root))
 
                 import api.extensions as extensions
 
                 artifact_bytes = artifact_path.read_bytes()
                 extensions._safe_download = lambda *args, **kwargs: artifact_bytes
-                installed = extensions.install_extension("mobile-haptics", download_url, sha256)
+                installed = extensions.install_extension(extension_id, download_url, sha256)
                 config = extensions.get_extension_config()
                 print("RESULT=" + json.dumps({"installed": installed, "config": config}))
                 """
@@ -110,7 +109,8 @@ class MobileHapticsInstalledArtifactTest(unittest.TestCase):
                     str(core_root),
                     str(artifact_path),
                     download_url,
-                    mobile_haptics["sha256"],
+                    registry_entry["sha256"],
+                    extension_id,
                 ],
                 cwd=core_root,
                 env=child_env,
@@ -130,20 +130,55 @@ class MobileHapticsInstalledArtifactTest(unittest.TestCase):
             ]
             self.assertEqual(len(result_lines), 1, core_run.stdout)
             result = json.loads(result_lines[0])
-
-            self.assertTrue(result["installed"]["installed"])
             runtime_entry = next(
                 entry
                 for entry in result["config"]["extensions"]
-                if entry["id"] == "mobile-haptics"
+                if entry["id"] == extension_id
             )
-            self.assertIs(runtime_entry["storage_owned"], True)
-            self.assertEqual(len(runtime_entry["settings_schema"]), 1)
-            setting = runtime_entry["settings_schema"][0]
-            self.assertEqual(setting["key"], "enabled")
-            self.assertEqual(setting["type"], "boolean")
-            self.assertEqual(setting["label"], "Vibrate when a turn finishes")
-            self.assertIs(setting["default"], True)
+            return result["installed"], runtime_entry
+
+    def test_production_artifact_install_exposes_haptics_setting(self) -> None:
+        core_root = self._core_root()
+        if not (core_root / "api" / "extensions.py").is_file():
+            self.skipTest(f"Hermes WebUI Core checkout is unavailable: {core_root}")
+
+        installed, runtime_entry = self._install_artifact("mobile-haptics")
+        self.assertTrue(installed["installed"])
+        self.assertIs(runtime_entry["storage_owned"], True)
+        self.assertEqual(len(runtime_entry["settings_schema"]), 1)
+        setting = runtime_entry["settings_schema"][0]
+        self.assertEqual(setting["key"], "enabled")
+        self.assertEqual(setting["type"], "boolean")
+        self.assertEqual(setting["label"], "Vibrate when a turn finishes")
+        self.assertIs(setting["default"], True)
+
+    def test_production_artifact_install_exposes_external_app_tab_settings(self) -> None:
+        core_root = self._core_root()
+        if not (core_root / "api" / "extensions.py").is_file():
+            self.skipTest(f"Hermes WebUI Core checkout is unavailable: {core_root}")
+
+        installed, runtime_entry = self._install_artifact("external-app-tab")
+        self.assertTrue(installed["installed"])
+        self.assertIs(runtime_entry["storage_owned"], True)
+        self.assertEqual(
+            runtime_entry["settings_schema"],
+            [
+                {
+                    "key": "url",
+                    "type": "string",
+                    "label": "App URL",
+                    "description": "",
+                    "default": "",
+                },
+                {
+                    "key": "label",
+                    "type": "string",
+                    "label": "Rail label",
+                    "description": "",
+                    "default": "App",
+                },
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`external-app-tab` already declares its `url` and `label` settings in `extension.json`, but gallery installs execute the checked-in `manifest.json`. That runtime manifest omitted both `permissions.storage.owned: true` and `settings_schema`, so Core sanitized the installed extension to `storage_owned: false` with no native settings fields.

## Change

- mirror the existing `url` and `label` settings metadata into `extensions/external-app-tab/manifest.json`;
- rename the existing mobile-only installed-artifact test to a shared settings-artifact test;
- retain the full `mobile-haptics` assertion and add an independent `external-app-tab` case through the same production registry ZIP → local artifact → Core install → runtime config chain.

The shared helper avoids duplicating the install harness now that a second extension needs the same boundary proof.

This PR is independent of #82. It changes no extension JavaScript, CSS, README, version, or runtime behavior beyond exposing metadata already declared in `extension.json`.

Refs #34.

## Regression proof

With the test change present and the runtime manifest untouched, the targeted test produced the discriminating RED:

```text
test_production_artifact_install_exposes_haptics_setting ... ok
test_production_artifact_install_exposes_external_app_tab_settings ... FAIL
AssertionError: False is not true
```

The external artifact installed successfully, but Core returned `storage_owned: false`. After the manifest parity change, the same two tests pass and Core exposes the exact sanitized schema:

- `url`: string, label `App URL`, default empty;
- `label`: string, label `Rail label`, default `App`.

## Verification

```text
HERMES_CORE_DIR=<Core 3c7fbe3809ff573199faee9d812179fcbeff2028> python3.12 -m unittest discover -s tests/compatibility -p 'test_installed_artifact_settings.py' -v
Ran 2 tests in 1.596s — OK

HERMES_CORE_DIR=<same Core> python3.12 -m unittest discover -s tests/compatibility -p 'test_*.py' -v
Ran 18 tests — OK (6 Playwright-only environment skips)

node scripts/test-extension-validator.mjs
extension validator self-tests passed

node scripts/validate-extensions.mjs
validated 18 extension entries

node scripts/scan-extension-safety.mjs
safety scan passed for 18 extension entries

node scripts/generate-registry.mjs --out dist/registry.json
wrote 18 extension entries and 18 artifacts

python3 -m json.tool extensions/external-app-tab/manifest.json
exit 0

git diff --check HEAD^..HEAD
exit 0
```

A direct JSON comparison also confirmed that runtime `storage.owned` and both schema entries exactly match `extension.json`.

## Risks and rollback

- The URL remains ordinary browser-local configuration, not a secret store; this PR does not change that trust model.
- The installed-artifact test still mocks only the artifact download bytes. Extraction, checksum verification, install, manifest sanitization, and `get_extension_config()` are real Core paths.
- Rollback is limited to the manifest metadata and the generalized test file; extension assets are untouched.

AI-assisted implementation: Luna Max performed the bounded RED/GREEN implementation and first validation pass. The final two-file logical diff, exact schema parity, installation chain, validators, and safety scan were independently reviewed and rerun before publication.
