### PR TITLE
feat(theme-creator): move editor to Extensions Configure

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -66,6 +66,9 @@ jobs:
           node scripts/test-typography-configure.mjs
           node scripts/test-typography.mjs
 
+      - name: Test Theme Creator Configure contract
+        run: node scripts/test-theme-creator-configure.mjs
+
       - name: Test Message Pins observer sync
         run: node scripts/test-message-pins-sync.mjs
 
@@ -198,6 +201,12 @@ jobs:
           HERMES_CORE_DIR: .ci/hermes-webui-core
           COMPATIBILITY_EVIDENCE_DIR: compatibility-evidence
         run: python tests/compatibility/typography_smoke.py
+
+      - name: Run Theme Creator Configure browser compatibility smoke
+        env:
+          HERMES_CORE_DIR: .ci/hermes-webui-core
+          COMPATIBILITY_EVIDENCE_DIR: compatibility-evidence
+        run: python tests/compatibility/theme_creator_smoke.py
 
       - name: Upload browser compatibility evidence
         if: always()

--- a/docs/compatibility-smoke.md
+++ b/docs/compatibility-smoke.md
@@ -94,6 +94,39 @@ the fixture only controls its deterministic first (thenable) and second
 (intentional failure) handler outcomes. It does not contact a provider or claim
 durable/global event delivery.
 
+### Theme Creator Configure track
+
+`theme_creator_smoke.py` is a separate extension-owned track for the
+`theme-creator` entry. It uses the same pinned Core checkout and isolated,
+no-provider browser boundary as the other compatibility smokes, and writes its
+JSON, server, network, and screenshot evidence under the selected
+`COMPATIBILITY_EVIDENCE_DIR`. It does not certify the Core Configure
+implementation itself; the Core capability contract remains covered by the
+`capability-probe` fixture above.
+
+Against a Core build with the authenticated E0 Configure capability, the track
+runs at both a desktop viewport and 390x844 mobile viewport and requires:
+
+- exactly one Theme Creator **Configure** button under Settings → Extensions →
+  Installed and none under Diagnostics;
+- pending state before the second click, with the duplicate click suppressed;
+- each X, Escape, and backdrop close path to roll back an active live preview
+  before the Configure promise settles, return to a reusable button, and let
+  Core restore the opener focus exactly once;
+- no legacy Theme Creator rail control, no retry timer, and no unexpected
+  HTTP/WebSocket egress;
+- one preseeded valid saved theme to survive reload and register on Core's
+  native skin surface; closing a live preview leaves both the previous skin and
+  the stored collection unchanged.
+
+The track is an entry-level compatibility check, not a claim that every Core
+viewport, browser, or extension API is covered. If the pinned Core checkout is
+missing, setup is incomplete, or Playwright cannot launch, the smoke records a
+`harness_error` rather than reporting an extension failure. The Node contract
+(`scripts/test-theme-creator-configure.mjs`) separately covers old-Core
+fail-closed behavior and programmatic API/storage preservation; a real Core
+run is required for the Settings UI, focus, persistence, and no-egress claims.
+
 ## Local run
 
 Install the hash-locked Core/browser-smoke dependencies in an isolated
@@ -112,6 +145,7 @@ export COMPATIBILITY_EVIDENCE_DIR="$PWD/compatibility-evidence"
 python3.12 tests/compatibility/browser_smoke.py
 python3.12 tests/compatibility/capability_smoke.py
 python3.12 tests/compatibility/typography_smoke.py
+python3.12 tests/compatibility/theme_creator_smoke.py
 ```
 
 Each command exits `0` only when its positive and negative contracts pass. A

--- a/docs/compatibility-smoke.md
+++ b/docs/compatibility-smoke.md
@@ -110,9 +110,12 @@ runs at both a desktop viewport and 390x844 mobile viewport and requires:
 - exactly one Theme Creator **Configure** button under Settings → Extensions →
   Installed and none under Diagnostics;
 - pending state before the second click, with the duplicate click suppressed;
+- modal semantics, initial focus, forward/reverse Tab containment, and
+  Configure-owned programmatic `.open()` reuse without early settlement;
 - each X, Escape, and backdrop close path to roll back an active live preview
   before the Configure promise settles, return to a reusable button, and let
-  Core restore the opener focus exactly once;
+  Core restore the opener focus exactly once; Escape must also leave the Core
+  Settings panel visible;
 - no legacy Theme Creator rail control, no retry timer, and no unexpected
   HTTP/WebSocket egress;
 - one preseeded valid saved theme to survive reload and register on Core's

--- a/extensions/theme-creator/README.md
+++ b/extensions/theme-creator/README.md
@@ -13,7 +13,9 @@ extension system is for.
 
 ## What It Does
 
-- Adds a rail button that opens the Theme Creator panel.
+- Adds a **Configure** entry under Settings → Extensions → Installed. The entry
+  opens the Theme Creator editor through Core's authenticated E0 Configure
+  capability; it does not add a permanent rail control.
 - A curated set of color inputs (background, surfaces, text, muted, accent,
   borders, your-message bubble), each with a color picker + hex field.
 - **Optional background image upload**: pick a JPEG/PNG from your device; it's
@@ -64,9 +66,13 @@ System Default base modes. The block is refreshed on register/save/preview/delet
 ## Dependency
 
 Requires the core **theme-registration capability** (`window.registerHermesSkin`),
-added in `nesquena/hermes-webui` **PR #5100**. Without it, the panel still opens
-and you can design a theme, but a notice explains it can't be applied yet (the
-extension does nothing destructive).
+added in `nesquena/hermes-webui` **PR #5100**, and the authenticated E0 identity /
+Configure capability (`window.hermesExt.register('theme-creator')` with
+`settings.registerConfigure`). On a Core build that lacks
+`hermesExt/registerConfigure`, the extension fails closed: it creates no rail
+fallback and no retry timer. The programmatic `.open()` API still opens the
+editor, and saved themes remain available through the existing local collection
+and `registerHermesSkin` registration path.
 
 ## Current Shape
 
@@ -74,7 +80,8 @@ extension does nothing destructive).
 Hermes WebUI page
   -> manifest-bundled extension assets
   -> /extensions/assets/theme-creator.js + .css
-  -> rail button -> editor panel (color pickers + optional image upload + live preview)
+  -> Settings → Extensions → Installed → Configure
+  -> editor panel (color pickers + optional image upload + live preview)
   -> window.registerHermesSkin({...derived tokens...})  -> native Appearance picker
   -> managed <style> element: hwxThemeCreatorBgStyles (root background-image + semi-transparent vars + backdrop-filter blur)
   -> localStorage: hermes-ext-custom-themes (your saved themes)
@@ -95,8 +102,10 @@ cd /path/to/hermes-webui
 HERMES_WEBUI_EXTENSION_DIR=/path/to/hermes-webui-extensions/extensions/theme-creator HERMES_WEBUI_EXTENSION_MANIFEST=manifest.json ./start.sh
 ```
 
-Click the Theme Creator rail button, design a theme, Live preview, then Save. It
-appears in Settings → Appearance.
+Open Settings → Extensions → Installed → Theme Creator → **Configure**, design a
+theme, Live preview, then Save. It appears in Settings → Appearance. On an older
+Core without the Configure hook, use `window.HermesThemeCreatorExtension.open()`
+from trusted local programmatic code; no legacy rail control is created.
 
 ## Controls
 
@@ -118,7 +127,8 @@ back to default).
 
 This is trusted local code. Current disclosed behavior:
 
-- creates extension-owned DOM (a rail button + the editor panel)
+- creates extension-owned DOM (the editor panel opened by Configure or the
+  programmatic API)
 - calls `window.registerHermesSkin(...)` with derived, sanitized color tokens
 - injects a single extension-managed `<style>` element:
   - `hwxThemeCreatorBgStyles` for all per-theme overrides (root background image,
@@ -142,8 +152,13 @@ This is trusted local code. Current disclosed behavior:
 ## Compatibility
 
 - manifest-bundled extension assets + same-origin serving under `/extensions/`
-- the left rail (`.rail`) to host the button
+- Core's authenticated E0 identity and Configure capability:
+  `window.hermesExt.register('theme-creator')` plus
+  `settings.registerConfigure(handler)`
 - the core theme-registration capability (`window.registerHermesSkin`, PR #5100)
+- older Core builds without `hermesExt/registerConfigure` fail closed for UI
+  entry-point registration; programmatic `.open()` and local saved-theme
+  storage remain available
 - uses the core `_pickSkin()` to apply when available, falling back to setting
   `data-skin` + `hermes-skin` directly
 
@@ -158,17 +173,24 @@ python3 -m json.tool extensions/theme-creator/extension.json
 python3 -m json.tool extensions/theme-creator/manifest.json
 ```
 
-Manual verification (on a WebUI build with PR #5100):
+Manual verification (on a WebUI build with the E0 Configure and PR #5100 capabilities):
 
-- the rail button opens the editor; color pickers + hex fields stay in sync
+- Settings → Extensions → Installed shows one Configure button and Diagnostics
+  shows none; Configure opens the editor and the button is pending while it is open
+- the Configure editor opens; color pickers + hex fields stay in sync
 - Live preview applies the theme app-wide; Stop preview reverts
 - Save registers the theme into Settings → Appearance and applies it
 - saved themes can be applied / edited / deleted
 - themes persist across a reload and re-register into the picker on load
+- X, Escape, and backdrop close paths roll back an active preview before the
+  Configure promise settles; Core restores the Configure opener focus once
+- on an older Core without `hermesExt/registerConfigure`, no rail or retry timer
+  appears and the programmatic API remains usable
 
 ## Known Limitations
 
-- Requires the core theme-registration capability (PR #5100).
+- Requires the core theme-registration capability (PR #5100) for native skin
+  registration and the E0 Configure capability for the Settings entry point.
 - Curated inputs with derived tokens (not every raw token is individually
   editable) — a deliberate usability trade-off.
 - Themes are per-browser (`localStorage`), not synced across devices.

--- a/extensions/theme-creator/README.md
+++ b/extensions/theme-creator/README.md
@@ -184,6 +184,10 @@ Manual verification (on a WebUI build with the E0 Configure and PR #5100 capabil
 - themes persist across a reload and re-register into the picker on load
 - X, Escape, and backdrop close paths roll back an active preview before the
   Configure promise settles; Core restores the Configure opener focus once
+- the editor declares modal semantics, focuses the name field, contains
+  forward/reverse Tab navigation, and consumes Escape without closing Settings
+- programmatic `.open()` reuses a visible editor in both Configure-first and
+  programmatic-first flows without settling Configure early
 - on an older Core without `hermesExt/registerConfigure`, no rail or retry timer
   appears and the programmatic API remains usable
 

--- a/extensions/theme-creator/assets/theme-creator.js
+++ b/extensions/theme-creator/assets/theme-creator.js
@@ -176,13 +176,29 @@
   }
   function showErr(msg) { const e = $('#' + PANEL_ID + ' .hwx-tc-err'); if (e) { e.hidden = !msg; e.textContent = msg || '' } }
 
+  const PANEL_FOCUSABLE = 'button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+  function panelFocusableControls(panel) {
+    if (!panel || typeof panel.querySelectorAll !== 'function') return []
+    return Array.from(panel.querySelectorAll(PANEL_FOCUSABLE)).filter(control => {
+      if (!control || control.disabled || control.hidden) return false
+      return typeof control.getClientRects !== 'function' || control.getClientRects().length > 0
+    })
+  }
+  function focusPanel(panel) {
+    if (!panel) return
+    const name = $('.hwx-tc-name', panel)
+    const target = name && !name.disabled && !name.hidden ? name : panelFocusableControls(panel)[0]
+    if (target && typeof target.focus === 'function') target.focus()
+  }
   function openPanel() {
-    closePanel(); editing = null; _currentBgImage = null; _currentGlassOpacity = .08; _currentBlur = 20
+    const existing = document.getElementById(PANEL_ID)
+    if (existing) { focusPanel(existing); return true }
     if (!document.body) return false
+    editing = null; _currentBgImage = null; _currentGlassOpacity = .08; _currentBlur = 20
     const panel = document.createElement('div')
     panel.id = PANEL_ID; panel.className = 'hwx-tc-panel'
     panel.innerHTML =
-      '<div class="hwx-tc-card" role="dialog" aria-label="Theme Creator"><div class="hwx-tc-head">'
+      '<div class="hwx-tc-card" role="dialog" aria-modal="true" aria-label="Theme Creator"><div class="hwx-tc-head">'
       + '<span class="hwx-tc-title">Theme Creator</span>'
       + '<button type="button" class="hwx-tc-x" aria-label="Close">\u2715</button></div>'
       + (hasCap() ? '' : '<div class="hwx-tc-warn">The theme-registration capability isn\u2019t available in this WebUI build (needs core PR #5100). You can still design a theme, but it can\u2019t be applied yet.</div>')
@@ -190,11 +206,36 @@
     document.body.appendChild(panel)
     $('.hwx-tc-x', panel).addEventListener('click', closePanel)
     panel.addEventListener('click', e => { if (e.target === panel) closePanel() })
-    document.addEventListener('keydown', escClose, true)
+    document.addEventListener('keydown', panelKeydown, true)
     renderEditor(); renderSaved()
+    focusPanel(panel)
     return true
   }
-  function escClose(ev) { if (ev.key === 'Escape') closePanel() }
+  function panelKeydown(ev) {
+    const panel = document.getElementById(PANEL_ID)
+    if (!panel) return
+    if (ev.key === 'Escape') {
+      ev.preventDefault()
+      ev.stopPropagation()
+      closePanel()
+      return
+    }
+    if (ev.key !== 'Tab') return
+    const focusable = panelFocusableControls(panel)
+    if (!focusable.length) return
+    const first = focusable[0], last = focusable[focusable.length - 1]
+    if (!panel.contains(document.activeElement)) {
+      ev.preventDefault()
+      const target = ev.shiftKey ? last : first
+      target.focus()
+      return
+    }
+    if (ev.shiftKey && document.activeElement === first) {
+      ev.preventDefault(); last.focus()
+    } else if (!ev.shiftKey && document.activeElement === last) {
+      ev.preventDefault(); first.focus()
+    }
+  }
   function settleConfigure() {
     const resolve = configureResolve
     configureResolve = null
@@ -203,7 +244,7 @@
   function closePanel() {
     cancelPreview(); _currentBgImage = null; _currentGlassOpacity = .08; _currentBlur = 20
     const p = document.getElementById(PANEL_ID); if (p) p.remove()
-    document.removeEventListener('keydown', escClose, true)
+    document.removeEventListener('keydown', panelKeydown, true)
     settleConfigure()
   }
 

--- a/extensions/theme-creator/assets/theme-creator.js
+++ b/extensions/theme-creator/assets/theme-creator.js
@@ -6,7 +6,7 @@
   window.__hermesThemeCreatorLoaded = true
 
   const EXT = 'theme-creator', STORE_KEY = 'hermes-ext-custom-themes', KEY_PREFIX = 'custom-'
-  const RAIL_BTN_ID = 'hwxThemeCreatorRailBtn', PANEL_ID = 'hwxThemeCreatorPanel', BG_STYLE_ID = 'hwxThemeCreatorBgStyles'
+  const PANEL_ID = 'hwxThemeCreatorPanel', BG_STYLE_ID = 'hwxThemeCreatorBgStyles'
   const MAX_IMAGE_DIM = 1920, IMAGE_QUALITY = 0.7, MAX_THEMES = 50, MAX_STORE_BYTES = 2 * 1024 * 1024
   const THEME_KEY_RE = /^custom-[a-z0-9_-]+$/
   const DATA_IMAGE_RE = /^data:image\/(?:png|jpeg|jpg|gif|webp);base64,[A-Za-z0-9+/]+={0,2}$/
@@ -19,7 +19,8 @@
     { id: 'border', label: 'Borders', def: '#2a2a3a' },
     { id: 'userBubble', label: 'Your message bubble', def: '#26314a' },
   ]
-  let editing = null, previewKey = null, prevSkinBeforePreview = null, _currentBgImage = null, _currentGlassOpacity = .08, _currentBlur = 20
+  let editing = null, previewKey = null, prevSkinBeforePreview = null, configureResolve = null, initialized = false
+  let _currentBgImage = null, _currentGlassOpacity = .08, _currentBlur = 20
 
   // ── helpers ──
   const $ = (s, p = document) => p.querySelector(s)
@@ -166,20 +167,6 @@
     return n
   }
 
-  // ── rail button ──
-  function ensureRailButton() {
-    if (document.getElementById(RAIL_BTN_ID)) return
-    const rail = document.querySelector('.rail')
-    if (!rail) return
-    const btn = document.createElement('button')
-    btn.id = RAIL_BTN_ID; btn.type = 'button'; btn.className = 'rail-btn nav-tab has-tooltip hwx-tc-rail'
-    btn.dataset.tooltip = 'Theme Creator'; btn.setAttribute('aria-label', 'Theme Creator')
-    btn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="6.5" cy="11.5" r="2.5"/><circle cx="16.5" cy="14.5" r="2.5"/><path d="M3 21h18"/></svg>'
-    btn.addEventListener('click', ev => { ev.preventDefault(); openPanel() })
-    const spacer = rail.querySelector('.rail-spacer')
-    if (spacer) rail.insertBefore(btn, spacer); else rail.appendChild(btn)
-  }
-
   // ── editor panel ──
   function defaultBase() { const b = {}; FIELDS.forEach(f => { b[f.id] = f.def }); b.bgImage = null; b.glassOpacity = .08; b.blur = 20; return b }
   function currentBaseFromInputs() {
@@ -191,6 +178,7 @@
 
   function openPanel() {
     closePanel(); editing = null; _currentBgImage = null; _currentGlassOpacity = .08; _currentBlur = 20
+    if (!document.body) return false
     const panel = document.createElement('div')
     panel.id = PANEL_ID; panel.className = 'hwx-tc-panel'
     panel.innerHTML =
@@ -204,9 +192,20 @@
     panel.addEventListener('click', e => { if (e.target === panel) closePanel() })
     document.addEventListener('keydown', escClose, true)
     renderEditor(); renderSaved()
+    return true
   }
   function escClose(ev) { if (ev.key === 'Escape') closePanel() }
-  function closePanel() { cancelPreview(); _currentBgImage = null; _currentGlassOpacity = .08; _currentBlur = 20; const p = document.getElementById(PANEL_ID); if (p) p.remove(); document.removeEventListener('keydown', escClose, true) }
+  function settleConfigure() {
+    const resolve = configureResolve
+    configureResolve = null
+    if (resolve) resolve()
+  }
+  function closePanel() {
+    cancelPreview(); _currentBgImage = null; _currentGlassOpacity = .08; _currentBlur = 20
+    const p = document.getElementById(PANEL_ID); if (p) p.remove()
+    document.removeEventListener('keydown', escClose, true)
+    settleConfigure()
+  }
 
   // ── image handlers ──
   function handleBgUpload(ev) {
@@ -320,19 +319,43 @@
     })
   }
 
-  // ── install ──
-  function install(attempt) {
-    attempt = attempt || 0
-    if (document.querySelector('.rail')) {
-      ensureRailButton(); registerAll()
-      window.HermesThemeCreatorExtension = { version: '0.3.6', themes: loadThemes, open: openPanel, registerAll }
-      return true
-    }
-    if (attempt < 80) { setTimeout(() => install(attempt + 1), 150); return false }
-    console.warn('[' + EXT + '] rail not found; not installed')
-    return false
+  // ── Core Configure entry ──
+  function registerConfigureHook() {
+    const api = window.hermesExt
+    if (!api || typeof api.register !== 'function') return
+    let extension
+    try { extension = api.register(EXT) } catch (_) { return }
+    if (!extension || extension.id !== EXT) return
+    const settings = extension.settings
+    if (!settings || typeof settings.registerConfigure !== 'function') return
+    try {
+      settings.registerConfigure(() => new Promise(resolve => {
+        let active = true
+        const finish = () => {
+          if (!active) return
+          active = false
+          if (configureResolve === finish) configureResolve = null
+          resolve()
+        }
+        let opened = false
+        try { opened = openPanel() } catch (_) {}
+        configureResolve = finish
+        let panel
+        try { panel = document.getElementById(PANEL_ID) } catch (_) {}
+        if (!opened || !panel) settleConfigure()
+      }))
+    } catch (_) {}
   }
 
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', () => install(), { once: true })
-  else install()
+  // ── initialize independent capabilities ──
+  function init() {
+    if (initialized) return
+    initialized = true
+    window.HermesThemeCreatorExtension = { version: '0.3.6', themes: loadThemes, open: openPanel, registerAll }
+    try { registerAll() } catch (_) {}
+    registerConfigureHook()
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init, { once: true })
+  else init()
 })()

--- a/scripts/test-theme-creator-configure.mjs
+++ b/scripts/test-theme-creator-configure.mjs
@@ -1,0 +1,424 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import * as vm from 'node:vm';
+
+const source = await readFile(new URL('../extensions/theme-creator/assets/theme-creator.js', import.meta.url), 'utf8');
+
+const EXTENSION_ID = 'theme-creator';
+const PANEL_ID = 'hwxThemeCreatorPanel';
+const RAIL_ID = 'hwxThemeCreatorRailBtn';
+const STORE_KEY = 'hermes-ext-custom-themes';
+
+const BASE_THEME = {
+  key: 'custom-saved',
+  name: 'Saved Theme',
+  base: {
+    bg: '#0d0d1a',
+    surface: '#16161f',
+    text: '#f5f5f5',
+    muted: '#9aa0b5',
+    accent: '#f5c542',
+    border: '#2a2a3a',
+    userBubble: '#26314a',
+    bgImage: null,
+    glassOpacity: 0.08,
+    blur: 20,
+  },
+};
+
+function findDescendant(node, predicate) {
+  for (const child of node?.children || []) {
+    if (predicate(child)) return child;
+    const nested = findDescendant(child, predicate);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+function matches(node, selector) {
+  if (!node) return false;
+  if (selector === '.rail-spacer') return node.className.split(/\s+/).includes('rail-spacer');
+  if (selector.startsWith('#')) return node.id === selector.slice(1);
+  if (selector.startsWith('.')) return node.className.split(/\s+/).includes(selector.slice(1));
+  if (/^[a-z]+$/i.test(selector)) return node.tagName === selector.toUpperCase();
+  return false;
+}
+
+function makeHarness({
+  configure = true,
+  rail = true,
+  register = true,
+  configureResult = () => true,
+  body = true,
+  themes = [BASE_THEME],
+  initialSkin = 'default',
+} = {}) {
+  const focusCalls = [];
+  const timers = [];
+  const registrations = [];
+  const configureHandlers = [];
+  const skinRegistrations = [];
+  const events = [];
+  const storage = new Map([
+    [STORE_KEY, JSON.stringify(themes)],
+    ['hermes-skin', initialSkin],
+  ]);
+  let document;
+
+  function makeElement(tagName, className = '') {
+    const listeners = new Map();
+    const queryCache = new Map();
+    const element = {
+      tagName: tagName.toUpperCase(),
+      id: '',
+      className,
+      children: [],
+      parentNode: null,
+      isConnected: false,
+      hidden: false,
+      disabled: false,
+      value: '',
+      textContent: '',
+      innerHTML: '',
+      dataset: {},
+      files: [],
+      style: { setProperty() {}, removeProperty() {} },
+      classList: {
+        toggle(name, enabled) {
+          const names = new Set(element.className.split(/\s+/).filter(Boolean));
+          if (enabled) names.add(name); else names.delete(name);
+          element.className = [...names].join(' ');
+        },
+        contains(name) { return element.className.split(/\s+/).includes(name); },
+      },
+      get firstChild() { return this.children[0] || null; },
+      appendChild(child) {
+        if (child.parentNode) child.parentNode.children = child.parentNode.children.filter((item) => item !== child);
+        this.children.push(child);
+        child.parentNode = this;
+        child.isConnected = this.isConnected;
+        return child;
+      },
+      append(...children) { children.forEach((child) => this.appendChild(child)); },
+      insertBefore(child, reference) {
+        if (!this.children.includes(reference)) return this.appendChild(child);
+        if (child.parentNode) child.parentNode.children = child.parentNode.children.filter((item) => item !== child);
+        this.children.splice(this.children.indexOf(reference), 0, child);
+        child.parentNode = this;
+        child.isConnected = this.isConnected;
+        return child;
+      },
+      removeChild(child) {
+        this.children = this.children.filter((item) => item !== child);
+        child.parentNode = null;
+        child.isConnected = false;
+        return child;
+      },
+      remove() {
+        if (this.parentNode) this.parentNode.removeChild(this);
+        this.isConnected = false;
+      },
+      addEventListener(type, listener) {
+        const entries = listeners.get(type) || [];
+        entries.push(listener);
+        listeners.set(type, entries);
+      },
+      removeEventListener(type, listener) {
+        listeners.set(type, (listeners.get(type) || []).filter((entry) => entry !== listener));
+      },
+      dispatchEvent(event) {
+        const payload = event || {};
+        if (!payload.target) payload.target = this;
+        for (const listener of [...(listeners.get(payload.type) || [])]) listener.call(this, payload);
+      },
+      click() { this.dispatchEvent({ type: 'click', target: this }); },
+      focus() {
+        focusCalls.push(this);
+        document.activeElement = this;
+      },
+      contains(candidate) {
+        if (candidate === this) return true;
+        return Boolean(findDescendant(this, (node) => node === candidate));
+      },
+      getClientRects() { return this.isConnected ? [{}] : []; },
+      getBoundingClientRect() { return { left: 0, right: 100, top: 0, bottom: 100 }; },
+      setAttribute(name, value) { this[name] = String(value); },
+      getAttribute(name) { return this[name] ?? null; },
+      querySelector(selector) {
+        const descendant = findDescendant(this, (child) => matches(child, selector));
+        if (descendant) return descendant;
+        if (!queryCache.has(selector)) {
+          const tag = selector === 'select' ? 'select' : 'div';
+          const fallback = makeElement(tag);
+          if (selector.startsWith('#')) fallback.id = selector.slice(1).split(/\s/, 1)[0];
+          if (selector.startsWith('.')) fallback.className = selector.slice(1);
+          fallback.isConnected = this.isConnected;
+          queryCache.set(selector, fallback);
+        }
+        return queryCache.get(selector);
+      },
+      querySelectorAll(selector) {
+        const match = this.querySelector(selector);
+        return match ? [match] : [];
+      },
+    };
+    return element;
+  }
+
+  const bodyNode = body ? makeElement('body') : null;
+  if (bodyNode) bodyNode.isConnected = true;
+  const head = makeElement('head');
+  head.isConnected = true;
+  const documentElement = makeElement('html');
+  documentElement.isConnected = true;
+  const railNode = makeElement('nav', 'rail');
+  railNode.isConnected = true;
+  const spacer = makeElement('div', 'rail-spacer');
+  railNode.appendChild(spacer);
+  if (bodyNode && rail) bodyNode.appendChild(railNode);
+
+  const documentListeners = new Map();
+  document = {
+    readyState: 'complete',
+    body: bodyNode,
+    head,
+    documentElement,
+    activeElement: makeElement('button'),
+    fonts: { add() {}, delete() {} },
+    getElementById(id) {
+      return findDescendant(bodyNode, (node) => node.id === id)
+        || findDescendant(head, (node) => node.id === id)
+        || (documentElement.id === id ? documentElement : null);
+    },
+    querySelector(selector) {
+      if (selector === '.rail') return bodyNode && rail ? railNode : null;
+      return findDescendant(bodyNode, (node) => matches(node, selector))
+        || findDescendant(head, (node) => matches(node, selector));
+    },
+    createElement(tagName) {
+      const element = makeElement(tagName);
+      element.isConnected = false;
+      return element;
+    },
+    addEventListener(type, listener) {
+      const entries = documentListeners.get(type) || [];
+      entries.push(listener);
+      documentListeners.set(type, entries);
+    },
+    removeEventListener(type, listener) {
+      documentListeners.set(type, (documentListeners.get(type) || []).filter((entry) => entry !== listener));
+    },
+    dispatchEvent(event) {
+      for (const listener of [...(documentListeners.get(event.type) || [])]) listener.call(document, event);
+    },
+  };
+
+  const localStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) { storage.set(key, String(value)); },
+    removeItem(key) { storage.delete(key); },
+  };
+  const settings = {};
+  if (configure) {
+    settings.registerConfigure = (handler) => {
+      const result = typeof configureResult === 'function' ? configureResult() : configureResult;
+      if (result !== null) configureHandlers.push(handler);
+      return result;
+    };
+  }
+  const handle = { id: EXTENSION_ID, settings };
+  const window = {
+    innerWidth: 1440,
+    innerHeight: 1000,
+    localStorage,
+    registerHermesSkin(descriptor) {
+      skinRegistrations.push(descriptor);
+      return true;
+    },
+    _pickSkin(key) {
+      events.push('apply:' + key);
+      document.documentElement.dataset.skin = key === 'default' ? '' : key;
+      localStorage.setItem('hermes-skin', key);
+    },
+    hermesExt: {
+      register(id) {
+        registrations.push(id);
+        return id === EXTENSION_ID ? handle : null;
+      },
+    },
+  };
+  if (!register) delete window.hermesExt;
+
+  const context = {
+    window,
+    document,
+    localStorage,
+    setTimeout(callback, delay) {
+      timers.push({ callback, delay });
+      return timers.length;
+    },
+    clearTimeout() {},
+    console,
+  };
+  vm.runInNewContext(source, context, { filename: 'theme-creator.js' });
+
+  return {
+    context,
+    window,
+    document,
+    body: bodyNode,
+    railNode,
+    focusCalls,
+    timers,
+    registrations,
+    configureHandlers,
+    skinRegistrations,
+    events,
+    storage,
+    extension: window.HermesThemeCreatorExtension,
+    evaluateAgain() { vm.runInNewContext(source, context, { filename: 'theme-creator.js' }); },
+  };
+}
+
+function countById(root, id) {
+  let count = 0;
+  const visit = (node) => {
+    if (!node) return;
+    if (node.id === id) count += 1;
+    for (const child of node.children || []) visit(child);
+  };
+  visit(root);
+  return count;
+}
+
+function invokeConfigure(harness) {
+  assert.equal(harness.configureHandlers.length, 1, 'one Configure handler is available');
+  const opener = harness.document.createElement('button');
+  opener.isConnected = true;
+  if (harness.body) harness.body.appendChild(opener);
+  let pending = false;
+  let settled = 0;
+  let restoreFocusCalls = 0;
+  let result;
+  const invoke = () => {
+    if (pending) return false;
+    pending = true;
+    result = harness.configureHandlers[0]({
+      opener,
+      restoreFocus() { restoreFocusCalls += 1; },
+    });
+    assert.equal(typeof result?.then, 'function', 'Configure handler returns a Promise');
+    Promise.resolve(result).then(() => {
+      pending = false;
+      settled += 1;
+      opener.focus();
+      harness.events.push('settled');
+    });
+    return true;
+  };
+  return {
+    opener,
+    invoke,
+    get result() { return result; },
+    get pending() { return pending; },
+    get settled() { return settled; },
+    get restoreFocusCalls() { return restoreFocusCalls; },
+  };
+}
+
+async function closeWith(harness, route) {
+  const panel = harness.document.getElementById(PANEL_ID);
+  assert.ok(panel, 'Configure opened the Theme Creator editor');
+  const preview = panel.querySelector('.hwx-tc-editor').querySelector('.hwx-tc-preview');
+  preview.click();
+  assert.ok(harness.events.some((event) => event === 'apply:custom-preview'), 'preview applies a temporary skin');
+  if (route === 'x') panel.querySelector('.hwx-tc-x').click();
+  else if (route === 'escape') harness.document.dispatchEvent({
+    type: 'keydown',
+    key: 'Escape',
+    preventDefault() {},
+    stopPropagation() {},
+  });
+  else panel.dispatchEvent({ type: 'click', target: panel });
+}
+
+// E0 Configure registration is the only supported Core-owned entry point.
+const modern = makeHarness({ configure: true, rail: true });
+assert.deepEqual(modern.registrations, [EXTENSION_ID], 'Theme Creator registers its exact manifest id once');
+assert.equal(modern.configureHandlers.length, 1, 'Theme Creator registers one Configure handler');
+assert.equal(countById(modern.body, RAIL_ID), 0, 'Configure-capable Core receives no permanent rail button');
+assert.equal(modern.timers.length, 0, 'Configure migration does not install a retry timer');
+assert.ok(modern.skinRegistrations.length >= 1, 'saved theme registration is independent of the rail');
+assert.equal(typeof modern.extension?.open, 'function', 'programmatic open API remains exported');
+assert.equal(typeof modern.extension?.registerAll, 'function', 'programmatic registerAll API remains exported');
+assert.equal(typeof modern.extension?.themes, 'function', 'saved theme collection API remains exported');
+assert.equal(JSON.stringify(modern.extension.themes()), JSON.stringify([BASE_THEME]), 'saved theme collection remains intact');
+
+const noConfigureHook = makeHarness({ configure: false, rail: true });
+assert.deepEqual(noConfigureHook.registrations, [EXTENSION_ID], 'old Core still receives the scoped identity lookup');
+assert.equal(noConfigureHook.configureHandlers.length, 0, 'Core without registerConfigure receives no handler');
+assert.equal(countById(noConfigureHook.body, RAIL_ID), 0, 'missing Configure capability receives no rail fallback');
+assert.equal(noConfigureHook.timers.length, 0, 'missing Configure capability receives no retry timer');
+
+const rejectedConfigureHook = makeHarness({ configure: true, rail: true, configureResult: null });
+assert.deepEqual(rejectedConfigureHook.registrations, [EXTENSION_ID]);
+assert.equal(rejectedConfigureHook.configureHandlers.length, 0, 'a failed Configure registration fails closed');
+assert.equal(countById(rejectedConfigureHook.body, RAIL_ID), 0, 'a failed Configure registration receives no rail fallback');
+assert.equal(rejectedConfigureHook.timers.length, 0, 'a failed Configure registration receives no retry timer');
+
+const noRail = makeHarness({ configure: true, rail: false });
+assert.deepEqual(noRail.registrations, [EXTENSION_ID], 'registration does not depend on a rail DOM node');
+assert.equal(noRail.configureHandlers.length, 1, 'Configure registration does not depend on a rail DOM node');
+assert.ok(noRail.skinRegistrations.length >= 1, 'theme registration does not depend on a rail DOM node');
+assert.equal(typeof noRail.extension?.open, 'function');
+
+const guard = makeHarness({ configure: true, rail: true });
+guard.evaluateAgain();
+assert.deepEqual(guard.registrations, [EXTENSION_ID], 'load guard prevents duplicate E0 registration');
+assert.equal(guard.configureHandlers.length, 1, 'load guard prevents duplicate Configure registration');
+assert.equal(guard.timers.length, 0, 'load guard does not create retry timers');
+
+for (const route of ['x', 'escape', 'backdrop']) {
+  const harness = makeHarness({ configure: true, rail: true });
+  const core = invokeConfigure(harness);
+  assert.equal(core.invoke(), true, 'first Configure invocation is accepted');
+  assert.equal(core.pending, true, 'Core pending state starts before the handler settles');
+  assert.equal(core.invoke(), false, 'a second Configure invocation is suppressed by Core state');
+  await closeWith(harness, route);
+  assert.equal(core.pending, true, 'Configure remains pending until the editor closes');
+  await core.result;
+  await Promise.resolve();
+  assert.equal(core.settled, 1, `${route} settles Configure exactly once`);
+  assert.equal(core.restoreFocusCalls, 0, 'extension does not call Core-owned restoreFocus');
+  assert.equal(countById(harness.body, PANEL_ID), 0, `${route} removes the Theme Creator editor`);
+  const rollback = harness.events.indexOf('apply:default');
+  const settled = harness.events.indexOf('settled');
+  assert.ok(rollback >= 0 && rollback < settled, `${route} rolls back preview before Promise settlement`);
+  assert.equal(core.invoke(), true, `${route} leaves Configure reusable`);
+  assert.ok(harness.document.getElementById(PANEL_ID), `${route} can reopen the editor`);
+  harness.document.getElementById(PANEL_ID).querySelector('.hwx-tc-x').click();
+  await core.result;
+  await Promise.resolve();
+  assert.equal(core.settled, 2, `${route} second close settles exactly once`);
+}
+
+const missingBody = makeHarness({ configure: true, body: false, rail: false });
+const missingBodyCore = invokeConfigure(missingBody);
+assert.equal(missingBodyCore.invoke(), true, 'Configure invocation with no body is accepted for fail-closed handling');
+await missingBodyCore.result;
+await Promise.resolve();
+assert.equal(missingBodyCore.settled, 1, 'missing body settles Configure immediately');
+assert.equal(missingBodyCore.restoreFocusCalls, 0, 'missing body does not invoke extension focus restoration');
+
+const legacy = makeHarness({ configure: false, register: false, rail: false });
+assert.deepEqual(legacy.registrations, [], 'legacy Core receives no attempted capability registration');
+assert.equal(countById(legacy.body, RAIL_ID), 0, 'legacy Core receives no rail fallback');
+assert.equal(legacy.timers.length, 0, 'legacy Core receives no retry timer');
+assert.equal(typeof legacy.extension?.open, 'function', 'legacy Core retains programmatic editor access');
+legacy.extension.open();
+assert.equal(countById(legacy.body, PANEL_ID), 1, 'programmatic open remains available on legacy Core');
+legacy.document.getElementById(PANEL_ID).querySelector('.hwx-tc-x').click();
+assert.equal(countById(legacy.body, PANEL_ID), 0, 'programmatic editor can close on legacy Core');
+assert.equal(legacy.extension.version, '0.3.6');
+
+console.log('theme-creator Configure-entry check passed');

--- a/scripts/test-theme-creator-configure.mjs
+++ b/scripts/test-theme-creator-configure.mjs
@@ -138,6 +138,7 @@ function makeHarness({
       },
       contains(candidate) {
         if (candidate === this) return true;
+        if ([...queryCache.values()].includes(candidate)) return true;
         return Boolean(findDescendant(this, (node) => node === candidate));
       },
       getClientRects() { return this.isConnected ? [{}] : []; },
@@ -158,6 +159,9 @@ function makeHarness({
         return queryCache.get(selector);
       },
       querySelectorAll(selector) {
+        if (selector.includes('button:not([disabled])')) {
+          return ['.hwx-tc-x', '.hwx-tc-name', '.hwx-tc-save'].map((item) => this.querySelector(item));
+        }
         const match = this.querySelector(selector);
         return match ? [match] : [];
       },
@@ -377,6 +381,80 @@ guard.evaluateAgain();
 assert.deepEqual(guard.registrations, [EXTENSION_ID], 'load guard prevents duplicate E0 registration');
 assert.equal(guard.configureHandlers.length, 1, 'load guard prevents duplicate Configure registration');
 assert.equal(guard.timers.length, 0, 'load guard does not create retry timers');
+
+const keyboard = makeHarness({ configure: true, rail: true });
+const keyboardCore = invokeConfigure(keyboard);
+assert.equal(keyboardCore.invoke(), true, 'keyboard probe opens Configure');
+const keyboardPanel = keyboard.document.getElementById(PANEL_ID);
+assert.ok(keyboardPanel.innerHTML.includes('aria-modal="true"'), 'editor dialog declares modal semantics');
+const nameInput = keyboardPanel.querySelector('.hwx-tc-name');
+assert.equal(keyboard.document.activeElement, nameInput, 'editor takes initial focus');
+const focusable = keyboardPanel.querySelectorAll('button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])');
+const firstFocusable = focusable[0];
+const lastFocusable = focusable[focusable.length - 1];
+lastFocusable.focus();
+let tabPrevented = false;
+keyboard.document.dispatchEvent({
+  type: 'keydown', key: 'Tab', shiftKey: false,
+  preventDefault() { tabPrevented = true; }, stopPropagation() {},
+});
+assert.equal(tabPrevented, true, 'forward Tab is consumed at the end of the dialog');
+assert.equal(keyboard.document.activeElement, firstFocusable, 'forward Tab wraps to the first control');
+firstFocusable.focus();
+let shiftTabPrevented = false;
+keyboard.document.dispatchEvent({
+  type: 'keydown', key: 'Tab', shiftKey: true,
+  preventDefault() { shiftTabPrevented = true; }, stopPropagation() {},
+});
+assert.equal(shiftTabPrevented, true, 'Shift+Tab is consumed at the start of the dialog');
+assert.equal(keyboard.document.activeElement, lastFocusable, 'Shift+Tab wraps to the last control');
+keyboardPanel.querySelector('.hwx-tc-x').click();
+await keyboardCore.result;
+
+const escapeIsolation = makeHarness({ configure: true, rail: true });
+const settingsPanel = escapeIsolation.document.createElement('section');
+settingsPanel.id = 'panelSettings';
+settingsPanel.hidden = false;
+escapeIsolation.body.appendChild(settingsPanel);
+const escapeCore = invokeConfigure(escapeIsolation);
+assert.equal(escapeCore.invoke(), true, 'Escape probe opens Configure');
+let escapePrevented = false;
+let escapeStopped = false;
+escapeIsolation.document.dispatchEvent({
+  type: 'keydown', key: 'Escape',
+  preventDefault() { escapePrevented = true; },
+  stopPropagation() { escapeStopped = true; },
+});
+if (!escapeStopped) settingsPanel.remove();
+assert.equal(escapePrevented, true, 'Escape prevents the Core default key path');
+assert.equal(escapeStopped, true, 'Escape does not propagate into Core Settings');
+assert.equal(settingsPanel.isConnected, true, 'Escape leaves the Core Settings panel visible');
+assert.equal(settingsPanel.hidden, false, 'Escape does not hide the Core Settings panel');
+await escapeCore.result;
+
+const configureThenProgrammatic = makeHarness({ configure: true, rail: true });
+const configureThenProgrammaticCore = invokeConfigure(configureThenProgrammatic);
+assert.equal(configureThenProgrammaticCore.invoke(), true, 'Configure opens before programmatic reuse');
+const configureOwnedPanel = configureThenProgrammatic.document.getElementById(PANEL_ID);
+configureThenProgrammatic.extension.open();
+assert.equal(configureThenProgrammatic.document.getElementById(PANEL_ID), configureOwnedPanel,
+  'programmatic open reuses the Configure-owned panel');
+await Promise.resolve();
+assert.equal(configureThenProgrammaticCore.pending, true,
+  'programmatic reuse does not settle Configure while its editor remains visible');
+configureOwnedPanel.querySelector('.hwx-tc-x').click();
+await configureThenProgrammaticCore.result;
+
+const programmaticThenConfigure = makeHarness({ configure: true, rail: true });
+programmaticThenConfigure.extension.open();
+const programmaticPanel = programmaticThenConfigure.document.getElementById(PANEL_ID);
+const programmaticThenConfigureCore = invokeConfigure(programmaticThenConfigure);
+assert.equal(programmaticThenConfigureCore.invoke(), true, 'Configure adopts an existing programmatic editor');
+assert.equal(programmaticThenConfigure.document.getElementById(PANEL_ID), programmaticPanel,
+  'Configure reuses rather than replaces the programmatic editor');
+assert.equal(programmaticThenConfigureCore.pending, true, 'adopted editor owns the Configure pending lifecycle');
+programmaticPanel.querySelector('.hwx-tc-x').click();
+await programmaticThenConfigureCore.result;
 
 for (const route of ['x', 'escape', 'backdrop']) {
   const harness = makeHarness({ configure: true, rail: true });

--- a/tests/compatibility/test_theme_creator_smoke.py
+++ b/tests/compatibility/test_theme_creator_smoke.py
@@ -1,0 +1,188 @@
+import unittest
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from browser_smoke import EXPECTED_CORE_BASELINE_REQUESTS
+from theme_creator_smoke import (
+    CONFIGURE_SELECTOR,
+    DIAGNOSTICS_SELECTOR,
+    EXTENSION_RESOURCES,
+    MOBILE_VIEWPORT,
+    FLOW_REQUEST_LIMITS,
+    RAIL_SELECTOR,
+    SAVED_THEME,
+    CompatibilityFailure,
+    _close_context_once,
+    _consume_core_theme_refresh,
+    _png_dimensions,
+)
+
+
+class ThemeCreatorConfigureSurfaceTests(unittest.TestCase):
+    def test_configure_selector_targets_installed_theme_creator_only(self) -> None:
+        self.assertEqual(
+            CONFIGURE_SELECTOR,
+            '#extensionsInstalled [data-extension-configure-id="theme-creator"]',
+        )
+        self.assertEqual(
+            DIAGNOSTICS_SELECTOR,
+            '#extensionsDiagnostics [data-extension-configure-id="theme-creator"]',
+        )
+        self.assertEqual(RAIL_SELECTOR, "#hwxThemeCreatorRailBtn")
+        self.assertEqual(
+            EXTENSION_RESOURCES,
+            (
+                "/extensions/theme-creator/assets/theme-creator.js",
+                "/extensions/theme-creator/assets/theme-creator.css",
+            ),
+        )
+
+    def test_mobile_viewport_is_the_required_dimensions(self) -> None:
+        self.assertEqual(MOBILE_VIEWPORT, {"width": 390, "height": 844})
+
+    def test_saved_theme_fixture_has_the_complete_storage_shape(self) -> None:
+        self.assertEqual(SAVED_THEME["key"], "custom-saved")
+        self.assertIsNone(SAVED_THEME["base"]["bgImage"])
+        self.assertEqual(SAVED_THEME["base"]["glassOpacity"], 0.08)
+        self.assertEqual(SAVED_THEME["base"]["blur"], 20)
+
+
+class ThemeCreatorNetworkFilterTests(unittest.TestCase):
+    def test_context_close_delivers_late_exact_request_before_consumption(self) -> None:
+        url, (resource_type, max_occurrences) = next(iter(EXPECTED_CORE_BASELINE_REQUESTS.items()))
+        exact_refresh = {
+            "url": url,
+            "method": "GET",
+            "resource_type": resource_type,
+            "occurrence": max_occurrences + 1,
+        }
+        events = {"unexpected_http": []}
+
+        class FakeContext:
+            def __init__(self) -> None:
+                self.close_calls = 0
+
+            def close(self) -> None:
+                self.close_calls += 1
+                events["unexpected_http"].append(exact_refresh)
+
+        context = FakeContext()
+        state: dict[str, bool] = {}
+        _close_context_once(context, state)
+        _close_context_once(context, state)
+        self.assertEqual(context.close_calls, 1)
+        self.assertEqual(
+            _consume_core_theme_refresh(events, 0, "theme-creator-flow"),
+            [{**exact_refresh, "checkpoint": "theme-creator-flow"}],
+        )
+
+    def test_context_close_does_not_hide_late_unknown_or_overage(self) -> None:
+        url, (resource_type, max_occurrences) = next(iter(EXPECTED_CORE_BASELINE_REQUESTS.items()))
+        exact_refresh = {
+            "url": url,
+            "method": "GET",
+            "resource_type": resource_type,
+            "occurrence": max_occurrences + 1,
+        }
+        late_events = (
+            [{**exact_refresh, "url": url + "?cache-bust=1"}],
+            [exact_refresh, dict(exact_refresh)],
+        )
+        for candidate_events in late_events:
+            with self.subTest(candidate_events=candidate_events):
+                events = {"unexpected_http": []}
+
+                class FakeContext:
+                    def close(self) -> None:
+                        events["unexpected_http"].extend(candidate_events)
+
+                _close_context_once(FakeContext(), {})
+                with self.assertRaises(CompatibilityFailure):
+                    _consume_core_theme_refresh(events, 0, "theme-creator-flow")
+
+    def test_one_exact_request_per_url_is_consumed_at_each_skin_checkpoint(self) -> None:
+        url, (resource_type, max_occurrences) = next(iter(EXPECTED_CORE_BASELINE_REQUESTS.items()))
+        exact_refresh = {
+            "url": url,
+            "method": "GET",
+            "resource_type": resource_type,
+            "occurrence": max_occurrences + 1,
+        }
+        events = {"unexpected_http": [{"url": "earlier"}, exact_refresh]}
+        self.assertEqual(
+            _consume_core_theme_refresh(events, 1, "preview"),
+            [{**exact_refresh, "checkpoint": "preview"}],
+        )
+        self.assertEqual(events["unexpected_http"], [{"url": "earlier"}])
+        self.assertEqual(
+            events["expected_core_theme_refresh_http"],
+            [{**exact_refresh, "checkpoint": "preview"}],
+        )
+
+    def test_skin_checkpoint_rejects_duplicate_or_inexact_requests(self) -> None:
+        url, (resource_type, max_occurrences) = next(iter(EXPECTED_CORE_BASELINE_REQUESTS.items()))
+        exact_refresh = {
+            "url": url,
+            "method": "GET",
+            "resource_type": resource_type,
+            "occurrence": max_occurrences + 1,
+        }
+        variants = (
+            [exact_refresh, dict(exact_refresh)],
+            [{**exact_refresh, "method": "POST"}],
+            [{**exact_refresh, "resource_type": "script" if resource_type != "script" else "stylesheet"}],
+            [{**exact_refresh, "url": url + "?cache-bust=1"}],
+        )
+        for candidate_events in variants:
+            with self.subTest(candidate_events=candidate_events):
+                events = {"unexpected_http": candidate_events}
+                with self.assertRaises(CompatibilityFailure):
+                    _consume_core_theme_refresh(events, 0, "rollback")
+                self.assertEqual(events["unexpected_http"], candidate_events)
+
+    def test_complete_flow_budget_is_explicit_and_rejects_an_extra_request(self) -> None:
+        url, (resource_type, max_occurrences) = next(iter(EXPECTED_CORE_BASELINE_REQUESTS.items()))
+        exact_refresh = {
+            "url": url,
+            "method": "GET",
+            "resource_type": resource_type,
+            "occurrence": max_occurrences + 1,
+        }
+        allowed = FLOW_REQUEST_LIMITS[url]
+        events = {"unexpected_http": [dict(exact_refresh) for _ in range(allowed)]}
+        self.assertEqual(
+            len(
+                _consume_core_theme_refresh(
+                    events,
+                    0,
+                    "theme-creator-flow",
+                    request_limits=FLOW_REQUEST_LIMITS,
+                )
+            ),
+            allowed,
+        )
+        excessive = {"unexpected_http": [dict(exact_refresh) for _ in range(allowed + 1)]}
+        with self.assertRaises(CompatibilityFailure):
+            _consume_core_theme_refresh(
+                excessive,
+                0,
+                "theme-creator-flow",
+                request_limits=FLOW_REQUEST_LIMITS,
+            )
+
+
+class ThemeCreatorEvidenceTests(unittest.TestCase):
+    def test_png_dimensions_reads_a_valid_png_header(self) -> None:
+        # PNG signature + IHDR length/type + width/height (4 bytes each).
+        payload = b"\x89PNG\r\n\x1a\n" + (13).to_bytes(4, "big") + b"IHDR" + (390).to_bytes(4, "big") + (844).to_bytes(4, "big")
+        path = NamedTemporaryFile(delete=False)
+        try:
+            path.write(payload)
+            path.close()
+            self.assertEqual(_png_dimensions(Path(path.name)), {"width": 390, "height": 844})
+        finally:
+            Path(path.name).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/compatibility/theme_creator_smoke.py
+++ b/tests/compatibility/theme_creator_smoke.py
@@ -259,6 +259,64 @@ def _close_panel(page: Any, method: str) -> None:
         raise AssertionError(f"unknown close method: {method}")
 
 
+def _assert_keyboard_modal(page: Any) -> None:
+    state = page.evaluate(
+        """selector => {
+          const panel = document.querySelector(selector);
+          const dialog = panel && panel.querySelector('[role="dialog"]');
+          const controls = panel ? Array.from(panel.querySelectorAll(
+            'button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+          )).filter(control => !control.hidden && control.getClientRects().length) : [];
+          return {
+            modal: dialog && dialog.getAttribute('aria-modal'),
+            initialFocusInName: !!(document.activeElement && document.activeElement.matches('.hwx-tc-name')),
+            controlCount: controls.length,
+          };
+        }""",
+        PANEL_SELECTOR,
+    )
+    if state.get("modal") != "true" or state.get("initialFocusInName") is not True:
+        raise CompatibilityFailure(f"Theme Creator modal/focus contract failed: {state!r}")
+    if state["controlCount"] < 2:
+        raise CompatibilityFailure(f"Theme Creator focus trap has too few controls: {state!r}")
+    page.evaluate(
+        """selector => {
+          const panel = document.querySelector(selector);
+          const controls = Array.from(panel.querySelectorAll(
+            'button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+          )).filter(control => !control.hidden && control.getClientRects().length);
+          controls[controls.length - 1].focus();
+        }""",
+        PANEL_SELECTOR,
+    )
+    page.keyboard.press("Tab")
+    forward_wrapped = page.evaluate(
+        """selector => {
+          const panel = document.querySelector(selector);
+          const controls = Array.from(panel.querySelectorAll(
+            'button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+          )).filter(control => !control.hidden && control.getClientRects().length);
+          return document.activeElement === controls[0];
+        }""",
+        PANEL_SELECTOR,
+    )
+    if not forward_wrapped:
+        raise CompatibilityFailure("Theme Creator forward Tab escaped the modal")
+    page.keyboard.press("Shift+Tab")
+    reverse_wrapped = page.evaluate(
+        """selector => {
+          const panel = document.querySelector(selector);
+          const controls = Array.from(panel.querySelectorAll(
+            'button:not([disabled]), select:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+          )).filter(control => !control.hidden && control.getClientRects().length);
+          return document.activeElement === controls[controls.length - 1];
+        }""",
+        PANEL_SELECTOR,
+    )
+    if not reverse_wrapped:
+        raise CompatibilityFailure("Theme Creator reverse Tab escaped the modal")
+
+
 def _exercise_configure(page: Any, screenshot: Path | None = None) -> dict[str, Any]:
     button = _open_extensions_installed(page)
     installed_buttons = page.locator(CONFIGURE_SELECTOR).count()
@@ -305,6 +363,24 @@ def _exercise_configure(page: Any, screenshot: Path | None = None) -> dict[str, 
             timeout=10_000,
         )
         if index == 0:
+            _assert_keyboard_modal(page)
+            reuse = page.evaluate(
+                """selector => {
+                  const before = document.querySelector(selector);
+                  window.HermesThemeCreatorExtension.open();
+                  const state = window.HermesExtensionSettings
+                    && window.HermesExtensionSettings._configureStateForExtension('theme-creator');
+                  return {
+                    samePanel: before === document.querySelector(selector),
+                    panelCount: document.querySelectorAll(selector).length,
+                    pending: !!(state && state.pending),
+                    focusedName: !!(document.activeElement && document.activeElement.matches('.hwx-tc-name')),
+                  };
+                }""",
+                PANEL_SELECTOR,
+            )
+            if reuse != {"samePanel": True, "panelCount": 1, "pending": True, "focusedName": True}:
+                raise CompatibilityFailure(f"Configure-owned programmatic reuse failed: {reuse!r}")
             page.evaluate("selector => document.querySelector(selector)?.click()", CONFIGURE_SELECTOR)
             page.wait_for_timeout(50)
             if page.locator(PANEL_SELECTOR).count() != 1:
@@ -320,6 +396,8 @@ def _exercise_configure(page: Any, screenshot: Path | None = None) -> dict[str, 
             page.screenshot(path=str(screenshot), full_page=True)
         _close_panel(page, method)
         _assert_settled(page, method)
+        if method == "escape" and not page.locator("#panelSettings").is_visible():
+            raise CompatibilityFailure("Escape propagated into Core and hid the Settings panel")
         skin_after_close = page.evaluate("() => document.documentElement.dataset.skin || 'default'")
         collection_after = page.evaluate("() => localStorage.getItem('hermes-ext-custom-themes')")
         if skin_after_close != "custom-saved":
@@ -339,6 +417,9 @@ def _exercise_configure(page: Any, screenshot: Path | None = None) -> dict[str, 
         "diagnostics_buttons": diagnostics_buttons,
         "pending_before_second_click": True,
         "second_click_suppressed": True,
+        "keyboard_modal_verified": True,
+        "configure_programmatic_reuse_verified": True,
+        "escape_preserved_settings": True,
         "close_settlements": close_settlements,
         "focus_restores": focus_restores,
         "stored_theme_collection_unchanged": True,

--- a/tests/compatibility/theme_creator_smoke.py
+++ b/tests/compatibility/theme_creator_smoke.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Real-browser Configure compatibility smoke for the Theme Creator extension.
+
+This is an entry-owned smoke against one independently pinned Core checkout. It
+does not send a chat or contact a provider. The browser guard is deny-by-default
+for off-origin HTTP/WebSocket traffic and all evidence is written to the
+requested compatibility evidence directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import struct
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from typing import Any
+
+try:
+    from browser_smoke import (
+        CompatibilityFailure,
+        EXPECTED_CORE_BASELINE_REQUESTS,
+        SetupFailure,
+        _assert_browser_health,
+        _install_network_guards,
+        _start_server,
+        _terminate,
+        _write_json,
+    )
+except ModuleNotFoundError:  # pragma: no cover - supports module execution.
+    from tests.compatibility.browser_smoke import (
+        CompatibilityFailure,
+        EXPECTED_CORE_BASELINE_REQUESTS,
+        SetupFailure,
+        _assert_browser_health,
+        _install_network_guards,
+        _start_server,
+        _terminate,
+        _write_json,
+    )
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESKTOP_VIEWPORT = {"width": 1440, "height": 1000}
+MOBILE_VIEWPORT = {"width": 390, "height": 844}
+EXTENSION_RESOURCES = (
+    "/extensions/theme-creator/assets/theme-creator.js",
+    "/extensions/theme-creator/assets/theme-creator.css",
+)
+CONFIGURE_SELECTOR = '#extensionsInstalled [data-extension-configure-id="theme-creator"]'
+DIAGNOSTICS_SELECTOR = '#extensionsDiagnostics [data-extension-configure-id="theme-creator"]'
+RAIL_SELECTOR = "#hwxThemeCreatorRailBtn"
+PANEL_SELECTOR = "#hwxThemeCreatorPanel"
+ACTIVE_CORE_THEME_STYLESHEET = (
+    "https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"
+)
+FLOW_REQUEST_LIMITS = {
+    url: (3 if url == ACTIVE_CORE_THEME_STYLESHEET else 1)
+    for url in EXPECTED_CORE_BASELINE_REQUESTS
+}
+SAVED_THEME = {
+    "key": "custom-saved",
+    "name": "Saved Theme",
+    "base": {
+        "bg": "#0d0d1a",
+        "surface": "#16161f",
+        "text": "#f5f5f5",
+        "muted": "#9aa0b5",
+        "accent": "#f5c542",
+        "border": "#2a2a3a",
+        "userBubble": "#26314a",
+        "bgImage": None,
+        "glassOpacity": 0.08,
+        "blur": 20,
+    },
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--core-dir",
+        default=os.environ.get("HERMES_CORE_DIR", ""),
+        help="independent Hermes WebUI Core checkout (or HERMES_CORE_DIR)",
+    )
+    parser.add_argument(
+        "--extension-root",
+        default=os.environ.get("HERMES_EXTENSION_ROOT", str(REPO_ROOT / "extensions")),
+        help="extension source root (default: this checkout's extensions/)",
+    )
+    parser.add_argument(
+        "--evidence-dir",
+        default=os.environ.get(
+            "COMPATIBILITY_EVIDENCE_DIR",
+            str(REPO_ROOT / ".compatibility-evidence"),
+        ),
+        help="directory for screenshots, server log, and result JSON",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("HERMES_COMPATIBILITY_PORT", "0") or "0"),
+        help="optional fixed non-production port; 0 chooses a free ephemeral port",
+    )
+    return parser.parse_args()
+
+
+def _new_page(browser: Any, viewport: dict[str, int], init_script: str) -> tuple[Any, Any, dict[str, list[dict[str, Any]]], list[dict[str, str]], list[str]]:
+    context = browser.new_context(
+        viewport=viewport,
+        is_mobile=viewport == MOBILE_VIEWPORT,
+        service_workers="block",
+    )
+    context.add_init_script(init_script)
+    network_events = _install_network_guards(context)
+    page = context.new_page()
+    console_errors: list[dict[str, str]] = []
+    page_errors: list[str] = []
+
+    def on_console(message: Any) -> None:
+        if message.type != "error":
+            return
+        location = getattr(message, "location", {}) or {}
+        location_url = location.get("url", "") if isinstance(location, dict) else getattr(location, "url", "")
+        console_errors.append({"text": str(message.text), "url": str(location_url)})
+
+    page.on("console", on_console)
+    page.on("pageerror", lambda error: page_errors.append(str(error)))
+    return context, page, network_events, console_errors, page_errors
+
+
+def _boot_page(page: Any, base_url: str) -> None:
+    page.goto(f"{base_url}/", wait_until="domcontentloaded", timeout=30_000)
+    try:
+        page.wait_for_load_state("networkidle", timeout=8_000)
+    except Exception:
+        pass
+    for resource in EXTENSION_RESOURCES:
+        page.wait_for_function(
+            "resource => performance.getEntriesByType('resource').some(entry => entry.name.includes(resource))",
+            arg=resource,
+            timeout=15_000,
+        )
+    page.locator(".messages-shell").wait_for(state="visible", timeout=15_000)
+    if page.locator(RAIL_SELECTOR).count() != 0:
+        raise CompatibilityFailure("Theme Creator created a legacy rail button")
+    page.wait_for_function(
+        "() => window.HermesThemeCreatorExtension && window.HermesThemeCreatorExtension.version === '0.3.6'",
+        timeout=15_000,
+    )
+
+
+def _open_extensions_installed(page: Any) -> Any:
+    button = page.locator(CONFIGURE_SELECTOR)
+    if button.count() and button.is_visible():
+        return button
+    settings_button = page.locator('button[data-panel="settings"]').first
+    if not settings_button.is_visible():
+        menu = page.locator("#btnHamburger")
+        menu.wait_for(state="visible", timeout=5_000)
+        menu.click()
+        page.locator(".sidebar.mobile-open").wait_for(state="visible", timeout=5_000)
+        settings_button = page.locator('.sidebar.mobile-open button[data-panel="settings"]').first
+    settings_button.click()
+    page.locator("#panelSettings").wait_for(state="visible", timeout=10_000)
+    page.locator('#settingsMenu button[data-settings-section="extensions"]').click()
+    page.locator("#settingsPaneExtensions").wait_for(state="visible", timeout=10_000)
+    page.locator('button[data-extensions-tab="installed"]').click()
+    page.locator("#extensionsInstalled .extension-installed-list").wait_for(
+        state="visible", timeout=10_000
+    )
+    button.wait_for(state="visible", timeout=15_000)
+    return button
+
+
+def _assert_settled(page: Any, label: str) -> None:
+    page.locator(PANEL_SELECTOR).wait_for(state="detached", timeout=5_000)
+    try:
+        page.wait_for_function(
+            """selector => {
+              const button = document.querySelector(selector);
+              const state = window.HermesExtensionSettings
+                && window.HermesExtensionSettings._configureStateForExtension('theme-creator');
+              return button && !button.disabled && button.getAttribute('aria-busy') === 'false'
+                && state && state.pending === false;
+            }""",
+            arg=CONFIGURE_SELECTOR,
+            timeout=10_000,
+        )
+    except Exception as exc:
+        raise CompatibilityFailure(f"Configure {label} close did not settle Core state") from exc
+
+
+def _consume_core_theme_refresh(
+    network_events: dict[str, list[dict[str, Any]]],
+    start_index: int,
+    checkpoint: str,
+    request_limits: dict[str, int] | None = None,
+) -> list[dict[str, Any]]:
+    """Consume one bounded exact pinned-Core request set for a known skin change."""
+
+    events = network_events.setdefault("unexpected_http", [])
+    if start_index < 0 or start_index > len(events):
+        raise CompatibilityFailure(
+            f"{checkpoint}: invalid Theme Creator network checkpoint: {start_index}"
+        )
+    candidates = events[start_index:]
+    allowed_counts = request_limits or {
+        url: 1 for url in EXPECTED_CORE_BASELINE_REQUESTS
+    }
+    seen_counts: dict[str, int] = {}
+    accepted: list[dict[str, Any]] = []
+    for event in candidates:
+        url = str(event.get("url", ""))
+        expected = EXPECTED_CORE_BASELINE_REQUESTS.get(url)
+        is_exact_core_refresh = bool(
+            expected
+            and event.get("method") == "GET"
+            and event.get("resource_type") == expected[0]
+            and event.get("occurrence") == expected[1] + 1
+        )
+        seen_counts[url] = seen_counts.get(url, 0) + 1
+        if (
+            not is_exact_core_refresh
+            or seen_counts[url] > allowed_counts.get(url, 0)
+        ):
+            raise CompatibilityFailure(
+                f"{checkpoint}: unexpected browser egress during Core theme refresh: {event!r}"
+            )
+        accepted.append({**event, "checkpoint": checkpoint})
+    del events[start_index:]
+    network_events.setdefault("expected_core_theme_refresh_http", []).extend(accepted)
+    return accepted
+
+
+def _close_context_once(context: Any, state: dict[str, bool]) -> None:
+    """Close a browser context at most once, including from an error path."""
+
+    if state.get("closed"):
+        return
+    state["closed"] = True
+    context.close()
+
+
+def _close_panel(page: Any, method: str) -> None:
+    if method == "x":
+        page.locator(f"{PANEL_SELECTOR} .hwx-tc-x").click()
+    elif method == "escape":
+        page.keyboard.press("Escape")
+    elif method == "backdrop":
+        page.locator(PANEL_SELECTOR).evaluate(
+            "panel => panel.dispatchEvent(new MouseEvent('click', {bubbles: true}))"
+        )
+    else:  # pragma: no cover - guarded by the caller's fixed list.
+        raise AssertionError(f"unknown close method: {method}")
+
+
+def _exercise_configure(page: Any, screenshot: Path | None = None) -> dict[str, Any]:
+    button = _open_extensions_installed(page)
+    installed_buttons = page.locator(CONFIGURE_SELECTOR).count()
+    page.locator('button[data-extensions-tab="diagnostics"]').click()
+    page.locator("#extensionsDiagnostics .extension-installed-list").wait_for(
+        state="visible", timeout=10_000
+    )
+    diagnostics_buttons = page.locator(DIAGNOSTICS_SELECTOR).count()
+    page.locator('button[data-extensions-tab="installed"]').click()
+    button.wait_for(state="visible", timeout=10_000)
+    if installed_buttons != 1 or diagnostics_buttons != 0:
+        raise CompatibilityFailure(
+            f"Theme Creator Configure visibility mismatch: installed={installed_buttons}, diagnostics={diagnostics_buttons}"
+        )
+    button.evaluate(
+        """button => {
+          window.__themeCreatorFocusRestoreCount = 0;
+          if (!button.__themeCreatorFocusPatched) {
+            const nativeFocus = button.focus.bind(button);
+            button.focus = (...args) => {
+              window.__themeCreatorFocusRestoreCount += 1;
+              return nativeFocus(...args);
+            };
+            button.__themeCreatorFocusPatched = true;
+          }
+        }"""
+    )
+    collection_before = page.evaluate("() => localStorage.getItem('hermes-ext-custom-themes')")
+    close_settlements: list[str] = []
+    for index, method in enumerate(("x", "escape", "backdrop")):
+        button = _open_extensions_installed(page)
+        button.wait_for(state="visible", timeout=10_000)
+        button.click()
+        page.locator(PANEL_SELECTOR).wait_for(state="visible", timeout=5_000)
+        page.wait_for_function(
+            """selector => {
+              const button = document.querySelector(selector);
+              const state = window.HermesExtensionSettings
+                && window.HermesExtensionSettings._configureStateForExtension('theme-creator');
+              return button && button.disabled && button.getAttribute('aria-busy') === 'true'
+                && state && state.pending === true;
+            }""",
+            arg=CONFIGURE_SELECTOR,
+            timeout=10_000,
+        )
+        if index == 0:
+            page.evaluate("selector => document.querySelector(selector)?.click()", CONFIGURE_SELECTOR)
+            page.wait_for_timeout(50)
+            if page.locator(PANEL_SELECTOR).count() != 1:
+                raise CompatibilityFailure("second Configure click created a duplicate Theme Creator editor")
+        preview = page.locator(f"{PANEL_SELECTOR} .hwx-tc-preview")
+        preview.click()
+        page.wait_for_function(
+            "() => document.documentElement.dataset.skin === 'custom-preview'",
+            timeout=5_000,
+        )
+        if screenshot and index == 0:
+            screenshot.parent.mkdir(parents=True, exist_ok=True)
+            page.screenshot(path=str(screenshot), full_page=True)
+        _close_panel(page, method)
+        _assert_settled(page, method)
+        skin_after_close = page.evaluate("() => document.documentElement.dataset.skin || 'default'")
+        collection_after = page.evaluate("() => localStorage.getItem('hermes-ext-custom-themes')")
+        if skin_after_close != "custom-saved":
+            raise CompatibilityFailure(
+                f"{method} close did not roll back to the prior skin: {skin_after_close!r}"
+            )
+        if collection_after != collection_before:
+            raise CompatibilityFailure(f"{method} close changed the stored theme collection")
+        close_settlements.append(method)
+    focus_restores = page.evaluate("() => window.__themeCreatorFocusRestoreCount || 0")
+    if focus_restores != len(close_settlements):
+        raise CompatibilityFailure(
+            f"Core did not restore Theme Creator Configure opener focus exactly once per close: {focus_restores!r}"
+        )
+    return {
+        "installed_buttons": installed_buttons,
+        "diagnostics_buttons": diagnostics_buttons,
+        "pending_before_second_click": True,
+        "second_click_suppressed": True,
+        "close_settlements": close_settlements,
+        "focus_restores": focus_restores,
+        "stored_theme_collection_unchanged": True,
+        "theme_refresh_actions": 2 * len(close_settlements),
+    }
+
+
+def _assert_native_skin_after_reload(page: Any, base_url: str) -> dict[str, Any]:
+    # `_boot_page` performs the fresh navigation. Do not call `page.reload()`
+    # first: that would navigate twice and fabricate a second Core request set.
+    _boot_page(page, base_url)
+    collection = page.evaluate("() => JSON.parse(localStorage.getItem('hermes-ext-custom-themes') || '[]')")
+    expected = page.evaluate("() => ({key: 'custom-saved', name: 'Saved Theme'})")
+    if not any(item.get("key") == expected["key"] and item.get("name") == expected["name"] for item in collection):
+        raise CompatibilityFailure(f"saved theme collection was lost after reload: {collection!r}")
+    _open_extensions_installed(page)
+    # The settings side menu is collapsed outside the 390px mobile viewport.
+    # Dispatch the existing button's native click and still require the target
+    # pane to become visible; do not call Core's section-switching function.
+    page.locator(
+        '#settingsMenu button[data-settings-section="appearance"]'
+    ).evaluate("button => button.click()")
+    page.locator("#settingsPaneAppearance").wait_for(state="visible", timeout=10_000)
+    native_skin = page.locator('#skinPickerGrid [data-skin-val="custom-saved"]')
+    native_skin.wait_for(state="visible", timeout=10_000)
+    if native_skin.count() != 1:
+        raise CompatibilityFailure(f"native skin surface has unexpected saved-theme count: {native_skin.count()}")
+    active_skin = page.evaluate("() => document.documentElement.dataset.skin || 'default'")
+    if active_skin != "custom-saved":
+        raise CompatibilityFailure(f"saved theme was not re-applied after reload: {active_skin!r}")
+    return {
+        "saved_theme_count": len(collection),
+        "native_skin_buttons": native_skin.count(),
+        "active_skin": active_skin,
+    }
+
+
+def _png_dimensions(path: Path) -> dict[str, int]:
+    try:
+        data = path.read_bytes()
+        if data[:8] == b"\x89PNG\r\n\x1a\n" and len(data) >= 24:
+            width, height = struct.unpack(">II", data[16:24])
+            return {"width": width, "height": height}
+    except OSError:
+        pass
+    return {}
+
+
+def _run_flow(base_url: str, evidence_dir: Path, browser: Any, viewport: dict[str, int], name: str) -> dict[str, Any]:
+    seed = json.dumps([SAVED_THEME], separators=(",", ":"))
+    init_script = f"""(() => {{
+      try {{
+        if (window.top !== window) return;
+        localStorage.setItem('hermes-ext-custom-themes', {json.dumps(seed)});
+        localStorage.setItem('hermes-skin', 'custom-saved');
+      }} catch (_) {{}}
+    }})();"""
+    context, page, network_events, console_errors, page_errors = _new_page(browser, viewport, init_script)
+    screenshot = evidence_dir / f"theme-creator-{name}.png"
+    context_state = {"closed": False}
+    try:
+        _boot_page(page, base_url)
+        configure = _exercise_configure(page, screenshot=screenshot)
+        persisted = _assert_native_skin_after_reload(page, base_url)
+        # Playwright can deliver a request caused by an earlier skin action only
+        # while the context is shutting down. Close first, then validate the
+        # complete flow against one finite exact-URL budget. Per-action slicing
+        # would misattribute late delivery between adjacent checkpoints.
+        _close_context_once(context, context_state)
+        _consume_core_theme_refresh(
+            network_events,
+            0,
+            "theme-creator-flow",
+            request_limits=FLOW_REQUEST_LIMITS,
+        )
+        _assert_browser_health(
+            case_name=f"theme-creator-{name}",
+            console_errors=console_errors,
+            page_errors=page_errors,
+            extension_fragments=EXTENSION_RESOURCES,
+            network_events=network_events,
+        )
+        return {
+            "status": "passed",
+            "viewport": viewport,
+            "configure": configure,
+            "persistence": persisted,
+            "legacy_rail_count": 0,
+            "unexpected_http": network_events.get("unexpected_http", []),
+            "expected_core_theme_refresh_http": network_events.get(
+                "expected_core_theme_refresh_http", []
+            ),
+            "unexpected_websockets": network_events.get("unexpected_websockets", []),
+            "screenshot": {"path": screenshot.name, **_png_dimensions(screenshot)},
+        }
+    except Exception:
+        try:
+            screenshot.parent.mkdir(parents=True, exist_ok=True)
+            page.screenshot(path=str(screenshot), full_page=True)
+        except Exception:
+            pass
+        raise
+    finally:
+        _close_context_once(context, context_state)
+        _write_json(evidence_dir / f"theme-creator-{name}-network.json", network_events)
+
+
+def main() -> int:
+    args = _parse_args()
+    evidence_dir = Path(args.evidence_dir).expanduser().resolve()
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    results: dict[str, Any] = {"status": "running", "track": "theme-creator-configure", "cases": {}}
+    results_path = evidence_dir / "theme-creator-results.json"
+    proc = None
+    log_file = None
+    try:
+        core_dir = Path(args.core_dir).expanduser().resolve()
+        extension_root = Path(args.extension_root).expanduser().resolve()
+        if not core_dir.is_dir():
+            raise SetupFailure("HERMES_CORE_DIR/--core-dir must point to an independent Hermes WebUI checkout")
+        source_dir = extension_root / "theme-creator"
+        if not source_dir.is_dir():
+            raise SetupFailure(f"Theme Creator extension directory not found: {source_dir}")
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise SetupFailure("Playwright is required; install tests/compatibility/requirements.txt") from exc
+
+        with tempfile.TemporaryDirectory(prefix="hermes-theme-creator-compat-") as temp:
+            temp_root = Path(temp)
+            bundle_root = temp_root / "theme-creator-bundle"
+            shutil.copytree(source_dir, bundle_root / "theme-creator")
+            state_root = temp_root / "state"
+            proc, log_file, base_url, port = _start_server(
+                core_dir=core_dir,
+                extension_root=bundle_root,
+                manifest_relative="theme-creator/manifest.json",
+                state_root=state_root,
+                log_path=temp_root / "theme-creator-server.log",
+                requested_port=args.port,
+            )
+            try:
+                with sync_playwright() as playwright:
+                    browser = playwright.chromium.launch(
+                        headless=True,
+                        args=["--no-sandbox", "--disable-dev-shm-usage"],
+                    )
+                    try:
+                        results["cases"]["desktop"] = _run_flow(
+                            base_url, evidence_dir, browser, DESKTOP_VIEWPORT, "desktop"
+                        )
+                        results["cases"]["mobile"] = _run_flow(
+                            base_url, evidence_dir, browser, MOBILE_VIEWPORT, "mobile"
+                        )
+                    finally:
+                        browser.close()
+            finally:
+                _terminate(proc, log_file)
+                proc = None
+                log_file = None
+                if (temp_root / "theme-creator-server.log").is_file():
+                    shutil.copyfile(temp_root / "theme-creator-server.log", evidence_dir / "theme-creator-server.log")
+            results["port"] = port
+        results["status"] = "passed"
+        _write_json(results_path, results)
+        print("THEME CREATOR CONFIGURE COMPATIBILITY PASSED")
+        print(f"evidence={evidence_dir}")
+        return 0
+    except SetupFailure as exc:
+        results["status"] = "setup_failure"
+        results["error"] = str(exc)
+        _write_json(results_path, results)
+        print(f"SETUP FAILURE: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 2
+    except CompatibilityFailure as exc:
+        results["status"] = "failed"
+        results["error"] = str(exc)
+        results["traceback"] = traceback.format_exc()
+        _write_json(results_path, results)
+        print(f"THEME CREATOR CONFIGURE COMPATIBILITY FAILED: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        results["status"] = "harness_error"
+        results["error"] = f"{type(exc).__name__}: {exc}"
+        results["traceback"] = traceback.format_exc()
+        _write_json(results_path, results)
+        print(f"HARNESS ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
+        print(f"evidence={evidence_dir}", file=sys.stderr)
+        return 2
+    finally:
+        _terminate(proc, log_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- replace the permanent Theme Creator rail launcher with the authenticated Settings → Extensions → Installed **Configure** entry
- preserve the existing editor, saved-theme collection, native skin registration, live preview rollback, and public programmatic API
- fail closed on older Core builds without the Configure capability instead of restoring a private DOM fallback
- add dedicated Node and real-Core desktop/mobile compatibility coverage, wired into CI

Advances #34.

## Why

Theme Creator is a multi-step editor, so a permanent navigation control spends attention on every visit. The shipped Configure capability gives it a Core-owned entry point and pending/focus lifecycle while the theme collection remains extension-owned.

## State and lifecycle

The extension continues to own `hermes-ext-custom-themes` and its preview state. X, Escape, and backdrop closure all cancel an active preview before settling the Configure promise. Core owns duplicate-click suppression and opener-focus restoration. Saved themes are registered independently of Configure availability, so an older Core does not lose stored themes or the programmatic `.open()` path.

## Verification

Pre-fix oracle against `main@9a37dc81`:

- `node scripts/test-theme-creator-configure.mjs` equivalent exited 1 because the previous implementation never registered `theme-creator` with the Configure capability.

Current branch, rebased after #92:

- `node scripts/test-theme-creator-configure.mjs` — passed
- `PYTHONPATH=tests/compatibility python3 -m unittest tests/compatibility/test_theme_creator_smoke.py` — 9 passed
- `PYTHONPATH=tests/compatibility python3 -m unittest discover -s tests/compatibility -p "test_*.py"` — 41 passed in CI
- extension validator, validator self-tests, message-pins sync, sidecar contract/scaffold/usage, safety scan, desktop-companion validator, registry generation, and `git diff --check` — passed
- real-Core browser smoke against pinned Core `b1c2bea92ee8369797d051a0e0789968bd351343` — desktop 1454×1000 and mobile 390×844 passed; Installed Configure count 1, Diagnostics count 0, X/Escape/backdrop settlement passed, focus restored once per close, saved theme survived reload, no unexpected HTTP/WebSocket remained

## Visual evidence

- Before: the existing repository screenshot shows the editor launched from the permanent rail surface: https://github.com/hermes-webui/hermes-webui-extensions/blob/main/extensions/theme-creator/screenshots/theme-creator-panel.png
- After: exact-head CI run 32830106830 captures desktop and 390×844 mobile Settings → Extensions Configure flows in the `extension-compatibility-evidence` artifact, including the corrected empty-background state from #92.

## Out of scope

- no theme data migration or storage-schema rewrite
- no changes to editor layout or styling in this PR's Configure patch
- no Core changes
- no fallback rail button for older Core builds

## Release note

Theme Creator now opens from Settings → Extensions → Installed → Configure, preserving saved themes and live-preview behavior without a permanent rail button.
