### PR TITLE
test: certify Configure capability against real Core

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -151,9 +151,10 @@ jobs:
           repository: nesquena/hermes-webui
           # Pin the independently verified Core contract; update this SHA only
           # after a maintainer reruns the smoke against the new Core head.
-          # exp-v0.52.201 — first release carrying both the cooperative E0
-          # identity handle and B1 turn-lifecycle event contract.
-          ref: 3c7fbe3809ff573199faee9d812179fcbeff2028
+          # exp-v0.52.241 — first release carrying the cooperative E0
+          # identity handle, B1 turn-lifecycle event contract, and scoped
+          # Configure hook.
+          ref: b1c2bea92ee8369797d051a0e0789968bd351343
           path: .ci/hermes-webui-core
           fetch-depth: 1
           persist-credentials: false
@@ -181,7 +182,7 @@ jobs:
           mkdir -p "$COMPATIBILITY_EVIDENCE_DIR"
           python tests/compatibility/browser_smoke.py
 
-      - name: Run E0/B1 capability baseline smoke
+      - name: Run E0/B1/Configure capability smoke
         env:
           HERMES_CORE_DIR: .ci/hermes-webui-core
           COMPATIBILITY_EVIDENCE_DIR: compatibility-evidence

--- a/docs/compatibility-smoke.md
+++ b/docs/compatibility-smoke.md
@@ -2,7 +2,7 @@
 
 The compatibility-certification job runs a real Hermes WebUI Core checkout and
 headless Chromium. It combines an allow-listed merged extension reference, a
-test-only E0/B1 capability probe, and Typography's dedicated browser scenarios;
+test-only E0/B1/Configure capability probe, and Typography's dedicated browser scenarios;
 it is not a claim that every changed extension has browser coverage.
 
 ## Current contract
@@ -58,7 +58,7 @@ Assertions use the extension's own id/data/ARIA surfaces. The Core host
 selector is only a readiness precondition, not the extension pass/fail oracle;
 Core remains the real host that serves the app shell and injected assets.
 
-### E0/B1 capability baseline
+### E0/B1/Configure capability certification
 
 The separate test-only `capability-probe` fixture certifies the public Core
 foundation that merged extensions can build on. It runs in the same isolated,
@@ -72,11 +72,27 @@ no-provider real Core browser environment and proves that:
 - the terminal callback observes the active stream cleared, the pane idle, and
   the settled assistant transcript; and
 - a duplicate terminal dispatch for that session/stream is rejected.
+- a boot-trusted fixture with no `settings_schema` and no
+  `permissions.storage.owned` receives `ext.settings.registerConfigure` as a
+  function; one handler registers, a duplicate fails closed, and its
+  unregister function is idempotent;
+- the effective-enabled fixture renders exactly one **Configure** button under
+  Settings → Extensions → Installed and none under Diagnostics;
+- Configure enters pending before the handler runs, suppresses a second click,
+  settles back to a reusable button, and restores focus exactly once to the
+  opener; and
+- an intentional handler failure emits the exact Core diagnostic
+  `[Hermes extensions] capability-probe Configure handler failed: Error:
+  capability-probe intentional Configure failure`, shows Core's generic
+  `Extension configuration failed.` UI, leaves Settings usable, and produces
+  no unhandled page error.
 
 The fixture replaces `EventSource` only for the controlled lifecycle invocation;
 Core still owns the live-stream handler, state transition, event normalization,
-and duplicate suppression being exercised. It does not contact a provider or
-claim durable/global event delivery.
+and duplicate suppression being exercised. Configure uses the real Settings UI;
+the fixture only controls its deterministic first (thenable) and second
+(intentional failure) handler outcomes. It does not contact a provider or claim
+durable/global event delivery.
 
 ## Local run
 
@@ -111,8 +127,8 @@ page.
 
 The `browser-compatibility` job checks out `nesquena/hermes-webui` independently
 at the pinned, maintainer-verified Core SHA in
-`.github/workflows/extensions.yml` (`3c7fbe3809ff573199faee9d812179fcbeff2028`,
-release `exp-v0.52.201`),
+`.github/workflows/extensions.yml` (`b1c2bea92ee8369797d051a0e0789968bd351343`,
+release `exp-v0.52.241`),
 installs the complete hash-locked Core/browser-smoke and Playwright dependency
 surface from `tests/compatibility/requirements.txt` with
 `pip --require-hashes`, and

--- a/tests/compatibility/capability_smoke.py
+++ b/tests/compatibility/capability_smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Certify the pinned Core E0 identity and B1 turn-lifecycle contracts."""
+"""Certify the pinned Core E0, B1, and scoped Configure contracts."""
 
 from __future__ import annotations
 
@@ -20,9 +20,33 @@ FIXTURE_ROOT = Path(__file__).resolve().parent / "fixtures" / "e0-b1-capability-
 PROBE_SCRIPT_FRAGMENT = "/extensions/capability-probe/assets/capability-probe.js"
 SESSION_ID = "capability-session"
 STREAM_ID = "capability-stream"
+EXPECTED_CONFIGURE_FAILURE = "capability-probe intentional Configure failure"
+EXPECTED_CONFIGURE_DIAGNOSTIC = (
+    "[Hermes extensions] capability-probe Configure handler failed: "
+    f"Error: {EXPECTED_CONFIGURE_FAILURE}"
+)
+EXPECTED_CONFIGURE_UI_FAILURE = "Extension configuration failed."
 
 SetupFailure = browser_smoke.SetupFailure
 CompatibilityFailure = browser_smoke.CompatibilityFailure
+
+
+def _is_expected_configure_diagnostic(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    text = entry.get("text")
+    if not isinstance(text, str):
+        return False
+    first_line = text.splitlines()[0] if text else ""
+    return first_line == EXPECTED_CONFIGURE_DIAGNOSTIC
+
+
+def _unexpected_page_errors(page_errors: list[str]) -> list[str]:
+    return [
+        text
+        for text in page_errors
+        if not browser_smoke._is_benign_core_page_error(text)
+    ]
 
 
 def _parse_args() -> argparse.Namespace:
@@ -102,6 +126,244 @@ def _validate_probe_result(result: dict[str, Any]) -> None:
         raise CompatibilityFailure(
             "B1 accepted a duplicate terminal event for the same session/stream"
         )
+
+    configure = result.get("configure")
+    if not isinstance(configure, dict):
+        raise CompatibilityFailure(
+            f"Configure compatibility result is missing or malformed: {configure!r}"
+        )
+    expected_registration = {
+        "api_function": True,
+        "registered": True,
+        "duplicate_rejected": True,
+        "unregister_idempotent": True,
+    }
+    if configure.get("registration") != expected_registration:
+        raise CompatibilityFailure(
+            f"Configure registration contract mismatch: {configure.get('registration')!r}"
+        )
+    expected_scalars = {
+        "installed_buttons": 1,
+        "diagnostics_buttons": 0,
+        "pending_before_handler": True,
+        "second_click_suppressed": True,
+        "reusable_after_settlement": True,
+    }
+    for key, expected in expected_scalars.items():
+        if configure.get(key) != expected:
+            raise CompatibilityFailure(
+                f"Configure {key} mismatch: {configure.get(key)!r}"
+            )
+    focus_restores = configure.get("focus_restores")
+    if focus_restores != {"success": 1, "failure": 1}:
+        raise CompatibilityFailure(
+            f"Configure settlement focus restoration mismatch: {focus_restores!r}"
+        )
+    failure = configure.get("failure")
+    expected_failure = {
+        "diagnostic": EXPECTED_CONFIGURE_DIAGNOSTIC,
+        "generic_ui_message": EXPECTED_CONFIGURE_UI_FAILURE,
+        "page_errors": [],
+        "settings_usable": True,
+    }
+    if failure != expected_failure:
+        raise CompatibilityFailure(
+            f"Configure failure isolation mismatch: {failure!r}"
+        )
+
+
+def _run_configure_ui(
+    page: Any,
+    page_errors: list[str],
+) -> dict[str, Any]:
+    """Exercise the shipped Configure hook through Settings → Extensions."""
+
+    try:
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+    except ImportError as exc:
+        raise SetupFailure(
+            "Playwright is required; install tests/compatibility/requirements.txt"
+        ) from exc
+
+    button_selector = (
+        '#extensionsInstalled [data-extension-configure-id="capability-probe"]'
+    )
+    ui_stage = "settings-click"
+    try:
+        # Navigate through the actual Settings controls so the assertions cover
+        # the mounted user surface, not only the private renderer helpers.
+        page.locator('button[data-panel="settings"]').first.click()
+        ui_stage = "settings-panel"
+        page.locator("#panelSettings").wait_for(
+            state="visible", timeout=browser_smoke.ENTRY_TIMEOUT_MS
+        )
+        ui_stage = "extensions-section-click"
+        page.locator(
+            '#settingsMenu button[data-settings-section="extensions"]'
+        ).click()
+        ui_stage = "extensions-pane"
+        page.locator("#settingsPaneExtensions").wait_for(
+            state="visible", timeout=browser_smoke.ENTRY_TIMEOUT_MS
+        )
+        ui_stage = "installed-tab"
+        page.locator('button[data-extensions-tab="installed"]').click()
+        ui_stage = "installed-list"
+        page.locator("#extensionsInstalled .extension-installed-list").wait_for(
+            state="visible", timeout=browser_smoke.ENTRY_TIMEOUT_MS
+        )
+        ui_stage = "configure-button"
+        page.locator(button_selector).wait_for(
+            state="visible", timeout=browser_smoke.ENTRY_TIMEOUT_MS
+        )
+    except PlaywrightTimeoutError as exc:
+        raise CompatibilityFailure(
+            "Configure Settings UI did not render the effective-enabled fixture "
+            f"(stage={ui_stage})"
+        ) from exc
+
+    installed_buttons = page.locator(button_selector).count()
+
+    page.locator('button[data-extensions-tab="diagnostics"]').click()
+    try:
+        page.locator("#extensionsDiagnostics .extension-installed-list").wait_for(
+            state="visible", timeout=browser_smoke.ENTRY_TIMEOUT_MS
+        )
+    except PlaywrightTimeoutError as exc:
+        raise CompatibilityFailure(
+            "Configure Diagnostics surface did not render"
+        ) from exc
+    diagnostics_buttons = page.locator(
+        '#extensionsDiagnostics [data-extension-configure-id="capability-probe"]'
+    ).count()
+
+    page.locator('button[data-extensions-tab="installed"]').click()
+    page.locator(button_selector).wait_for(
+        state="visible", timeout=browser_smoke.ENTRY_TIMEOUT_MS
+    )
+
+    page.locator(button_selector).evaluate(
+        """button => {
+          button.__configureFocusRestoreCount = 0;
+          const nativeFocus = button.focus.bind(button);
+          button.focus = (...args) => {
+            button.__configureFocusRestoreCount += 1;
+            return nativeFocus(...args);
+          };
+        }"""
+    )
+    button = page.locator(button_selector)
+    button.click()
+    try:
+        page.wait_for_function(
+            """() => {
+              const probe = window.HermesCapabilityBaselineProbe;
+              const state = window.HermesExtensionSettings
+                ._configureStateForExtension('capability-probe');
+              const button = document.querySelector(%r);
+              return probe.configure.invocations === 1
+                && probe.configure.pending_before_handler === true
+                && state.pending === true
+                && button && button.disabled === true;
+            }""" % button_selector,
+            timeout=browser_smoke.ENTRY_TIMEOUT_MS,
+        )
+    except PlaywrightTimeoutError as exc:
+        raise CompatibilityFailure(
+            "Configure did not enter pending before invoking the handler"
+        ) from exc
+
+    pending_before_handler = page.evaluate(
+        "() => window.HermesCapabilityBaselineProbe.configure.pending_before_handler"
+    )
+    invocations_before_suppressed_click = page.evaluate(
+        "() => window.HermesCapabilityBaselineProbe.configure.invocations"
+    )
+    page.evaluate(
+        """selector => {
+          const button = document.querySelector(selector);
+          if (button) button.click();
+        }""",
+        button_selector,
+    )
+    page.wait_for_timeout(50)
+    invocations_after_suppressed_click = page.evaluate(
+        "() => window.HermesCapabilityBaselineProbe.configure.invocations"
+    )
+    second_click_suppressed = (
+        invocations_after_suppressed_click == invocations_before_suppressed_click
+    )
+
+    if not page.evaluate("() => window.HermesCapabilityBaselineProbe.resolveConfigure()"):
+        raise CompatibilityFailure("Configure success handler could not be settled")
+    try:
+        page.wait_for_function(
+            """() => {
+              const state = window.HermesExtensionSettings
+                ._configureStateForExtension('capability-probe');
+              const button = document.querySelector(%r);
+              return state.pending === false && button && button.disabled === false;
+            }""" % button_selector,
+            timeout=browser_smoke.ENTRY_TIMEOUT_MS,
+        )
+    except PlaywrightTimeoutError as exc:
+        raise CompatibilityFailure(
+            "Configure settlement did not restore a reusable button"
+        ) from exc
+    success_focus_count = page.locator(button_selector).evaluate(
+        "button => button.__configureFocusRestoreCount"
+    )
+
+    button.click()
+    try:
+        page.wait_for_function(
+            "() => window.HermesCapabilityBaselineProbe.configure.invocations === 2",
+            timeout=browser_smoke.ENTRY_TIMEOUT_MS,
+        )
+        page.wait_for_function(
+            """() => document.querySelector('#toast')?.dataset.toastMessage
+              === %r""" % EXPECTED_CONFIGURE_UI_FAILURE,
+            timeout=browser_smoke.ENTRY_TIMEOUT_MS,
+        )
+        page.wait_for_function(
+            """() => {
+              const state = window.HermesExtensionSettings
+                ._configureStateForExtension('capability-probe');
+              const button = document.querySelector(%r);
+              return state.pending === false && button && button.disabled === false;
+            }""" % button_selector,
+            timeout=browser_smoke.ENTRY_TIMEOUT_MS,
+        )
+    except PlaywrightTimeoutError as exc:
+        raise CompatibilityFailure(
+            "Configure failure did not settle with the expected generic UI error"
+        ) from exc
+    failure_focus_count = page.locator(button_selector).evaluate(
+        "button => button.__configureFocusRestoreCount"
+    )
+    generic_ui_message = page.locator("#toast").get_attribute("data-toast-message")
+    reusable_after_settlement = page.locator(button_selector).is_enabled()
+    settings_usable = (
+        page.locator("#settingsPaneExtensions").is_visible()
+        and page.locator(button_selector).count() == 1
+    )
+
+    return {
+        "installed_buttons": installed_buttons,
+        "diagnostics_buttons": diagnostics_buttons,
+        "pending_before_handler": pending_before_handler,
+        "second_click_suppressed": second_click_suppressed,
+        "focus_restores": {
+            "success": success_focus_count,
+            "failure": failure_focus_count - success_focus_count,
+        },
+        "reusable_after_settlement": reusable_after_settlement,
+        "failure": {
+            "diagnostic": None,
+            "generic_ui_message": generic_ui_message,
+            "page_errors": _unexpected_page_errors(page_errors),
+            "settings_usable": settings_usable,
+        },
+    }
 
 
 def _run_probe(base_url: str, evidence_dir: Path) -> dict[str, Any]:
@@ -190,12 +452,35 @@ def _run_probe(base_url: str, evidence_dir: Path) -> dict[str, Any]:
             result = page.evaluate(
                 "() => window.HermesCapabilityBaselineProbe.runCompleteLifecycle()"
             )
+            configure_result = _run_configure_ui(page, page_errors)
+            result["configure"] = configure_result
+            expected_diagnostics = [
+                entry
+                for entry in console_errors
+                if _is_expected_configure_diagnostic(entry)
+            ]
+            if len(expected_diagnostics) != 1:
+                raise CompatibilityFailure(
+                    "Configure failure did not emit exactly the expected Core diagnostic: "
+                    f"{expected_diagnostics!r}"
+                )
+            configure_result["failure"]["diagnostic"] = str(
+                expected_diagnostics[0]["text"]
+            ).splitlines()[0]
+            browser_smoke._record_screenshot(page, screenshot_path)
+            configure_result["registration"] = page.evaluate(
+                "() => window.HermesCapabilityBaselineProbe.finishConfigureRegistration()"
+            )
+            unexpected_console_errors = [
+                entry
+                for entry in console_errors
+                if not _is_expected_configure_diagnostic(entry)
+            ]
             _validate_probe_result(result)
             page.wait_for_timeout(250)
-            browser_smoke._record_screenshot(page, screenshot_path)
             browser_smoke._assert_browser_health(
                 case_name="e0-b1-capability",
-                console_errors=console_errors,
+                console_errors=unexpected_console_errors,
                 page_errors=page_errors,
                 extension_fragments=(PROBE_SCRIPT_FRAGMENT,),
                 network_events=network_events,
@@ -222,7 +507,7 @@ def main() -> int:
     evidence_dir.mkdir(parents=True, exist_ok=True)
     result_path = evidence_dir / "e0-b1-capability-results.json"
     result: dict[str, Any] = {
-        "core_contract": "E0+B1",
+        "core_contract": "E0+B1+Configure",
         "fixture_extension": "capability-probe",
     }
     proc = None
@@ -258,8 +543,11 @@ def main() -> int:
                 proc = None
                 log_file = None
         browser_smoke._write_json(result_path, result)
-        print("E0/B1 CAPABILITY COMPATIBILITY PASSED")
-        print("registration=passed lifecycle=start+complete-once settled-idle=passed")
+        print("E0/B1/CONFIGURE CAPABILITY COMPATIBILITY PASSED")
+        print(
+            "registration=passed lifecycle=start+complete-once settled-idle=passed "
+            "configure=registered-ui-pending-focus-failure-isolated"
+        )
         print(f"evidence={evidence_dir}")
         return 0
     except SetupFailure as exc:

--- a/tests/compatibility/fixtures/e0-b1-capability-probe/assets/capability-probe.js
+++ b/tests/compatibility/fixtures/e0-b1-capability-probe/assets/capability-probe.js
@@ -4,7 +4,17 @@
   const EXTENSION_ID = 'capability-probe';
   const SESSION_ID = 'capability-session';
   const STREAM_ID = 'capability-stream';
+  const EXPECTED_CONFIGURE_FAILURE = 'capability-probe intentional Configure failure';
   const events = [];
+  const configureProbe = {
+    api_function: false,
+    registered: false,
+    duplicate_rejected: false,
+    invocations: 0,
+    pending_before_handler: false,
+  };
+  let configureUnregister = null;
+  let configureResolver = null;
 
   const storageKeys = () => Array.from(
     { length: window.localStorage.length },
@@ -18,6 +28,31 @@
   const unknown = register ? register('untrusted-capability-probe') : undefined;
   const afterUnknown = storageKeys();
   const extension = register ? register(EXTENSION_ID) : null;
+  const settingsRuntime = window.HermesExtensionSettings;
+
+  if (extension && extension.settings) {
+    const registerConfigure = extension.settings.registerConfigure;
+    configureProbe.api_function = typeof registerConfigure === 'function';
+    if (configureProbe.api_function) {
+      configureUnregister = registerConfigure(({ opener }) => {
+        configureProbe.invocations += 1;
+        configureProbe.pending_before_handler = Boolean(
+          settingsRuntime
+          && settingsRuntime._configureStateForExtension
+          && settingsRuntime._configureStateForExtension(EXTENSION_ID).pending,
+        );
+        configureProbe.opener_connected = Boolean(opener && opener.isConnected);
+        if (configureProbe.invocations === 1) {
+          return new Promise(resolve => {
+            configureResolver = resolve;
+          });
+        }
+        throw new Error(EXPECTED_CONFIGURE_FAILURE);
+      });
+      configureProbe.registered = typeof configureUnregister === 'function';
+      configureProbe.duplicate_rejected = registerConfigure(() => {}) === null;
+    }
+  }
 
   const probe = {
     ready: false,
@@ -31,8 +66,32 @@
       unknown_storage_unchanged: JSON.stringify(beforeUnknown) === JSON.stringify(afterUnknown),
     },
     events,
+    configure: configureProbe,
   };
   window.HermesCapabilityBaselineProbe = probe;
+
+  probe.resolveConfigure = () => {
+    if (typeof configureResolver !== 'function') return false;
+    const resolve = configureResolver;
+    configureResolver = null;
+    resolve();
+    return true;
+  };
+
+  probe.finishConfigureRegistration = () => {
+    const first = typeof configureUnregister === 'function'
+      ? configureUnregister()
+      : null;
+    const second = typeof configureUnregister === 'function'
+      ? configureUnregister()
+      : null;
+    return {
+      api_function: configureProbe.api_function,
+      registered: configureProbe.registered,
+      duplicate_rejected: configureProbe.duplicate_rejected,
+      unregister_idempotent: first === true && second === false,
+    };
+  };
 
   if (!extension) {
     probe.error = register

--- a/tests/compatibility/fixtures/e0-b1-capability-probe/manifest.json
+++ b/tests/compatibility/fixtures/e0-b1-capability-probe/manifest.json
@@ -2,8 +2,8 @@
   "extensions": [
     {
       "id": "capability-probe",
-      "name": "E0/B1 capability compatibility probe",
-      "description": "Test-only extension for the pinned Core identity and turn-lifecycle contract.",
+      "name": "E0/B1/Configure capability compatibility probe",
+      "description": "Test-only extension for the pinned Core identity, turn-lifecycle, and scoped Configure contracts.",
       "scripts": [
         "assets/capability-probe.js"
       ],

--- a/tests/compatibility/test_capability_smoke.py
+++ b/tests/compatibility/test_capability_smoke.py
@@ -42,12 +42,87 @@ def _valid_result() -> dict:
             },
         ],
         "duplicate_terminal_accepted": False,
+        "configure": {
+            "registration": {
+                "api_function": True,
+                "registered": True,
+                "duplicate_rejected": True,
+                "unregister_idempotent": True,
+            },
+            "installed_buttons": 1,
+            "diagnostics_buttons": 0,
+            "pending_before_handler": True,
+            "second_click_suppressed": True,
+            "focus_restores": {"success": 1, "failure": 1},
+            "reusable_after_settlement": True,
+            "failure": {
+                "diagnostic": capability_smoke.EXPECTED_CONFIGURE_DIAGNOSTIC,
+                "generic_ui_message": capability_smoke.EXPECTED_CONFIGURE_UI_FAILURE,
+                "page_errors": [],
+                "settings_usable": True,
+            },
+        },
     }
 
 
 class CapabilityResultContractTests(unittest.TestCase):
+    def test_expected_configure_diagnostic_accepts_playwright_stack_suffix(self) -> None:
+        entry = {
+            "text": (
+                capability_smoke.EXPECTED_CONFIGURE_DIAGNOSTIC
+                + "\n    at <anonymous>:1:80"
+            )
+        }
+        self.assertTrue(capability_smoke._is_expected_configure_diagnostic(entry))
+
+    def test_near_match_configure_diagnostic_is_not_expected(self) -> None:
+        entries = [
+            {
+                "text": capability_smoke.EXPECTED_CONFIGURE_DIAGNOSTIC.replace(
+                    "capability-probe", "other-extension", 1
+                )
+            },
+            {
+                "text": capability_smoke.EXPECTED_CONFIGURE_DIAGNOSTIC.replace(
+                    "intentional Configure failure", "different failure", 1
+                )
+            },
+            {
+                "text": capability_smoke.EXPECTED_CONFIGURE_DIAGNOSTIC
+                + " extra text on the first line"
+            },
+        ]
+        for entry in entries:
+            self.assertFalse(capability_smoke._is_expected_configure_diagnostic(entry))
+
+    def test_known_sandbox_page_error_is_filtered(self) -> None:
+        benign = (
+            "Failed to read the 'serviceWorker' property from 'Navigator': "
+            "Service worker is disabled because the context is sandboxed "
+            "and lacks the 'allow-same-origin' flag."
+        )
+        self.assertEqual(capability_smoke._unexpected_page_errors([benign]), [])
+
+    def test_configure_page_error_is_not_filtered(self) -> None:
+        unexpected = "capability-probe Configure page error"
+        self.assertEqual(
+            capability_smoke._unexpected_page_errors([unexpected]), [unexpected]
+        )
+
     def test_complete_lifecycle_result_is_accepted(self) -> None:
         capability_smoke._validate_probe_result(_valid_result())
+
+    def test_configure_result_is_required(self) -> None:
+        result = _valid_result()
+        result.pop("configure")
+        with self.assertRaises(capability_smoke.CompatibilityFailure):
+            capability_smoke._validate_probe_result(result)
+
+    def test_malformed_configure_result_is_rejected(self) -> None:
+        result = _valid_result()
+        result["configure"]["failure"]["generic_ui_message"] = "handler boom"
+        with self.assertRaises(capability_smoke.CompatibilityFailure):
+            capability_smoke._validate_probe_result(result)
 
     def test_duplicate_terminal_event_is_rejected(self) -> None:
         result = _valid_result()


### PR DESCRIPTION
Advances #76.

## Problem

The compatibility job currently pins the first E0/B1 Core release and proves only scoped identity plus turn lifecycle. Core now ships the scoped Configure hook, but this repository has no real-Core certification for its registration, UI surface, pending/focus lifecycle, or failure isolation.

## What changed

- pin the compatibility checkout to Core `b1c2bea92ee8369797d051a0e0789968bd351343` (`exp-v0.52.241`);
- extend the test-only capability fixture without `settings_schema` or extension-owned storage;
- exercise Configure through the real Settings -> Extensions UI;
- require one Installed button and zero Diagnostics buttons;
- prove pending-before-handler, duplicate-click suppression, reusable settlement, and one focus restoration on both success and failure;
- require the exact Core diagnostic, generic failure UI, usable Settings surface, no unexpected page errors, and no unexpected network egress;
- document the expanded E0/B1/Configure certification boundary.

## RED proof

Before the validator implementation, the focused unit suite exited 1 because removing the Configure result did not raise `CompatibilityFailure`:

```text
AssertionError: CompatibilityFailure not raised
```

## Verification

- `python3.12 -m unittest discover -s tests/compatibility -p 'test_capability_smoke.py' -v` — 11 passed
- `python3.12 -m unittest discover -s tests/compatibility -p 'test_*.py' -v` — 29 passed, 8 skipped for isolated optional environments
- real-Core capability smoke against `b1c2bea92ee8369797d051a0e0789968bd351343` — `E0/B1/CONFIGURE CAPABILITY COMPATIBILITY PASSED`
- `node scripts/test-extension-validator.mjs`
- `node scripts/validate-extensions.mjs`
- `node scripts/scan-extension-safety.mjs`
- `node scripts/generate-registry.mjs --out dist/registry.json`
- `git diff --check`

All listed commands exited 0. The real-Core result recorded one Installed Configure button, none in Diagnostics, success/failure focus restoration exactly once, an empty unexpected page-error set, and empty unexpected HTTP/WebSocket sets.

## Scope

This does not migrate a shipped extension, change Core, add a dependency, or claim browser certification for all 18 entries. Per-extension Configure adoption remains in #34 and will follow separately after this certification PR lands.
