### PR TITLE
Migrate Mobile Haptics to E0/B1 lifecycle events

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Test Message Pins observer sync
         run: node scripts/test-message-pins-sync.mjs
 
+      - name: Test Mobile Haptics E0/B1 lifecycle
+        run: node scripts/test-mobile-haptics.mjs
+
       - name: Test sidecar contract enforcement
         run: node scripts/test-sidecar-contract.mjs
 

--- a/extensions/mobile-haptics/README.md
+++ b/extensions/mobile-haptics/README.md
@@ -1,17 +1,17 @@
 # Mobile Haptics
 
 Mobile Haptics is a trusted local Hermes WebUI extension that gives your phone a
-short vibration when an assistant turn finishes — so if you fire off a long task
-and set the device down, you get a physical "it's done" cue.
+short vibration when an assistant turn finishes. If you start a long task and
+set the device down, the buzz is a physical "it's done" cue.
 
 ## What It Does
 
-- Watches for the end of an assistant turn and triggers a short
+- Subscribes to the Core `turn:complete` lifecycle event and triggers a short
   `navigator.vibrate()` buzz.
-- Opt-in preference, on by default; managed via the native Settings → Extensions toggle (sanctioned extension-settings store, legacy `hermes-ext-haptics-enabled` localStorage fallback on older core)
-  where vibration is supported.
-- Ignores sub-100ms flickers; the real "a turn happened" gate is observing a
-  genuine busy action (stop/steer/interrupt), so only real turns buzz.
+- Vibrates only when the extension is enabled and the platform exposes
+  `navigator.vibrate`.
+- Keeps the preference in the native Settings → Extensions toggle through the
+  scoped extension settings handle.
 
 ## Platform support (important)
 
@@ -28,12 +28,17 @@ Android-leaning feature.
 
 ## How it detects "turn complete"
 
-Extensions can't see the server's streaming (SSE) events, so this reads the DOM
-instead: the composer send button (`#btnSend`) carries a busy action
-(`stop` / `steer` / `interrupt`) while the assistant is generating and returns
-to the idle `send` action when the turn finishes. A `MutationObserver` on that
-button's `class` / `data-action` catches the busy → idle transition and fires
-the buzz.
+The extension uses the cooperative E0/B1 capability handle:
+
+1. It calls `window.hermesExt.register('mobile-haptics')` to obtain its scoped
+   handle.
+2. It subscribes only to `ext.events.on('turn:complete', handler)`.
+3. The handler reads `ext.settings.get('enabled')` and, when enabled on a
+   supported device, calls `navigator.vibrate([18])` once.
+
+The extension does not depend on Core's private implementation details. If the
+scoped E0/B1 handle is unavailable (as on an older Core), it warns and fails
+closed without subscribing or vibrating.
 
 ## Current Shape
 
@@ -41,8 +46,9 @@ the buzz.
 Hermes WebUI page
   -> manifest-bundled extension assets
   -> /extensions/assets/mobile-haptics.js
-  -> MutationObserver on #btnSend (busy -> idle) -> navigator.vibrate()
-  -> setting `enabled` via window.HermesExtensionSettings (Settings → Extensions toggle)
+  -> scoped E0 handle (hermesExt.register)
+  -> B1 turn:complete event -> navigator.vibrate([18])
+  -> scoped ext.settings `enabled` preference
 ```
 
 This extension is `static-ui` / manifest-bundle only. It does not add backend
@@ -60,24 +66,23 @@ cd /path/to/hermes-webui
 HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/mobile-haptics HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
 ```
 
-Open the WebUI on an Android device (or Android-PWA), send a message, and feel a
-short buzz when the reply completes.
+Open the WebUI on an Android device (or Android-PWA), send a message, and feel
+a short buzz when the reply completes.
 
 ## Controls
 
 The **on/off toggle renders natively in Settings → Extensions → Mobile Haptics**
-("Vibrate when a turn finishes"), via the sanctioned extension-settings system
-(`settings_schema` + `permissions.storage.owned: true`). Toggling it there persists
-through `window.HermesExtensionSettings` — no separate panel.
+(`settings_schema` + `permissions.storage.owned: true`). The extension reads and
+writes this value only through the returned `ext.settings` handle.
 
-A small JS control surface is also exposed on `window.HermesMobileHapticsExtension`:
+A small JS control surface is also exposed on
+`window.HermesMobileHapticsExtension`:
 
 - `.supported` — whether `navigator.vibrate` exists on this device
-- `.isEnabled()` — current opt-in state (reads the settings store; falls back to the
-  legacy `hermes-ext-haptics-enabled` localStorage key on older core without the
-  settings system)
-- `.setEnabled(true|false)` — toggle and persist (settings store, legacy fallback)
-- `.test()` — fire a test buzz (returns false if unsupported)
+- `.isEnabled()` — current opt-in state from the scoped settings handle
+- `.setEnabled(true|false)` — toggle and persist through scoped settings
+- `.test()` — fire a test buzz (returns false if unsupported or the lifecycle
+  capability is unavailable)
 
 ## Disable And Uninstall
 
@@ -90,29 +95,28 @@ keeping the extension installed, or restart Hermes WebUI without
 
 This is trusted local code. Current disclosed behavior:
 
-- calls `navigator.vibrate()` when an assistant turn completes (if enabled +
-  supported)
-- observes the `#btnSend` button's `class` / `data-action` via a
-  `MutationObserver` (read-only)
-- reads/writes the `enabled` setting through the sanctioned `window.HermesExtensionSettings`
-  store (`permissions.storage.owned: true`); on older core without that system it
-  falls back to the single localStorage key `hermes-ext-haptics-enabled`
-- creates NO DOM
+- calls `navigator.vibrate([18])` when Core emits `turn:complete` and the
+  extension is enabled on a supported device
+- obtains the scoped E0 handle with `window.hermesExt.register('mobile-haptics')`
+  and subscribes to the B1 `turn:complete` event
+- reads/writes the `enabled` setting through the returned `ext.settings` handle
+- creates NO DOM and does not inspect Core-owned DOM views
 - does not call WebUI HTTP APIs
-- does not access cookies
-- does not contact loopback or external network services
+- does not access cookies, unscoped browser storage, loopback, or external
+  network services
 - does not use arbitrary filesystem or native host APIs
 
 ## Compatibility
 
-- manifest-bundled extension assets + same-origin serving under `/extensions/`
-- the composer send button `#btnSend` with its `data-action` / busy-class
-  contract (used to detect turn completion)
-- a device with `navigator.vibrate` (Android) for any actual effect
+The minimum lifecycle contract is **exp-v0.52.201 / Core #6924**, which provides
+the cooperative E0 scoped identity handle and B1 turn-lifecycle events. Older
+Core builds fail closed with a warning; this extension does not fall back to
+private DOM state or legacy storage.
 
 ## Verification
 
 ```bash
+node scripts/test-mobile-haptics.mjs
 node scripts/validate-extensions.mjs
 node scripts/scan-extension-safety.mjs
 node scripts/generate-registry.mjs --out dist/registry.json
@@ -121,20 +125,19 @@ python3 -m json.tool extensions/mobile-haptics/extension.json
 python3 -m json.tool extensions/mobile-haptics/manifest.json
 ```
 
-Functional verification (the busy → idle detection is the testable core; the
-actual vibration only fires on Android hardware):
+Functional verification (the lifecycle handler is covered by the Node contract
+test; the actual vibration only fires on Android hardware):
 
 - on a desktop browser, `HermesMobileHapticsExtension.supported` is `false` and
   no error occurs
-- sending a message flips `#btnSend` to a busy action and back; the extension's
-  state machine logs/triggers on the idle transition
-- on an Android device, completing a turn produces a short buzz when enabled
+- with Core exp-v0.52.201 or newer, completing a turn emits one
+  `turn:complete` event and produces a short buzz when enabled
+- on an older Core without E0/B1, the extension logs a warning and remains
+  inactive
 
 ## Known Limitations
 
 - No effect on desktop or iOS (platform limitation of `navigator.vibrate`).
-- Detects turn completion from the send-button state, so it relies on the
-  current `#btnSend` `data-action` / busy-class contract.
 - Browsers may suppress vibration until the user has interacted with the page
   (a standard mobile-browser gesture requirement); sending a message satisfies
   that.

--- a/extensions/mobile-haptics/assets/mobile-haptics.js
+++ b/extensions/mobile-haptics/assets/mobile-haptics.js
@@ -2,141 +2,118 @@
   'use strict';
 
   // ── Mobile Haptics extension for Hermes WebUI ────────────────────────────
-  // Gives a short device vibration when an assistant turn finishes, so a phone
-  // user who set the device down gets a physical "it's done" cue. Opt-in and
-  // mobile-only by nature (navigator.vibrate is a no-op on desktop and is not
-  // supported on iOS Safari — so this is effectively an Android / Android-PWA
-  // feature; it degrades silently everywhere else).
-  //
-  // It cannot see SSE events, so it detects "turn complete" purely from the DOM:
-  // the composer send button (#btnSend) carries a busy action (stop / steer /
-  // interrupt) while the assistant is generating, and returns to the idle 'send'
-  // action when the turn finishes. The busy -> idle transition is the trigger.
+  // Give a short device vibration when the current page observes a completed
+  // assistant turn. This extension relies only on the cooperative E0/B1
+  // extension capability handle; it does not inspect Core-owned DOM state.
 
   const EXT = 'mobile-haptics';
   if (window.__hermesMobileHapticsLoaded) return;
   window.__hermesMobileHapticsLoaded = true;
 
-  const PREF_KEY = 'hermes-ext-haptics-enabled';      // legacy localStorage key (pre-settings_schema)
-  const COMPLETE_PATTERN = [18];                       // short single buzz on turn-complete
-  const BUSY_ACTIONS = new Set(['stop', 'steer', 'interrupt']);
-  const MIN_BUSY_MS = 100;                            // tiny floor: filters pure flicker; the sawBusy flag is the real "a turn happened" gate
-
-  let sawBusy = false;        // have we observed a genuine busy (stop/steer/interrupt) action this turn?
-  let busyStartedAt = 0;      // when the busy period began
-  let observer = null;
+  const COMPLETE_PATTERN = [18];
 
   function hapticsSupported() {
     return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
   }
 
-  // The 'enabled' preference now lives in the sanctioned extension-settings store
-  // (settings_schema key `enabled`), so it renders as a native toggle under
-  // Settings → Extensions → Mobile Haptics. Read through HermesExtensionSettings
-  // when core supports it; fall back to the legacy localStorage key on older core
-  // (so the toggle still works if this loads against a build without the settings
-  // system). Default ON either way. (Retrofit — issue #34.)
-  function extSettings() {
-    try {
-      var api = window.HermesExtensionSettings;
-      if (api && typeof api.settingsForExtension === 'function') {
-        var s = api.settingsForExtension('mobile-haptics');
-        if (s && s.supported) return s;
-      }
-    } catch (_) {}
-    return null;
+  function warn(message) {
+    try { console.warn('[' + EXT + '] ' + message); } catch (_) {}
   }
 
-  function enabled() {
-    var s = extSettings();
-    if (s) { var v = s.get('enabled'); return v === undefined ? true : v !== false; }
-    // Legacy fallback: localStorage key, default ON.
+  function scopedCapability() {
+    const api = window.hermesExt;
+    if (!api || typeof api.register !== 'function') {
+      warn('hermesExt.register is unavailable; haptics disabled');
+      return null;
+    }
+
+    let ext;
     try {
-      const v = localStorage.getItem(PREF_KEY);
-      return v === null ? true : v === '1';
-    } catch (_) { return true; }
+      ext = api.register(EXT);
+    } catch (_) {
+      warn('hermesExt.register failed; haptics disabled');
+      return null;
+    }
+    if (!ext || ext.id !== EXT) {
+      warn('scoped extension handle is unavailable; haptics disabled');
+      return null;
+    }
+
+    const settings = ext.settings;
+    if (!settings || typeof settings.get !== 'function' || typeof settings.set !== 'function') {
+      warn('scoped settings are unavailable; haptics disabled');
+      return null;
+    }
+    if (!ext.events || typeof ext.events.on !== 'function') {
+      warn('scoped lifecycle events are unavailable; haptics disabled');
+      return null;
+    }
+    return ext;
+  }
+
+  const ext = scopedCapability();
+  const settings = ext && ext.settings;
+  let lifecycleReady = false;
+
+  function enabled() {
+    if (!settings) return false;
+    try {
+      const value = settings.get('enabled');
+      return value === undefined ? true : value !== false;
+    } catch (_) {
+      return false;
+    }
   }
 
   function setEnabled(on) {
-    var s = extSettings();
-    if (s) { try { s.set('enabled', !!on); return; } catch (_) {} }
-    try { localStorage.setItem(PREF_KEY, on ? '1' : '0'); } catch (_) {}
-  }
-
-  function sendBtnAction() {
-    const btn = document.getElementById('btnSend');
-    if (!btn) return null;
-    const a = btn.dataset ? btn.dataset.action : null;
-    if (a) return a;
-    for (const cls of BUSY_ACTIONS) if (btn.classList.contains(cls)) return cls;
-    return 'send';
-  }
-
-  // Turn lifecycle as reflected by #btnSend's action:
-  //   send  -> (busy: stop/steer/interrupt, possibly interleaved with 'disabled'
-  //             while the composer is empty mid-stream) -> back to send/disabled idle.
-  // The reliable "turn complete" signal is: we saw a genuine busy action, and the
-  // button has now returned to the idle 'send'/'disabled' state. 'disabled' alone
-  // is NOT busy (empty composer) and NOT a completion on its own — only the
-  // transition OUT of a confirmed-busy turn counts.
-  function onStateMaybeChanged() {
-    const action = sendBtnAction();
-    const busy = BUSY_ACTIONS.has(action);
-    if (busy) {
-      if (!sawBusy) { sawBusy = true; busyStartedAt = Date.now(); }
-      return;
+    if (!settings) return false;
+    try {
+      const result = settings.set('enabled', !!on);
+      return !!(result && typeof result === 'object' && result.ok === true);
+    } catch (_) {
+      return false;
     }
-    // 'queue' is NOT completion: core sets #btnSend.dataset.action to 'queue' while
-    // an assistant turn is STILL active and the user has typed/queued a follow-up
-    // (static/ui.js getComposerPrimaryAction). Treat it as a holding state so a
-    // mid-turn stop->queue transition does not fire a premature buzz (and then a
-    // second one on the real completion). (Codex gate, PR #22.)
-    if (sawBusy && action === 'queue') return;
-    // Not a busy/holding action. If we had seen a busy action this turn, it's done.
-    if (sawBusy) {
-      const ranFor = Date.now() - busyStartedAt;
-      sawBusy = false;
-      if (ranFor >= MIN_BUSY_MS && enabled() && hapticsSupported()) {
-        try { navigator.vibrate(COMPLETE_PATTERN); } catch (_) {}
+  }
+
+  function onTurnComplete(event) {
+    if (!lifecycleReady) return;
+    if (!event || event.type !== 'turn:complete') return;
+    if (!enabled() || !hapticsSupported()) return;
+    try { navigator.vibrate(COMPLETE_PATTERN); } catch (_) {}
+  }
+
+  if (ext) {
+    try {
+      const unsubscribe = ext.events.on('turn:complete', onTurnComplete);
+      if (typeof unsubscribe === 'function') {
+        lifecycleReady = true;
+      } else {
+        warn('turn:complete subscription was rejected; haptics disabled');
       }
+    } catch (_) {
+      warn('turn:complete subscription failed; haptics disabled');
     }
   }
 
-  function startObserver() {
-    const btn = document.getElementById('btnSend');
-    if (!btn || observer) return !!observer;
-    // Watch the send button's class + data-action for the busy/idle flip.
-    observer = new MutationObserver(onStateMaybeChanged);
-    observer.observe(btn, { attributes: true, attributeFilter: ['class', 'data-action'] });
-    sawBusy = BUSY_ACTIONS.has(sendBtnAction());
-    if (sawBusy) busyStartedAt = Date.now();
-    return true;
-  }
-
-  function install(attempt) {
-    attempt = attempt || 0;
-    if (document.getElementById('btnSend')) {
-      startObserver();
-      window.HermesMobileHapticsExtension = {
-        version: '0.1.0',
-        supported: hapticsSupported(),
-        isEnabled: enabled,
-        setEnabled: setEnabled,
-        test() { if (hapticsSupported()) { try { navigator.vibrate(COMPLETE_PATTERN); return true; } catch (_) {} } return false; }
-      };
-      if (!hapticsSupported()) {
-        console.info('[' + EXT + '] navigator.vibrate not supported on this device (desktop / iOS Safari); haptics inactive.');
+  window.HermesMobileHapticsExtension = {
+    version: '0.1.0',
+    supported: hapticsSupported(),
+    isEnabled: enabled,
+    setEnabled,
+    test() {
+      if (!lifecycleReady || !hapticsSupported()) return false;
+      try {
+        navigator.vibrate(COMPLETE_PATTERN);
+        return true;
+      } catch (_) {
+        return false;
       }
-      return true;
-    }
-    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false; }
-    console.warn('[' + EXT + '] send button (#btnSend) not found; haptics not installed');
-    return false;
-  }
+    },
+  };
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => install(), { once: true });
-  } else {
-    install();
+  if (!hapticsSupported()) {
+    try {
+      console.info('[' + EXT + '] navigator.vibrate not supported on this device (desktop / iOS Safari); haptics inactive.');
+    } catch (_) {}
   }
 })();

--- a/scripts/test-mobile-haptics.mjs
+++ b/scripts/test-mobile-haptics.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const extensionSource = readFileSync(
+  path.join(repoRoot, 'extensions/mobile-haptics/assets/mobile-haptics.js'),
+  'utf8'
+);
+
+function createHarness({
+  registerMode = 'valid',
+  settingValue = true,
+  settingWriteAccepted = true,
+  vibrateSupported = true,
+} = {}) {
+  const registrations = [];
+  const subscriptions = [];
+  const vibrateCalls = [];
+  const settingGets = [];
+  const settingSets = [];
+  const warnings = [];
+  const infos = [];
+  const timers = [];
+  const documentLookups = [];
+  let setting = settingValue;
+
+  const settings = {
+    supported: true,
+    get(key) {
+      settingGets.push(key);
+      return key === 'enabled' ? setting : undefined;
+    },
+    set(key, value) {
+      settingSets.push([key, value]);
+      if (!settingWriteAccepted) {
+        return { ok: false, values: { enabled: setting }, errors: { storage: 'unavailable' } };
+      }
+      if (key === 'enabled') setting = value;
+      return { ok: true, values: { enabled: setting }, errors: {} };
+    },
+  };
+
+  const events = {
+    on(type, handler) {
+      subscriptions.push({ type, handler });
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        const index = subscriptions.findIndex(
+          (subscription) => subscription.type === type && subscription.handler === handler
+        );
+        if (index >= 0) subscriptions.splice(index, 1);
+      };
+    },
+  };
+
+  const handle = {
+    id: 'mobile-haptics',
+    settings,
+    events,
+  };
+
+  const hermesExt = {
+    register(id) {
+      registrations.push(id);
+      return registerMode === 'null' ? null : handle;
+    },
+  };
+
+  const document = {
+    readyState: 'complete',
+    addEventListener() {},
+    getElementById(id) {
+      documentLookups.push(id);
+      return null;
+    },
+  };
+
+  const navigator = vibrateSupported
+    ? { vibrate(pattern) { vibrateCalls.push(Array.from(pattern)); } }
+    : {};
+  const console = {
+    warn(message) { warnings.push(String(message)); },
+    info(message) { infos.push(String(message)); },
+    error(message) { warnings.push(String(message)); },
+    log() {},
+  };
+  const window = { document, navigator };
+  if (registerMode !== 'missing') window.hermesExt = hermesExt;
+
+  const context = {
+    window,
+    document,
+    navigator,
+    console,
+    setTimeout(callback, delay) {
+      const timer = { callback, delay };
+      timers.push(timer);
+      return timers.length;
+    },
+    clearTimeout() {},
+  };
+  vm.createContext(context);
+
+  function runScript() {
+    vm.runInContext(extensionSource, context, { filename: 'mobile-haptics.js' });
+  }
+
+  function emit(type = 'turn:complete') {
+    const event = {
+      type,
+      sessionId: 'session-test',
+      streamId: 'stream-test',
+      timestamp: 1700000000,
+      endedAt: 1700000001,
+      status: 'completed',
+    };
+    for (const subscription of [...subscriptions]) {
+      if (subscription.type === type) subscription.handler(event);
+    }
+  }
+
+  runScript();
+  return {
+    context,
+    window,
+    registrations,
+    subscriptions,
+    vibrateCalls,
+    settingGets,
+    settingSets,
+    warnings,
+    infos,
+    timers,
+    documentLookups,
+    runScript,
+    emit,
+  };
+}
+
+function assertScopedRegistration(harness) {
+  assert.deepEqual(harness.registrations, ['mobile-haptics'],
+    'the extension must register its exact manifest ID');
+  assert.deepEqual(harness.subscriptions.map(({ type }) => type), ['turn:complete'],
+    'the extension must subscribe only to turn:complete');
+}
+
+// E0/B1 should work without any Core-owned DOM surface, retry timer, or
+// legacy settings object. This is the primary regression guard for the move
+// away from #btnSend polling.
+{
+  const harness = createHarness();
+  assertScopedRegistration(harness);
+  assert.deepEqual(harness.documentLookups, [], 'the extension must not look up #btnSend');
+  assert.deepEqual(harness.timers, [], 'the extension must not install a retry timer');
+}
+
+// A normal completed turn produces exactly one short vibration.
+{
+  const harness = createHarness();
+  harness.emit('turn:complete');
+  assert.deepEqual(harness.vibrateCalls, [[18]],
+    'turn:complete should vibrate once with the short completion pattern');
+}
+
+// Settings are read and written through the scoped handle only.
+{
+  const harness = createHarness({ settingValue: false });
+  harness.emit('turn:complete');
+  assert.deepEqual(harness.vibrateCalls, [], 'disabled settings must suppress vibration');
+  const controls = harness.window.HermesMobileHapticsExtension;
+  assert.ok(controls, 'the extension control surface should still be exposed');
+  assert.strictEqual(controls.setEnabled(true), true,
+    'setEnabled must report a successful scoped settings write');
+  assert.deepEqual(harness.settingSets, [['enabled', true]],
+    'setEnabled must write through the scoped settings handle');
+  assert.equal(controls.isEnabled(), true, 'isEnabled should read the scoped setting');
+  harness.emit('turn:complete');
+  assert.deepEqual(harness.vibrateCalls, [[18]],
+    'an enabled setting should allow the next completed turn to vibrate');
+  assert.ok(harness.settingGets.includes('enabled'),
+    'isEnabled should read the enabled key from scoped settings');
+}
+
+// A rejected Core settings write must be reported to the caller and must not
+// change the value observed by a later read.
+{
+  const harness = createHarness({ settingValue: true, settingWriteAccepted: false });
+  const controls = harness.window.HermesMobileHapticsExtension;
+  assert.equal(controls.setEnabled(false), false,
+    'setEnabled must report a rejected scoped settings write');
+  assert.equal(controls.isEnabled(), true,
+    'a rejected settings write must leave the prior enabled value unchanged');
+  assert.deepEqual(harness.settingSets, [['enabled', false]],
+    'the rejected write must still target the scoped enabled key');
+}
+
+// Unsupported platforms are a no-op and must not throw.
+{
+  const harness = createHarness({ vibrateSupported: false });
+  const controls = harness.window.HermesMobileHapticsExtension;
+  assert.ok(controls, 'the control surface should exist on unsupported platforms');
+  assert.equal(controls.supported, false, 'unsupported navigator should be reported');
+  assert.doesNotThrow(() => {
+    harness.emit('turn:complete');
+    assert.equal(controls.test(), false);
+  });
+  assert.deepEqual(harness.vibrateCalls, [], 'unsupported navigator must not vibrate');
+}
+
+// An unavailable registration capability fails closed: no event listener,
+// no vibration, and an actionable warning. Exercise both missing and null
+// registration results because old Core builds may expose either shape.
+for (const registerMode of ['null', 'missing']) {
+  const harness = createHarness({ registerMode });
+  assert.deepEqual(harness.subscriptions, [],
+    `${registerMode} registration must not subscribe to lifecycle events`);
+  harness.emit('turn:complete');
+  assert.deepEqual(harness.vibrateCalls, [],
+    `${registerMode} registration must not vibrate`);
+  assert.ok(harness.warnings.some((message) => /register|scoped|unavailable/i.test(message)),
+    `${registerMode} registration must emit a clear warning`);
+}
+
+// The load guard must make repeated asset execution idempotent.
+{
+  const harness = createHarness();
+  harness.runScript();
+  assert.deepEqual(harness.registrations, ['mobile-haptics'],
+    'repeated execution must not register the extension twice');
+  assert.deepEqual(harness.subscriptions.map(({ type }) => type), ['turn:complete'],
+    'repeated execution must not subscribe twice');
+}
+
+console.log('ok - mobile-haptics E0/B1 lifecycle contract passed');


### PR DESCRIPTION
## Summary

- replace Mobile Haptics' private `#btnSend` / `MutationObserver` completion heuristic with the cooperative E0/B1 extension contract
- register the exact `mobile-haptics` identity and subscribe only to `turn:complete`
- read and write `enabled` through the scoped settings handle, including truthful handling of rejected writes
- add a behavioral Node contract test, CI coverage, and updated compatibility documentation

## Why

The previous implementation inferred turn completion from composer button state. That tied the extension to private Core DOM details and required its own timing and transition logic. Core now provides the supported lifecycle signal through `window.hermesExt` (minimum exp-v0.52.201 / nesquena/hermes-webui#6924), so the extension can consume the authoritative event instead.

Older Core builds without the scoped E0/B1 handle fail closed with a warning. They do not fall back to DOM polling or legacy browser storage.

## Validation

- RED: before the product change, `node scripts/test-mobile-haptics.mjs` exited 1 because the extension did not register its exact manifest ID
- GREEN: `node scripts/test-mobile-haptics.mjs` exits 0 and covers exact registration, one lifecycle subscription, scoped settings success and rejection, unsupported platforms, unavailable capability, and repeated asset execution
- `node --check extensions/mobile-haptics/assets/mobile-haptics.js`
- `node scripts/test-extension-validator.mjs`
- `node scripts/validate-extensions.mjs`
- `node scripts/scan-extension-safety.mjs`
- `node scripts/test-message-pins-sync.mjs`
- all sidecar validation and registry-generation gates
- compatibility unittest suite against pinned Core `3c7fbe3809ff573199faee9d812179fcbeff2028`: 23 tests passed
- real-Core E0/B1 capability smoke: registration passed, lifecycle start + exactly one completion passed, settled-idle invariant passed
- `git diff --check`

## Out of scope / not verified

- no Core, manifest, permission, or settings-schema changes
- no Android hardware or PWA vibration test was performed locally
