### PR TITLE
ci: execute registered behavior tests and reject omissions

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -58,39 +58,13 @@ jobs:
       - name: Validate extension entries
         run: node scripts/validate-extensions.mjs
 
-      - name: Test extension validator
-        run: node scripts/test-extension-validator.mjs
-
-      - name: Test Typography
-        run: |
-          node scripts/test-typography-configure.mjs
-          node scripts/test-typography.mjs
-
-      - name: Test Theme Creator Configure contract
-        run: node scripts/test-theme-creator-configure.mjs
-
-      - name: Test Message Pins observer sync
-        run: node scripts/test-message-pins-sync.mjs
-
-      - name: Test Mobile Haptics E0/B1 lifecycle
-        run: node scripts/test-mobile-haptics.mjs
-
-      - name: Test sidecar contract enforcement
-        run: node scripts/test-sidecar-contract.mjs
-
-      - name: Test canonical sidecar scaffold
-        run: python scripts/test-sidecar-scaffold.py
-
-      - name: Test Profile Avatars
-        run: python scripts/test-profile-avatars.py
+      - name: Run registered behavior test suites
+        run: node scripts/run-behavior-tests.mjs
 
       - name: Test sysinfo sidecar regressions (op/bulk ownership + update-target parity)
         run: |
           python extensions/sysinfo/sidecar/test_op_ownership.py
           python extensions/sysinfo/sidecar/test_update_target_parity.py
-
-      - name: Test auto-list keyboard contracts
-        run: node --test scripts/test-auto-list-keyboard.mjs
 
       - name: Scan extension safety gates
         run: node scripts/scan-extension-safety.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ before adding a large implementation.
 - Document the WebUI version or extension API surface the entry was tested
   against.
 - Prefer docs and examples when the WebUI extension contract is still changing.
+- Register every new top-level behavior test in `scripts/behavior-tests.json`
+  with its `path` and `runner` (`node`, `node-test`, or `python`), then run the
+  shared behavior-test runner locally.
 
 ## Pull Request Checklist
 
@@ -31,6 +34,8 @@ Before opening a PR, confirm:
 - [ ] Install, disable, and uninstall behavior is documented.
 - [ ] Any sidecar or native integration is documented clearly.
 - [ ] Compatibility and verification notes are included.
+- [ ] `node scripts/run-behavior-tests.mjs --check` and
+      `node scripts/run-behavior-tests.mjs` pass locally.
 - [ ] No secrets, generated local state, or unreviewed binaries are included.
 
 ## Review Expectations
@@ -38,3 +43,8 @@ Before opening a PR, confirm:
 Maintainers may ask for an extension to start as documentation or an example
 until the WebUI-side API is ready. This is expected while the foundation work
 lands in stages.
+
+The behavior-test inventory is intentionally limited to top-level
+`scripts/test-*.mjs` and `scripts/test-*.py` files. It is an execution gate,
+not a malicious-code sandbox or a substitute for reviewing test assertions;
+inventory, runner, and workflow changes receive maintainer review.

--- a/README.md
+++ b/README.md
@@ -97,16 +97,23 @@ Run the current repo-wide checks locally with:
 
 ```bash
 node scripts/validate-extensions.mjs
-node scripts/test-extension-validator.mjs
-node scripts/test-message-pins-sync.mjs
-node scripts/test-sidecar-contract.mjs
-python3 scripts/test-sidecar-scaffold.py
+node scripts/run-behavior-tests.mjs --check
+node scripts/run-behavior-tests.mjs
 node scripts/scan-extension-safety.mjs
 node scripts/sync-sidecar-base.mjs --check
 node scripts/check-sidecar-usage.mjs
 node scripts/validate-desktop-companion.mjs
 node scripts/generate-registry.mjs --out dist/registry.json
 ```
+
+Behavior suites are the explicitly registered, top-level
+`scripts/test-*.mjs` and `scripts/test-*.py` files in
+[`scripts/behavior-tests.json`](scripts/behavior-tests.json). The runner
+validates the complete inventory before executing anything, dispatches each
+entry with the same Node or Python runner locally and in CI, and fails on
+unknown, missing, duplicate, unsafe, or mismatched entries. This inventory
+does not judge assertion quality or replace the browser compatibility smoke;
+changes to the inventory, runner, or workflow still require maintainer review.
 
 Pull requests run the same validation, contract, and safety checks in CI. Pushes to `main`
 generate the registry and per-extension zip artifacts for GitHub Pages. The

--- a/docs/compatibility-smoke.md
+++ b/docs/compatibility-smoke.md
@@ -160,6 +160,19 @@ extension regression. Evidence includes JSON results, server logs,
 network-block records, and screenshots when the browser reaches the relevant
 page.
 
+## Behavior-test inventory boundary
+
+This inventory covers only the explicitly registered, top-level
+`scripts/test-*.mjs` and `scripts/test-*.py` files in
+`scripts/behavior-tests.json`; the sysinfo sidecar checks and browser
+compatibility steps remain independent workflow steps. The
+`scripts/run-behavior-tests.mjs` runner validates the whole inventory before
+dispatching suites, and uses the same Node/Python runner locally and in CI. It
+catches unknown, missing, duplicate, unsafe, and runner-mismatched entries,
+but it does not assess assertion quality, browse the whole repository, or
+provide a malicious-code sandbox. New suites must be registered; inventory,
+runner, and workflow changes require maintainer review.
+
 ## CI boundary
 
 The `browser-compatibility` job checks out `nesquena/hermes-webui` independently

--- a/scripts/behavior-tests.json
+++ b/scripts/behavior-tests.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "tests": [
+    {"path": "scripts/test-auto-list-keyboard.mjs", "runner": "node-test"},
+    {"path": "scripts/test-behavior-test-runner.mjs", "runner": "node"},
+    {"path": "scripts/test-extension-validator.mjs", "runner": "node"},
+    {"path": "scripts/test-message-pins-sync.mjs", "runner": "node"},
+    {"path": "scripts/test-mobile-haptics.mjs", "runner": "node"},
+    {"path": "scripts/test-profile-avatars.py", "runner": "python"},
+    {"path": "scripts/test-sidecar-contract.mjs", "runner": "node"},
+    {"path": "scripts/test-sidecar-scaffold.py", "runner": "python"},
+    {"path": "scripts/test-theme-creator-configure.mjs", "runner": "node"},
+    {"path": "scripts/test-typography-configure.mjs", "runner": "node"},
+    {"path": "scripts/test-typography.mjs", "runner": "node"}
+  ]
+}

--- a/scripts/run-behavior-tests.mjs
+++ b/scripts/run-behavior-tests.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const RUNNERS = new Set(['node', 'node-test', 'python']);
+const TEST_FILE_RE = /^test-[^/]+\.(mjs|py)$/;
+const INVENTORY_RELATIVE_PATH = 'scripts/behavior-tests.json';
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+export class InventoryError extends Error {
+  constructor(errors) {
+    const messages = Array.isArray(errors) ? errors : [String(errors)];
+    super(messages.join('\n'));
+    this.name = 'InventoryError';
+    this.errors = messages;
+  }
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function exactKeys(value, expected, label, errors) {
+  if (!isPlainObject(value)) {
+    errors.push(`${label} must be an object`);
+    return false;
+  }
+  const allowed = new Set(expected);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) errors.push(`${label} has unknown key ${JSON.stringify(key)}`);
+  }
+  for (const key of expected) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) {
+      errors.push(`${label} is missing key ${JSON.stringify(key)}`);
+    }
+  }
+  return true;
+}
+
+function assertSafePath(root, relativePath, label, errors) {
+  if (typeof relativePath !== 'string' || !relativePath) {
+    errors.push(`${label} must be a non-empty relative path`);
+    return null;
+  }
+  if (relativePath.includes('\0')) {
+    errors.push(`${label} contains a NUL byte`);
+    return null;
+  }
+  if (relativePath.includes('\\')) {
+    errors.push(`${label} must use POSIX separators`);
+    return null;
+  }
+  if (path.isAbsolute(relativePath) || /^[A-Za-z]:[\\/]/.test(relativePath)) {
+    errors.push(`${label} must not be absolute`);
+    return null;
+  }
+  const parts = relativePath.split('/');
+  if (parts.some((part) => !part || part === '.' || part === '..')) {
+    errors.push(`${label} contains an invalid or traversal segment`);
+    return null;
+  }
+  const normalized = path.posix.normalize(relativePath);
+  if (normalized !== relativePath) {
+    errors.push(`${label} is not normalized`);
+    return null;
+  }
+  const absolutePath = path.resolve(root, ...parts);
+  const relativeCheck = path.relative(root, absolutePath);
+  if (!relativeCheck || relativeCheck.startsWith(`..${path.sep}`) || path.isAbsolute(relativeCheck)) {
+    errors.push(`${label} escapes the repository root`);
+    return null;
+  }
+
+  let cursor = root;
+  for (const part of parts) {
+    cursor = path.join(cursor, part);
+    let stat;
+    try {
+      stat = lstatSync(cursor);
+    } catch (error) {
+      errors.push(`${label} does not exist: ${relativePath}`);
+      return null;
+    }
+    if (stat.isSymbolicLink()) {
+      errors.push(`${label} must not traverse a symbolic link: ${relativePath}`);
+      return null;
+    }
+  }
+  const finalStat = lstatSync(absolutePath);
+  if (!finalStat.isFile()) {
+    errors.push(`${label} must name a regular file: ${relativePath}`);
+    return null;
+  }
+  return absolutePath;
+}
+
+function discoverTopLevelTests(root) {
+  const scriptsPath = path.join(root, 'scripts');
+  let scriptsStat;
+  try {
+    scriptsStat = lstatSync(scriptsPath);
+  } catch (error) {
+    throw new InventoryError(`scripts directory is missing: ${scriptsPath}`);
+  }
+  if (scriptsStat.isSymbolicLink() || !scriptsStat.isDirectory()) {
+    throw new InventoryError('scripts must be a real directory');
+  }
+  return readdirSync(scriptsPath, { withFileTypes: true })
+    .filter((entry) => TEST_FILE_RE.test(entry.name))
+    .map((entry) => `scripts/${entry.name}`)
+    .sort();
+}
+
+function inventoryPathFor(root, inventoryPath) {
+  const candidate = inventoryPath || path.join(root, INVENTORY_RELATIVE_PATH);
+  const absolute = path.resolve(candidate);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new InventoryError('inventory path must be inside the repository root');
+  }
+  const errors = [];
+  assertSafePath(root, relative.split(path.sep).join('/'), 'inventory path', errors);
+  if (errors.length) throw new InventoryError(errors);
+  return absolute;
+}
+
+function readInventory(inventoryPath) {
+  let raw;
+  try {
+    raw = readFileSync(inventoryPath, 'utf8');
+  } catch (error) {
+    throw new InventoryError(`cannot read inventory: ${inventoryPath}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new InventoryError(`inventory is not valid JSON: ${error.message}`);
+  }
+}
+
+export function validateInventory({ repoRoot = REPO_ROOT, inventoryPath } = {}) {
+  const root = path.resolve(repoRoot);
+  const inventory = inventoryPathFor(root, inventoryPath);
+  const raw = readInventory(inventory);
+  const errors = [];
+
+  if (exactKeys(raw, ['version', 'tests'], 'inventory', errors)) {
+    if (raw.version !== 1 || !Number.isInteger(raw.version)) {
+      errors.push('inventory.version must be the integer 1');
+    }
+    if (!Array.isArray(raw.tests)) errors.push('inventory.tests must be an array');
+  }
+
+  const tests = Array.isArray(raw?.tests) ? raw.tests : [];
+  const normalizedTests = [];
+  const seenPaths = new Set();
+  tests.forEach((entry, index) => {
+    const label = `inventory.tests[${index}]`;
+    if (!exactKeys(entry, ['path', 'runner'], label, errors)) return;
+    const relativePath = entry.path;
+    const runner = entry.runner;
+    if (typeof runner !== 'string' || !RUNNERS.has(runner)) {
+      errors.push(`${label}.runner must be one of node, node-test, python`);
+    }
+    const safePath = assertSafePath(root, relativePath, `${label}.path`, errors);
+    if (!safePath) return;
+    const relativeParts = relativePath.split('/');
+    if (relativeParts.length !== 2 || relativeParts[0] !== 'scripts' || !TEST_FILE_RE.test(relativeParts[1])) {
+      errors.push(`${label}.path must name a top-level scripts/test-*.mjs or scripts/test-*.py file`);
+    }
+    const extension = path.posix.extname(relativePath);
+    if (extension === '.py' && runner !== 'python') {
+      errors.push(`${label}.runner python is required for .py files`);
+    }
+    if (extension === '.mjs' && runner === 'python') {
+      errors.push(`${label}.runner python cannot execute .mjs files`);
+    }
+    if (seenPaths.has(relativePath)) {
+      errors.push(`${label}.path is duplicated: ${relativePath}`);
+    } else {
+      seenPaths.add(relativePath);
+    }
+    normalizedTests.push({ path: relativePath, runner, absolutePath: safePath });
+  });
+
+  let discovered = [];
+  try {
+    discovered = discoverTopLevelTests(root);
+  } catch (error) {
+    errors.push(...(error instanceof InventoryError ? error.errors : [error.message]));
+  }
+  const listedPaths = new Set(normalizedTests.map((entry) => entry.path));
+  for (const discoveredPath of discovered) {
+    if (!listedPaths.has(discoveredPath)) {
+      errors.push(`top-level test is missing from inventory: ${discoveredPath}`);
+    }
+  }
+  for (const listedPath of listedPaths) {
+    if (!discovered.includes(listedPath)) {
+      errors.push(`inventory path is not a discovered top-level test: ${listedPath}`);
+    }
+  }
+
+  if (errors.length) throw new InventoryError(errors);
+  return {
+    repoRoot: root,
+    inventoryPath: inventory,
+    tests: normalizedTests,
+    discovered,
+  };
+}
+
+function commandFor(entry) {
+  if (entry.runner === 'python') return { command: 'python3', args: [entry.path] };
+  if (entry.runner === 'node-test') return { command: process.execPath, args: ['--test', entry.path] };
+  return { command: process.execPath, args: [entry.path] };
+}
+
+export function executeInventory(validated, { stdio = 'inherit', log = console.log } = {}) {
+  let passed = 0;
+  for (const entry of validated.tests) {
+    const { command, args } = commandFor(entry);
+    log(`[behavior-tests] RUN ${entry.path} (${entry.runner})`);
+    const result = spawnSync(command, args, {
+      cwd: validated.repoRoot,
+      shell: false,
+      stdio,
+    });
+    if (result.error) {
+      log(`[behavior-tests] FAIL ${entry.path}: ${result.error.message}`);
+      log(`[behavior-tests] summary: ${passed}/${validated.tests.length} suites passed`);
+      return { ok: false, passed, failed: 1, total: validated.tests.length, failedPath: entry.path };
+    }
+    if (result.status !== 0) {
+      const status = result.status === null ? `signal ${result.signal || 'unknown'}` : `exit ${result.status}`;
+      log(`[behavior-tests] FAIL ${entry.path}: ${status}`);
+      log(`[behavior-tests] summary: ${passed}/${validated.tests.length} suites passed`);
+      return { ok: false, passed, failed: 1, total: validated.tests.length, failedPath: entry.path };
+    }
+    passed += 1;
+  }
+  log(`[behavior-tests] summary: ${passed}/${validated.tests.length} suites passed`);
+  return { ok: true, passed, failed: 0, total: validated.tests.length };
+}
+
+export function runInventory(options = {}) {
+  const { checkOnly = false, ...validationOptions } = options;
+  const validated = validateInventory(validationOptions);
+  if (checkOnly) return { ok: true, checked: true, total: validated.tests.length, validated };
+  const result = executeInventory(validated, options);
+  return { ...result, validated };
+}
+
+function usage() {
+  console.error('Usage: node scripts/run-behavior-tests.mjs [--check]');
+}
+
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+function main(argv = process.argv.slice(2)) {
+  if (argv.some((arg) => arg !== '--check')) {
+    usage();
+    return 2;
+  }
+  const checkOnly = argv.includes('--check');
+  try {
+    const result = runInventory({ checkOnly });
+    if (checkOnly) {
+      console.log(`[behavior-tests] inventory valid: ${result.total} suites`);
+      return 0;
+    }
+    return result.ok ? 0 : 1;
+  } catch (error) {
+    console.error(`[behavior-tests] inventory validation failed:\n${error.message}`);
+    return 1;
+  }
+}
+
+if (isMainModule()) process.exitCode = main();

--- a/scripts/test-behavior-test-runner.mjs
+++ b/scripts/test-behavior-test-runner.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { InventoryError, runInventory } from './run-behavior-tests.mjs';
+
+const projects = [];
+const linkedPaths = [];
+
+function makeProject() {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'hermes-behavior-runner-'));
+  mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  projects.push(root);
+  return root;
+}
+
+function writeScript(root, relativePath, source) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, source, 'utf8');
+  return filePath;
+}
+
+function writeInventory(root, tests) {
+  writeFileSync(
+    path.join(root, 'scripts', 'behavior-tests.json'),
+    `${JSON.stringify({ version: 1, tests }, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+function options(root) {
+  return { repoRoot: root, stdio: 'ignore', log: () => {} };
+}
+
+function expectInventoryError(action, message) {
+  assert.throws(action, (error) => {
+    assert(error instanceof InventoryError, `expected InventoryError, got ${error}`);
+    if (message) assert.match(error.message, message);
+    return true;
+  });
+}
+
+function nodeWriter(sentinel, marker) {
+  return `import { appendFileSync } from 'node:fs';\nappendFileSync(${JSON.stringify(sentinel)}, ${JSON.stringify(`${marker}\n`)});\n`;
+}
+
+function pythonWriter(sentinel, marker) {
+  return `from pathlib import Path\nPath(${JSON.stringify(sentinel)}).open("a", encoding="utf-8").write(${JSON.stringify(`${marker}\n`)})\n`;
+}
+
+try {
+  // Red first: an unregistered top-level test is rejected and never executes.
+  const unregisteredRoot = makeProject();
+  const unregisteredSentinel = path.join(unregisteredRoot, 'unregistered-sentinel');
+  writeScript(unregisteredRoot, 'scripts/test-unregistered.mjs', nodeWriter(unregisteredSentinel, 'unregistered'));
+  writeInventory(unregisteredRoot, []);
+  expectInventoryError(
+    () => runInventory(options(unregisteredRoot)),
+    /missing from inventory: scripts\/test-unregistered\.mjs/,
+  );
+  assert.equal(existsSync(unregisteredSentinel), false, 'unregistered test must not execute');
+  console.log('[behavior-tests] red fixture rejected before execution');
+
+  // Registering the same fixture makes the gate green and executes it once.
+  writeInventory(unregisteredRoot, [{ path: 'scripts/test-unregistered.mjs', runner: 'node' }]);
+  const registered = runInventory(options(unregisteredRoot));
+  assert.equal(registered.ok, true);
+  assert.equal(registered.passed, 1);
+  assert.equal(readFileSync(unregisteredSentinel, 'utf8'), 'unregistered\n');
+  console.log('[behavior-tests] green registration executed the fixture');
+
+  // Every inventory error is found before a registered sentinel can execute.
+  const missingRoot = makeProject();
+  const missingSentinel = path.join(missingRoot, 'missing-sentinel');
+  writeScript(missingRoot, 'scripts/test-first.mjs', nodeWriter(missingSentinel, 'first'));
+  writeInventory(missingRoot, [
+    { path: 'scripts/test-first.mjs', runner: 'node' },
+    { path: 'scripts/test-missing.mjs', runner: 'node' },
+  ]);
+  expectInventoryError(() => runInventory(options(missingRoot)), /does not exist: scripts\/test-missing\.mjs/);
+  assert.equal(existsSync(missingSentinel), false, 'missing inventory entry must block all execution');
+
+  const invalidRunnerRoot = makeProject();
+  const invalidRunnerSentinel = path.join(invalidRunnerRoot, 'invalid-runner-sentinel');
+  writeScript(invalidRunnerRoot, 'scripts/test-first.mjs', nodeWriter(invalidRunnerSentinel, 'first'));
+  writeScript(invalidRunnerRoot, 'scripts/test-second.mjs', nodeWriter(invalidRunnerSentinel, 'second'));
+  writeInventory(invalidRunnerRoot, [
+    { path: 'scripts/test-first.mjs', runner: 'invalid' },
+    { path: 'scripts/test-second.mjs', runner: 'node' },
+  ]);
+  expectInventoryError(() => runInventory(options(invalidRunnerRoot)), /runner must be one of/);
+  assert.equal(existsSync(invalidRunnerSentinel), false, 'invalid runner must block all execution');
+
+  const traversalRoot = makeProject();
+  const traversalSentinel = path.join(traversalRoot, 'traversal-sentinel');
+  writeScript(traversalRoot, 'scripts/test-safe.mjs', nodeWriter(traversalSentinel, 'safe'));
+  writeInventory(traversalRoot, [
+    { path: 'scripts/test-safe.mjs', runner: 'node' },
+    { path: 'scripts/../scripts/test-safe.mjs', runner: 'node' },
+  ]);
+  expectInventoryError(() => runInventory(options(traversalRoot)), /invalid or traversal segment/);
+  assert.equal(existsSync(traversalSentinel), false, 'traversal path must block all execution');
+
+  const duplicateRoot = makeProject();
+  const duplicateSentinel = path.join(duplicateRoot, 'duplicate-sentinel');
+  writeScript(duplicateRoot, 'scripts/test-duplicate.mjs', nodeWriter(duplicateSentinel, 'duplicate'));
+  writeInventory(duplicateRoot, [
+    { path: 'scripts/test-duplicate.mjs', runner: 'node' },
+    { path: 'scripts/test-duplicate.mjs', runner: 'node' },
+  ]);
+  expectInventoryError(() => runInventory(options(duplicateRoot)), /path is duplicated/);
+  assert.equal(existsSync(duplicateSentinel), false, 'duplicate path must block all execution');
+
+  const symlinkRoot = makeProject();
+  const symlinkSentinel = path.join(symlinkRoot, 'symlink-sentinel');
+  writeScript(symlinkRoot, 'scripts/test-real.mjs', nodeWriter(symlinkSentinel, 'real'));
+  symlinkSync('test-real.mjs', path.join(symlinkRoot, 'scripts', 'test-link.mjs'));
+  writeInventory(symlinkRoot, [
+    { path: 'scripts/test-real.mjs', runner: 'node' },
+    { path: 'scripts/test-link.mjs', runner: 'node' },
+  ]);
+  expectInventoryError(() => runInventory(options(symlinkRoot)), /symbolic link/);
+  assert.equal(existsSync(symlinkSentinel), false, 'symlink path must block all execution');
+
+  const extraKeyRoot = makeProject();
+  writeScript(extraKeyRoot, 'scripts/test-extra.mjs', '');
+  writeFileSync(
+    path.join(extraKeyRoot, 'scripts', 'behavior-tests.json'),
+    '{"version":1,"tests":[{"path":"scripts/test-extra.mjs","runner":"node","extra":true}]}\n',
+    'utf8',
+  );
+  expectInventoryError(() => runInventory(options(extraKeyRoot)), /unknown key/);
+
+  const failureRoot = makeProject();
+  const afterFailureSentinel = path.join(failureRoot, 'after-failure-sentinel');
+  writeScript(failureRoot, 'scripts/test-failure.mjs', 'process.exitCode = 7;\n');
+  writeScript(failureRoot, 'scripts/test-after-failure.mjs', nodeWriter(afterFailureSentinel, 'after'));
+  writeScript(
+    failureRoot,
+    'scripts/run-behavior-tests.mjs',
+    readFileSync(fileURLToPath(new URL('./run-behavior-tests.mjs', import.meta.url)), 'utf8'),
+  );
+  writeInventory(failureRoot, [
+    { path: 'scripts/test-failure.mjs', runner: 'node' },
+    { path: 'scripts/test-after-failure.mjs', runner: 'node' },
+  ]);
+  const failed = runInventory(options(failureRoot));
+  assert.equal(failed.ok, false, 'a registered failing suite must make the gate nonzero');
+  assert.equal(failed.failedPath, 'scripts/test-failure.mjs');
+  assert.equal(failed.passed, 0);
+  assert.equal(existsSync(afterFailureSentinel), false, 'execution must fail fast');
+  const failedCli = spawnSync(process.execPath, ['scripts/run-behavior-tests.mjs'], {
+    cwd: failureRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  assert.equal(failedCli.status, 1, failedCli.stderr);
+  assert.match(failedCli.stdout, /summary: 0\/2 suites passed/);
+  assert.equal(existsSync(afterFailureSentinel), false, 'CLI failure must remain fail-fast');
+
+  const versionRoot = makeProject();
+  writeScript(versionRoot, 'scripts/test-version.mjs', '');
+  writeFileSync(
+    path.join(versionRoot, 'scripts', 'behavior-tests.json'),
+    '{"version":2,"tests":[{"path":"scripts/test-version.mjs","runner":"node"}]}\n',
+    'utf8',
+  );
+  expectInventoryError(() => runInventory(options(versionRoot)), /version must be the integer 1/);
+
+  const schemaRoot = makeProject();
+  writeScript(schemaRoot, 'scripts/test-schema.mjs', '');
+  writeFileSync(
+    path.join(schemaRoot, 'scripts', 'behavior-tests.json'),
+    '{"version":1,"tests":{}}\n',
+    'utf8',
+  );
+  expectInventoryError(() => runInventory(options(schemaRoot)), /tests must be an array/);
+
+  const pythonSuffixRoot = makeProject();
+  writeScript(pythonSuffixRoot, 'scripts/test-python.py', '');
+  writeInventory(pythonSuffixRoot, [{ path: 'scripts/test-python.py', runner: 'node' }]);
+  expectInventoryError(() => runInventory(options(pythonSuffixRoot)), /python is required for \.py/);
+
+  const nodeSuffixRoot = makeProject();
+  writeScript(nodeSuffixRoot, 'scripts/test-node.mjs', '');
+  writeInventory(nodeSuffixRoot, [{ path: 'scripts/test-node.mjs', runner: 'python' }]);
+  expectInventoryError(() => runInventory(options(nodeSuffixRoot)), /python cannot execute \.mjs/);
+
+  const successRoot = makeProject();
+  const successSentinel = path.join(successRoot, 'success-sentinel');
+  writeScript(successRoot, 'scripts/test-node.mjs', nodeWriter(successSentinel, 'node'));
+  writeScript(
+    successRoot,
+    'scripts/test-node-test.mjs',
+    `import { test } from 'node:test';\nimport { appendFileSync } from 'node:fs';\ntest('node-test fixture', () => appendFileSync(${JSON.stringify(successSentinel)}, 'node-test\\n'));\n`,
+  );
+  writeScript(successRoot, 'scripts/test-python.py', pythonWriter(successSentinel, 'python'));
+  writeInventory(successRoot, [
+    { path: 'scripts/test-node.mjs', runner: 'node' },
+    { path: 'scripts/test-node-test.mjs', runner: 'node-test' },
+    { path: 'scripts/test-python.py', runner: 'python' },
+  ]);
+  const checked = runInventory({ ...options(successRoot), checkOnly: true });
+  assert.equal(checked.ok, true);
+  assert.equal(checked.checked, true);
+  assert.equal(existsSync(successSentinel), false, '--check must not execute suites');
+  const succeeded = runInventory(options(successRoot));
+  assert.equal(succeeded.ok, true);
+  assert.equal(succeeded.passed, 3);
+  assert.deepEqual(
+    new Set(readFileSync(successSentinel, 'utf8').trim().split('\n')),
+    new Set(['node', 'node-test', 'python']),
+  );
+
+  // Entry-point checks must still run when /tmp or the repository is symlinked.
+  const runnerPath = fileURLToPath(new URL('./run-behavior-tests.mjs', import.meta.url));
+  const absoluteCheck = spawnSync(process.execPath, [runnerPath, '--check'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  assert.equal(absoluteCheck.status, 0, absoluteCheck.stderr);
+  assert.match(absoluteCheck.stdout, /inventory valid: /);
+
+  const linkedRepo = path.join(os.tmpdir(), `hermes-behavior-runner-linked-${process.pid}`);
+  symlinkSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'), linkedRepo, 'dir');
+  linkedPaths.push(linkedRepo);
+  const linkedCheck = spawnSync(process.execPath, [path.join(linkedRepo, 'scripts', 'run-behavior-tests.mjs'), '--check'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  assert.equal(linkedCheck.status, 0, linkedCheck.stderr);
+  assert.match(linkedCheck.stdout, /inventory valid: /);
+
+  console.log('[behavior-tests] runner self-test passed: validation, fail-fast, and node/node-test/python dispatch');
+} finally {
+  for (const project of projects) rmSync(project, { recursive: true, force: true });
+  for (const linkedPath of linkedPaths) rmSync(linkedPath, { force: true });
+}


### PR DESCRIPTION
## Thinking Path

A behavior-test file can exist in the repository while the generic validation job stays green without executing that suite. The current workflow maintains individual commands separately from the test files. We are closing that wiring gap under #76, not certifying every extension's behavior.

## What Changed

- Add a reviewed inventory for top-level `scripts/test-*.mjs` and `scripts/test-*.py` files.
- Make one runner validate the entire inventory before executing any registered suite. Discovery detects omissions; it does not grant execution permission.
- Use only the `node`, `node-test`, and `python` runner types, without shell commands. Reject missing/unregistered files, duplicate entries, unsupported schema/runner combinations, invalid paths, and symlinks.
- Replace the existing per-script workflow steps with that runner. Keep the sysinfo sidecar steps, browser compatibility job, and certified Core SHA unchanged.
- Add isolated positive/negative fixtures and document registration, local execution, and the coverage boundary.

## Why It Matters

When a contributor adds a top-level behavior suite, CI must either execute the reviewed registration or fail visibly. A green generic extension validator can no longer silently stand in for that suite's execution.

## Contract Routing

Repository CI and contributor testing instructions: `CONTRIBUTING.md`, `README.md`, and `docs/compatibility-smoke.md`. No Core API, extension permission, runtime-state, or deployment contract changes.

## Verification

Exact local head: `aa26c91c3edee87c6fdee2afd04bd7e8aa499f88`; base: `b41e2e5450c7bded832a40794f7a2f8760cb06a4`.

Luna's implementation was independently reviewed and these checks rerun by the coordinator:

```sh
node scripts/run-behavior-tests.mjs --check
node scripts/test-behavior-test-runner.mjs
node scripts/run-behavior-tests.mjs
node scripts/validate-extensions.mjs
node scripts/scan-extension-safety.mjs
node scripts/sync-sidecar-base.mjs --check
node scripts/check-sidecar-usage.mjs
node scripts/validate-desktop-companion.mjs
node scripts/generate-registry.mjs --out dist/registry.json
python3 extensions/sysinfo/sidecar/test_op_ownership.py
python3 extensions/sysinfo/sidecar/test_update_target_parity.py
node --check scripts/run-behavior-tests.mjs
node --check scripts/test-behavior-test-runner.mjs
git diff --check
```

All exited 0. The runner executed **11/11 suites** (all ten previously wired suites plus its selftest); validator/safety/registry checked 19 entries. Existing sidecar scaffold tests used isolated temporary local listeners.

Independent omission proof: on a separate checkout, the old validator stayed green with an unregistered `scripts/test-zz-unregistered.mjs` present. At the new head, both full runner and absolute-path `--check` exited **1**, naming the missing inventory entry, with no suite started and no fixture sentinel written. The selftest also proves registered failure yields CLI exit 1, validation happens before any execution, and registration turns the positive fixture green.

A mechanical baseline comparison verified all ten previous script suites are registered, there is exactly one new CI entry, and the sysinfo step plus the complete browser job/Core pin remain byte-identical.

Exact-head hosted CI is green: [Validate extensions and Browser extension compatibility](https://github.com/hermes-webui/hermes-webui-extensions/actions/runs/33035934878) both passed on `aa26c91c3edee87c6fdee2afd04bd7e8aa499f88`. Pages deployment was intentionally skipped because this is a pull request.

## Risks / Follow-ups

- Scope is top-level script-test wiring. It does not prove assertion quality, certify the whole extension library, or prevent a PR from changing the runner/workflow; those changes still need review.
- A registered test is executable contributor code. The inventory is a review/execution contract, not a sandbox.
- Existing sidecar and real-Core browser/capability checks remain separate and required.
- #60's unresolved review findings are unchanged. This PR does not modify or approve Chat Tiling.
- Refs #76; keep the compatibility umbrella open. A3 certification still waits for Core #7245 to be reviewed and merged, followed by a separate Message Pins migration.
- No user-facing UI or extension implementation changes; screenshots are not applicable.

## Model Used

OpenAI Codex coordinated implementation and independent review; Luna Max (`gpt-5.6-luna`, max reasoning) implemented the bounded runner, fixtures, and wiring changes.

## AI Disclosure

AI-assisted under maintainer-directed scope. Publication follows coordinator diff review and independent validation, not the worker's self-report alone.
