### PR TITLE
Fix Theme Creator empty background visibility

### DIFF
--- a/extensions/theme-creator/assets/theme-creator.css
+++ b/extensions/theme-creator/assets/theme-creator.css
@@ -22,6 +22,7 @@
 .hwx-tc-filelabel:hover .hwx-tc-filelabel-text{background:var(--hover-bg,rgba(127,127,127,.18));border-color:var(--border,rgba(127,127,127,.4))}
 .hwx-tc-bg-none{color:var(--muted,#888);font-size:12px;font-style:italic}
 .hwx-tc-bg-preview-wrap{display:inline-flex;align-items:center;gap:8px}
+.hwx-tc-bg-preview-wrap[hidden],.hwx-tc-bg-none[hidden]{display:none!important}
 .hwx-tc-bg-preview{width:48px;height:32px;object-fit:cover;border-radius:6px;border:1px solid var(--border2,rgba(127,127,127,.3));background:var(--border2,rgba(127,127,127,.3))}
 .hwx-tc-remove-img{font-size:11px;color:var(--error,#e5534b)}
 .hwx-tc-glass-section,.hwx-tc-blur-section{margin-top:12px}

--- a/tests/compatibility/test_theme_creator_background_visibility.py
+++ b/tests/compatibility/test_theme_creator_background_visibility.py
@@ -1,0 +1,104 @@
+"""Browser regression coverage for Theme Creator background-image visibility."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THEME_CREATOR_CSS = REPO_ROOT / "extensions/theme-creator/assets/theme-creator.css"
+VIEWPORTS = (
+    {"name": "desktop", "width": 1454, "height": 1000},
+    {"name": "mobile", "width": 390, "height": 844},
+)
+
+
+@unittest.skipUnless(
+    importlib.util.find_spec("playwright"),
+    "Playwright is required for computed-style visibility assertions",
+)
+class ThemeCreatorBackgroundVisibilityTests(unittest.TestCase):
+    def test_hidden_state_controls_empty_preview_layout(self) -> None:
+        from playwright.sync_api import sync_playwright
+
+        css = THEME_CREATOR_CSS.read_text(encoding="utf-8")
+        html = f"""
+          <style>{css}</style>
+          <div class="hwx-tc-panel">
+            <div class="hwx-tc-card" role="dialog" aria-label="Theme Creator">
+              <div class="hwx-tc-title">Theme Creator</div>
+              <div class="hwx-tc-section-title">Background image <span class="hwx-tc-muted">(optional)</span></div>
+              <div class="hwx-tc-bg-row">
+                <span class="hwx-tc-filelabel-text">Choose image…</span>
+                <span class="hwx-tc-bg-none">None</span>
+                <div class="hwx-tc-bg-preview-wrap" hidden>
+                  <img class="hwx-tc-bg-preview" alt="Background">
+                  <button class="hwx-tc-link hwx-tc-remove-img">Remove</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        """
+
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            try:
+                for viewport in VIEWPORTS:
+                    with self.subTest(viewport=viewport["name"]):
+                        page = browser.new_page(viewport=viewport)
+                        page.set_content(html)
+
+                        self._assert_state(page, has_background=False)
+
+                        page.evaluate(
+                            """() => {
+                              document.querySelector('.hwx-tc-bg-none').hidden = true;
+                              document.querySelector('.hwx-tc-bg-preview-wrap').hidden = false;
+                            }"""
+                        )
+                        self._assert_state(page, has_background=True)
+
+                        page.evaluate(
+                            """() => {
+                              document.querySelector('.hwx-tc-bg-none').hidden = false;
+                              document.querySelector('.hwx-tc-bg-preview-wrap').hidden = true;
+                            }"""
+                        )
+                        self._assert_state(page, has_background=False)
+                        evidence_dir = os.environ.get("COMPATIBILITY_EVIDENCE_DIR")
+                        if not evidence_dir and os.environ.get("GITHUB_ACTIONS") == "true":
+                            evidence_dir = "compatibility-evidence"
+                        if evidence_dir:
+                            output = Path(evidence_dir)
+                            output.mkdir(parents=True, exist_ok=True)
+                            page.screenshot(
+                                path=str(output / f"theme-creator-empty-background-{viewport['name']}.png"),
+                                full_page=True,
+                            )
+                        page.close()
+            finally:
+                browser.close()
+
+    def _assert_state(self, page, *, has_background: bool) -> None:
+        state = page.evaluate(
+            """() => ({
+              noneDisplay: getComputedStyle(document.querySelector('.hwx-tc-bg-none')).display,
+              previewDisplay: getComputedStyle(document.querySelector('.hwx-tc-bg-preview-wrap')).display,
+              removeVisible: !!document.querySelector('.hwx-tc-remove-img').getClientRects().length,
+            })"""
+        )
+        if has_background:
+            self.assertEqual(state["noneDisplay"], "none")
+            self.assertNotEqual(state["previewDisplay"], "none")
+            self.assertTrue(state["removeVisible"])
+        else:
+            self.assertNotEqual(state["noneDisplay"], "none")
+            self.assertEqual(state["previewDisplay"], "none")
+            self.assertFalse(state["removeVisible"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #91.

## Problem

Theme Creator rendered contradictory empty-background UI: `None` appeared together with the broken preview image and `Remove` action.

## Root cause and fix

The JavaScript already maintains the correct `hidden` attributes. The component's author CSS (`display: inline-flex`) overrode the browser's default hidden presentation.

This change adds a scoped, load-bearing hidden rule for the two background-state elements. It does not change Theme Creator's JavaScript state machine.

## Regression coverage

The new Chromium test uses the production stylesheet in a focused HTML fixture at desktop 1454×1000 and mobile 390×844. It verifies all three state transitions:

- empty: `None` is in layout; preview and `Remove` are absent;
- image present: preview and `Remove` are in layout; `None` is absent;
- remove: the UI returns to the empty state.

Before the CSS fix, both viewport cases fail with the hidden preview still computing to `display: flex`. On the fixed head, both pass. In GitHub Actions, the test also writes desktop/mobile after screenshots into the existing `extension-compatibility-evidence` artifact.

## Verification

- `python -m unittest tests/compatibility/test_theme_creator_background_visibility.py -v`
- `python -m unittest discover -s tests/compatibility -p 'test_*.py' -v` — 32 tests, 2 environment-dependent skips in CI
- `node scripts/validate-extensions.mjs`
- `node scripts/test-extension-validator.mjs`
- `node scripts/scan-extension-safety.mjs`
- `node scripts/generate-registry.mjs --out dist/registry.json`

## Out of scope

This PR does not include the Configure migration from #89 or alter any Theme Creator behavior beyond the background visibility bug.
